### PR TITLE
Returns EXIT_FAILURE if an error was reported

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -104,17 +104,17 @@ int main(int argc, char **argv) {
   quick_lint_js::options o = quick_lint_js::parse_options(argc, argv);
   if (o.help) {
     quick_lint_js::print_help_message();
-    return 0;
+    return EXIT_SUCCESS;
   }
   if (!o.error_unrecognized_options.empty()) {
     for (const auto &option : o.error_unrecognized_options) {
       std::cerr << "error: unrecognized option: " << option << '\n';
     }
-    return 1;
+    return EXIT_FAILURE;
   }
   if (o.files_to_lint.empty()) {
     std::cerr << "error: expected file name\n";
-    return 1;
+    return EXIT_FAILURE;
   }
 
   quick_lint_js::any_error_reporter reporter =
@@ -129,7 +129,7 @@ int main(int argc, char **argv) {
   }
   reporter.finish();
 
-  return 0;
+  return EXIT_SUCCESS;
 }
 
 namespace quick_lint_js {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,7 +20,7 @@
 #include <iomanip>
 #include <iostream>
 #include <quick-lint-js/char8.h>
-#include <quick-lint-js/error.h>
+#include <quick-lint-js/error-tape.h>
 #include <quick-lint-js/file.h>
 #include <quick-lint-js/language.h>
 #include <quick-lint-js/lex.h>
@@ -44,9 +44,11 @@ class any_error_reporter {
   static any_error_reporter make(output_format format) {
     switch (format) {
     case output_format::gnu_like:
-      return any_error_reporter(text_error_reporter(std::cerr));
+      return any_error_reporter(
+          error_tape<text_error_reporter>(text_error_reporter(std::cerr)));
     case output_format::vim_qflist_json:
-      return any_error_reporter(vim_qflist_json_error_reporter(std::cout));
+      return any_error_reporter(error_tape<vim_qflist_json_error_reporter>(
+          vim_qflist_json_error_reporter(std::cout)));
     }
     QLJS_UNREACHABLE();
   }
@@ -55,40 +57,45 @@ class any_error_reporter {
     std::visit(
         [&](auto &r) {
           using reporter_type = std::decay_t<decltype(r)>;
-          if constexpr (std::is_base_of_v<vim_qflist_json_error_reporter,
-                                          reporter_type>) {
-            r.set_source(input, file.path, file.vim_bufnr);
+          if constexpr (std::is_base_of_v<
+                            error_tape<vim_qflist_json_error_reporter>,
+                            reporter_type>) {
+            r.get_reporter()->set_source(input, file.path, file.vim_bufnr);
           } else {
-            r.set_source(input, file.path);
+            r.get_reporter()->set_source(input, file.path);
           }
         },
-        this->reporter_);
+        this->tape_);
   }
 
   error_reporter *get() noexcept {
-    return std::visit([](error_reporter &r) { return &r; }, this->reporter_);
+    return std::visit([](error_reporter &r) { return &r; }, this->tape_);
+  }
+
+  bool get_error() noexcept {
+    return std::visit([](auto &r) { return r.get_error(); }, this->tape_);
   }
 
   void finish() {
     std::visit(
         [&](auto &r) {
           using reporter_type = std::decay_t<decltype(r)>;
-          if constexpr (std::is_base_of_v<vim_qflist_json_error_reporter,
-                                          reporter_type>) {
-            r.finish();
+          if constexpr (std::is_base_of_v<
+                            error_tape<vim_qflist_json_error_reporter>,
+                            reporter_type>) {
+            r.get_reporter()->finish();
           }
         },
-        this->reporter_);
+        this->tape_);
   }
 
  private:
-  using reporter_variant =
-      std::variant<text_error_reporter, vim_qflist_json_error_reporter>;
+  using tape_variant = std::variant<error_tape<text_error_reporter>,
+                                    error_tape<vim_qflist_json_error_reporter>>;
 
-  explicit any_error_reporter(reporter_variant &&reporter)
-      : reporter_(std::move(reporter)) {}
+  explicit any_error_reporter(tape_variant &&tape) : tape_(tape) {}
 
-  reporter_variant reporter_;
+  tape_variant tape_;
 };
 
 void process_file(padded_string_view input, error_reporter *,
@@ -128,6 +135,10 @@ int main(int argc, char **argv) {
                                 o.print_parser_visits);
   }
   reporter.finish();
+
+  if (reporter.get_error() == true) {
+    return EXIT_FAILURE;
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/quick-lint-js/error-tape.h
+++ b/src/quick-lint-js/error-tape.h
@@ -1,0 +1,65 @@
+// quick-lint-js finds bugs in JavaScript programs.
+// Copyright (C) 2020  Matthew Glazar
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef QUICK_LINT_JS_ERROR_TAPE_H
+#define QUICK_LINT_JS_ERROR_TAPE_H
+
+#include <quick-lint-js/error.h>
+#include <quick-lint-js/text-error-reporter.h>
+#include <quick-lint-js/vim-qflist-json-error-reporter.h>
+
+namespace quick_lint_js {
+template <typename T>
+class error_tape final : public error_reporter {
+ public:
+  error_tape(T reporter) : reporter_(reporter), error_(false) {}
+
+  T *get_reporter() { return &(this->reporter_); }
+
+  bool get_error(void) { return this->error_; }
+
+  void set_error(void) { this->error_ = true; }
+
+#define QLJS_ERROR_TYPE(name, struct_body, format) \
+  void report(name e) override final {             \
+    set_error();                                   \
+    reporter_.report(e);                           \
+  }
+  QLJS_X_ERROR_TYPES
+#undef QLJS_ERROR_TYPE
+
+  void report_fatal_error_unimplemented_character(
+      const char *qljs_file_name, int qljs_line, const char *qljs_function_name,
+      const char8 *character) override final {
+    reporter_.report_fatal_error_unimplemented_character(
+        qljs_file_name, qljs_line, qljs_function_name, character);
+  }
+
+  void report_fatal_error_unimplemented_token(
+      const char *qljs_file_name, int qljs_line, const char *qljs_function_name,
+      token_type type, const char8 *token_begin) override final {
+    reporter_.report_fatal_error_unimplemented_token(
+        qljs_file_name, qljs_line, qljs_function_name, type, token_begin);
+  }
+
+ private:
+  T reporter_;
+
+  bool error_;
+};
+}
+
+#endif


### PR DESCRIPTION
Hi.


First, I do hope you are all fine and the same for your relatives.

I modified linter code to first uses EXIT_SUCCESS and EXIT_FAILURE macros instead of 0 and 1.
I do not know if this a good practice in C++ but in C this a good one (see [this post](https://stackoverflow.com/a/8868139)).

Then I added a static variable to error_exporter class.
This variable can be seed as a fuse, it is initialized as false and set to true by text_reporter::report.
Finally, it is tested in main and if is true main returns EXIT_FAILURE.

For now, I only modified text_reporter::report and not other reporters.
Please let me know if I should do it or if there is problem with the code.
Indeed, I am not very skilled in C++ so using static variable is maybe a bad approach.


Best regards.