### PR TITLE
Add version information

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,6 +37,12 @@
 #include <string>
 #include <variant>
 
+// Version information
+#define QUICK_LINT_JS_VERSION_MAJOR 1
+#define QUICK_LINT_JS_VERSION_MINOR 0
+#define QUICK_LINT_JS_VERSION_PATCHLEVEL 0
+#define QUICK_LINT_JS_VERSION_STRING "1.0.0"
+
 namespace quick_lint_js {
 namespace {
 class any_error_reporter {
@@ -95,6 +101,7 @@ void process_file(padded_string_view input, error_reporter *,
                   bool print_parser_visits);
 
 void print_help_message();
+void print_version_information();
 }
 }
 
@@ -104,6 +111,10 @@ int main(int argc, char **argv) {
   quick_lint_js::options o = quick_lint_js::parse_options(argc, argv);
   if (o.help) {
     quick_lint_js::print_help_message();
+    return 0;
+  }
+  if (o.version) {
+    quick_lint_js::print_version_information();
     return 0;
   }
   if (!o.error_unrecognized_options.empty()) {
@@ -304,9 +315,14 @@ void print_help_message() {
   print_option("--output-format=[FORMAT]",
                "Format to print feedback where FORMAT is one of:");
   print_option("", "gnu-like (default if omitted), vim-qflist-json");
+  print_option("--v, --version", "Print version information");
   print_option("--vim-file-bufnr=[NUMBER]",
                "Select a vim buffer for outputting feedback");
   print_option("--h, --help", "Print help message");
+}
+
+void print_version_information() {
+  std::cout << "quick-lint-js version " << QUICK_LINT_JS_VERSION_STRING << '\n';
 }
 }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,9 +38,6 @@
 #include <variant>
 
 // Version information
-#define QUICK_LINT_JS_VERSION_MAJOR 1
-#define QUICK_LINT_JS_VERSION_MINOR 0
-#define QUICK_LINT_JS_VERSION_PATCHLEVEL 0
 #define QUICK_LINT_JS_VERSION_STRING "1.0.0"
 
 namespace quick_lint_js {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,8 +37,7 @@
 #include <string>
 #include <variant>
 
-// Version information
-#define QUICK_LINT_JS_VERSION_STRING "1.0.0"
+#define QUICK_LINT_JS_VERSION_STRING "0.1.0"
 
 namespace quick_lint_js {
 namespace {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -182,6 +182,8 @@ options parse_options(int argc, char** argv) {
       }
     } else if (parser.match_flag_option("--help"sv, "--h"sv)) {
       o.help = true;
+    } else if (parser.match_flag_option("--version"sv, "--v"sv)) {
+      o.version = true;
     } else {
       const char* unrecognized = parser.match_anything();
       o.error_unrecognized_options.emplace_back(unrecognized);

--- a/src/quick-lint-js/options.h
+++ b/src/quick-lint-js/options.h
@@ -33,6 +33,7 @@ struct file_to_lint {
 
 struct options {
   bool help = false;
+  bool version = false;
   bool print_parser_visits = false;
   quick_lint_js::output_format output_format =
       quick_lint_js::output_format::gnu_like;

--- a/test/test-options.cpp
+++ b/test/test-options.cpp
@@ -43,6 +43,7 @@ TEST(test_options, default_options_with_no_files) {
   options o = parse_options({});
   EXPECT_FALSE(o.print_parser_visits);
   EXPECT_FALSE(o.help);
+  EXPECT_FALSE(o.version);
   EXPECT_EQ(o.output_format, output_format::gnu_like);
   EXPECT_THAT(o.files_to_lint, IsEmpty());
 }
@@ -175,6 +176,18 @@ TEST(test_options, print_help) {
   {
     options o = parse_options({"--h"});
     EXPECT_TRUE(o.help);
+  }
+}
+
+TEST(test_options, print_version) {
+  {
+    options o = parse_options({"--version"});
+    EXPECT_TRUE(o.version);
+  }
+
+  {
+    options o = parse_options({"--v"});
+    EXPECT_TRUE(o.version);
   }
 }
 


### PR DESCRIPTION
This adds two flags, --v and --version, along with implementations of two tests in test-options.cpp and therefore closes #71.

As I could not find any version info, I set the version string to "1.0.0", I don't know if that's okay.
I'd be happy to hear your feedback on this!