### PR TITLE
Add support for -h and -v options

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -324,10 +324,10 @@ void print_help_message() {
   print_option("--output-format=[FORMAT]",
                "Format to print feedback where FORMAT is one of:");
   print_option("", "gnu-like (default if omitted), vim-qflist-json");
-  print_option("--v, --version", "Print version information");
+  print_option("-v, --v, --version", "Print version information");
   print_option("--vim-file-bufnr=[NUMBER]",
                "Select a vim buffer for outputting feedback");
-  print_option("--h, --help", "Print help message");
+  print_option("-h, --h, --help", "Print help message");
 }
 
 void print_version_information() {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -59,6 +59,18 @@ class arg_parser {
     return arg_value;
   }
 
+  bool match_flag_shorthand(std::string_view option_shorthand) noexcept {
+    if (!this->option_.has_value()) {
+      return false;
+    }
+    bool matches = this->option_->arg_key == option_shorthand;
+
+    if (matches) {
+      this->advance(1);
+    }
+    return matches;
+  }
+
   bool match_flag_option(std::string_view full_option_name,
                          std::string_view partial_option_name) noexcept {
     if (!this->option_.has_value()) {
@@ -101,7 +113,7 @@ class arg_parser {
       }
       this->is_ignoring_options_ = true;
       this->option_ = std::nullopt;
-    } else if (this->current_arg()[0] == '-' && this->current_arg()[1] == '-') {
+    } else if (this->current_arg()[0] == '-') {
       const char* equal = std::strchr(this->current_arg(), '=');
       option o;
       o.arg_has_equal = equal != nullptr;
@@ -180,9 +192,11 @@ options parse_options(int argc, char** argv) {
       } else {
         next_vim_file_bufnr = bufnr;
       }
-    } else if (parser.match_flag_option("--help"sv, "--h"sv)) {
+    } else if (parser.match_flag_option("--help"sv, "--h"sv) ||
+               parser.match_flag_shorthand("-h"sv)) {
       o.help = true;
-    } else if (parser.match_flag_option("--version"sv, "--v"sv)) {
+    } else if (parser.match_flag_option("--version"sv, "--v"sv) ||
+               parser.match_flag_shorthand("-v"sv)) {
       o.version = true;
     } else {
       const char* unrecognized = parser.match_anything();

--- a/test/test-options.cpp
+++ b/test/test-options.cpp
@@ -248,7 +248,6 @@ TEST(test_options, invalid_option) {
     EXPECT_EQ(o.error_unrecognized_options[0], "-version"sv);
     EXPECT_THAT(o.files_to_lint, IsEmpty());
   }
-
 }
 }
 }

--- a/test/test-options.cpp
+++ b/test/test-options.cpp
@@ -177,6 +177,11 @@ TEST(test_options, print_help) {
     options o = parse_options({"--h"});
     EXPECT_TRUE(o.help);
   }
+
+  {
+    options o = parse_options({"-h"});
+    EXPECT_TRUE(o.help);
+  }
 }
 
 TEST(test_options, print_version) {
@@ -187,6 +192,11 @@ TEST(test_options, print_version) {
 
   {
     options o = parse_options({"--v"});
+    EXPECT_TRUE(o.version);
+  }
+
+  {
+    options o = parse_options({"-v"});
     EXPECT_TRUE(o.version);
   }
 }
@@ -231,6 +241,14 @@ TEST(test_options, invalid_option) {
     EXPECT_EQ(o.error_unrecognized_options[0], "--debug-parse-visits-xxx"sv);
     EXPECT_THAT(o.files_to_lint, IsEmpty());
   }
+
+  {
+    options o = parse_options({"-version", "foo.js"});
+    ASSERT_EQ(o.error_unrecognized_options.size(), 1);
+    EXPECT_EQ(o.error_unrecognized_options[0], "-version"sv);
+    EXPECT_THAT(o.files_to_lint, IsEmpty());
+  }
+
 }
 }
 }


### PR DESCRIPTION
This addresses #78. Previously, quick-lint-js only supported options starting with "--".
By adding the method `match_flag_shorthand` to the `parser` class allows to define shorthand flags (usually beginning with '-') for common options.