### PR TITLE
Report parse error when there's no digits exist on number literals.

### DIFF
--- a/src/lex.cpp
+++ b/src/lex.cpp
@@ -782,7 +782,7 @@ void lexer::parse_binary_number() {
 
   if (input == this->input_) {
     this->error_reporter_->report(
-        error_no_digits_in_binary_number{source_code_span(input, input)});
+        error_no_digits_in_binary_number{source_code_span(this->last_token_.begin, input)});
   } else {
     this->input_ = check_garbage_in_number_literal(input);
   }
@@ -795,7 +795,7 @@ void lexer::parse_octal_number(octal_kind kind) {
 
   if (input == this->input_) {
     this->error_reporter_->report(
-        error_no_digits_in_octal_number{source_code_span(input, input)});
+        error_no_digits_in_octal_number{source_code_span(this->last_token_.begin, input)});
     return;
   }
 
@@ -922,7 +922,7 @@ void lexer::parse_hexadecimal_number() {
 
   if (input == this->input_) {
     this->error_reporter_->report(
-        error_no_digits_in_hex_number{source_code_span(input, input)});
+        error_no_digits_in_hex_number{source_code_span(this->last_token_.begin, input)});
   } else {
     this->input_ = check_garbage_in_number_literal(input);
   }

--- a/src/lex.cpp
+++ b/src/lex.cpp
@@ -108,8 +108,6 @@
   case '8':                     \
   case '9'
 
-// TODO: add more space characters.
-
 namespace quick_lint_js {
 string8_view identifier::normalized_name() const noexcept {
   const char8* begin = this->span_.begin();

--- a/src/lex.cpp
+++ b/src/lex.cpp
@@ -759,6 +759,7 @@ char8* lexer::check_garbage_in_number_literal(char8* input) {
     switch (*input) {
     QLJS_CASE_DECIMAL_DIGIT:
     QLJS_CASE_IDENTIFIER_START:
+    case u8'.':
       input += 1;
       break;
     default:

--- a/src/lex.cpp
+++ b/src/lex.cpp
@@ -798,6 +798,13 @@ void lexer::parse_octal_number(octal_kind kind) {
 
   input = this->parse_octal_digits(input);
 
+  char8 c = *(input + 1);
+  if (input == this->input_ && (this->is_space(c) || c == u8'\0')) {
+    this->error_reporter_->report(
+        error_no_digits_in_octal_number{source_code_span(input, input)});
+    return;
+  }
+
   if (kind == octal_kind::sloppy && is_digit(*input)) {
     this->input_ = input;
     this->parse_number();

--- a/src/lex.cpp
+++ b/src/lex.cpp
@@ -922,12 +922,17 @@ void lexer::parse_number() {
 }
 
 void lexer::parse_hexadecimal_number() {
-  QLJS_ASSERT(this->is_hex_digit(this->input_[0]) || this->input_[0] == '.');
   char8* input = this->input_;
 
   input = parse_hex_digits_and_underscores(input);
 
-  this->input_ = check_garbage_in_number_literal(input);
+  char8 c = *(input + 1);
+  if (input == this->input_ && (this->is_space(c) || c == u8'\0')) {
+    this->error_reporter_->report(
+        error_no_digits_in_hex_number{source_code_span(input, input)});
+  } else {
+    this->input_ = check_garbage_in_number_literal(input);
+  }
 }
 
 template <class Func>

--- a/src/lex.cpp
+++ b/src/lex.cpp
@@ -109,9 +109,9 @@
   case '9'
 
 // TODO: add more space characters.
-#define QLJS_CASE_SPACE  \
-  case ' ':              \
-  case '\t':             \
+#define QLJS_CASE_SPACE \
+  case ' ':             \
+  case '\t':            \
   case '\n'
 
 namespace quick_lint_js {
@@ -786,8 +786,8 @@ void lexer::parse_binary_number() {
 
   char8 c = *(input + 1);
   if (input == this->input_ && (this->is_space(c) || c == u8'\0')) {
-    this->error_reporter_->report(error_no_digits_in_binary_number{
-        source_code_span(input, input)});
+    this->error_reporter_->report(
+        error_no_digits_in_binary_number{source_code_span(input, input)});
   } else {
     this->input_ = check_garbage_in_number_literal(input);
   }

--- a/src/lex.cpp
+++ b/src/lex.cpp
@@ -109,10 +109,6 @@
   case '9'
 
 // TODO: add more space characters.
-#define QLJS_CASE_SPACE \
-  case ' ':             \
-  case '\t':            \
-  case '\n'
 
 namespace quick_lint_js {
 string8_view identifier::normalized_name() const noexcept {
@@ -784,8 +780,7 @@ void lexer::parse_binary_number() {
     input += 1;
   }
 
-  char8 c = *(input + 1);
-  if (input == this->input_ && (this->is_space(c) || c == u8'\0')) {
+  if (input == this->input_) {
     this->error_reporter_->report(
         error_no_digits_in_binary_number{source_code_span(input, input)});
   } else {
@@ -798,8 +793,7 @@ void lexer::parse_octal_number(octal_kind kind) {
 
   input = this->parse_octal_digits(input);
 
-  char8 c = *(input + 1);
-  if (input == this->input_ && (this->is_space(c) || c == u8'\0')) {
+  if (input == this->input_) {
     this->error_reporter_->report(
         error_no_digits_in_octal_number{source_code_span(input, input)});
     return;
@@ -926,8 +920,7 @@ void lexer::parse_hexadecimal_number() {
 
   input = parse_hex_digits_and_underscores(input);
 
-  char8 c = *(input + 1);
-  if (input == this->input_ && (this->is_space(c) || c == u8'\0')) {
+  if (input == this->input_) {
     this->error_reporter_->report(
         error_no_digits_in_hex_number{source_code_span(input, input)});
   } else {
@@ -1389,15 +1382,6 @@ void lexer::skip_line_comment_body() {
 bool lexer::is_eof(const char8* input) noexcept {
   QLJS_ASSERT(*input == u8'\0');
   return input == this->original_input_.null_terminator();
-}
-
-bool lexer::is_space(char8 c) noexcept {
-  switch (c) {
-  QLJS_CASE_SPACE:
-    return true;
-  default:
-    return false;
-  }
 }
 
 bool lexer::is_binary_digit(char8 c) { return c == u8'0' || c == u8'1'; }

--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -284,13 +284,13 @@
              characters))                                                      \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
+      error_no_digits_in_hex_number, { source_code_span characters; },         \
+      .error(QLJS_TRANSLATE("hex number literal has no digits"), characters))  \
+                                                                               \
+  QLJS_ERROR_TYPE(                                                             \
       error_no_digits_in_octal_number, { source_code_span characters; },       \
       .error(QLJS_TRANSLATE("octal number literal has no digits"),             \
              characters))                                                      \
-                                                                               \
-  QLJS_ERROR_TYPE(                                                             \
-      error_no_digits_in_hex_number, { source_code_span characters; },         \
-      .error(QLJS_TRANSLATE("hex number literal has no digits"), characters))  \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
       error_unexpected_hash_character, { source_code_span where; },            \

--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -277,6 +277,10 @@
              characters))                                                      \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
+      error_no_digits_in_hex_number, { source_code_span characters; },         \
+      .error(QLJS_TRANSLATE("hex number literal has no digits"), characters))  \
+                                                                               \
+  QLJS_ERROR_TYPE(                                                             \
       error_unexpected_hash_character, { source_code_span where; },            \
       .error(QLJS_TRANSLATE("unexpected '#'"), where))                         \
                                                                                \

--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -267,6 +267,12 @@
              characters))                                                      \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
+      error_no_digits_in_binary_number,                                        \
+      { source_code_span characters; },                                        \
+      .error(QLJS_TRANSLATE("binary number literal has no digits"),            \
+             characters))                                                      \
+                                                                               \
+  QLJS_ERROR_TYPE(                                                             \
       error_unexpected_hash_character, { source_code_span where; },            \
       .error(QLJS_TRANSLATE("unexpected '#'"), where))                         \
                                                                                \

--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -261,9 +261,21 @@
       .error(QLJS_TRANSLATE("unexpected control character"), character))       \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
+      error_unexpected_characters_in_binary_number,                            \
+      { source_code_span characters; },                                        \
+      .error(QLJS_TRANSLATE("unexpected characters in binary literal"),        \
+             characters))                                                      \
+                                                                               \
+  QLJS_ERROR_TYPE(                                                             \
       error_unexpected_characters_in_octal_number,                             \
       { source_code_span characters; },                                        \
       .error(QLJS_TRANSLATE("unexpected characters in octal literal"),         \
+             characters))                                                      \
+                                                                               \
+  QLJS_ERROR_TYPE(                                                             \
+      error_unexpected_characters_in_hex_number,                               \
+      { source_code_span characters; },                                        \
+      .error(QLJS_TRANSLATE("unexpected characters in hex literal"),           \
              characters))                                                      \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \

--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -272,6 +272,11 @@
              characters))                                                      \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
+      error_no_digits_in_octal_number, { source_code_span characters; },       \
+      .error(QLJS_TRANSLATE("octal number literal has no digits"),             \
+             characters))                                                      \
+                                                                               \
+  QLJS_ERROR_TYPE(                                                             \
       error_unexpected_hash_character, { source_code_span where; },            \
       .error(QLJS_TRANSLATE("unexpected '#'"), where))                         \
                                                                                \

--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -267,8 +267,7 @@
              characters))                                                      \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
-      error_no_digits_in_binary_number,                                        \
-      { source_code_span characters; },                                        \
+      error_no_digits_in_binary_number, { source_code_span characters; },      \
       .error(QLJS_TRANSLATE("binary number literal has no digits"),            \
              characters))                                                      \
                                                                                \

--- a/src/quick-lint-js/lex.h
+++ b/src/quick-lint-js/lex.h
@@ -350,7 +350,6 @@ class lexer {
   void skip_line_comment_body();
 
   bool is_eof(const char8*) noexcept;
-  bool is_space(char8) noexcept;
 
   static bool is_binary_digit(char8);
   static bool is_octal_digit(char8);

--- a/src/quick-lint-js/lex.h
+++ b/src/quick-lint-js/lex.h
@@ -350,6 +350,7 @@ class lexer {
   void skip_line_comment_body();
 
   bool is_eof(const char8*) noexcept;
+  bool is_space(char8) noexcept;
 
   static bool is_binary_digit(char8);
   static bool is_octal_digit(char8);

--- a/src/quick-lint-js/lex.h
+++ b/src/quick-lint-js/lex.h
@@ -332,6 +332,7 @@ class lexer {
   };
   void parse_octal_number(octal_kind);
   void parse_hexadecimal_number();
+  template <class Error>
   char8* check_garbage_in_number_literal(char8* input);
   void parse_number();
 

--- a/test/test-lex.cpp
+++ b/test/test-lex.cpp
@@ -161,22 +161,21 @@ TEST(test_lex, lex_binary_numbers) {
   check_single_token(u8"0B010101010101010", token_type::number);
 }
 
-// TODO(mc2) binary numbers may not have decimals
-TEST(test_lex, DISABLED_fail_lex_binary_number) {
-  {
-    error_collector v;
-    padded_string input(u8"0b1.1");
-    lexer l(&input, &v);
-    EXPECT_EQ(l.peek().type, token_type::number);
-    l.skip();
-    EXPECT_EQ(l.peek().type, token_type::end_of_file);
-
-    // q(🎅🏾) have another error kind for
-    // `unexpected_character_in_binary_number?
-    EXPECT_THAT(v.errors, ElementsAre(ERROR_TYPE_FIELD(
-                              error_unexpected_characters_in_number, characters,
-                              offsets_matcher(&input, 3, 4))));
-  }
+TEST(test_lex, fail_lex_binary_number_no_digits) {
+  check_tokens_with_errors(
+      u8"0b", {token_type::number},
+      [](padded_string_view input, const auto& errors) {
+        EXPECT_THAT(errors, ElementsAre(ERROR_TYPE_FIELD(
+                                error_no_digits_in_binary_number,
+                                characters, offsets_matcher(input, 2, 2))));
+      });
+  check_tokens_with_errors(
+      u8"0b ", {token_type::number},
+      [](padded_string_view input, const auto& errors) {
+        EXPECT_THAT(errors, ElementsAre(ERROR_TYPE_FIELD(
+                                error_no_digits_in_binary_number,
+                                characters, offsets_matcher(input, 2, 2))));
+      });
 }
 
 TEST(test_lex, lex_octal_numbers_strict) {

--- a/test/test-lex.cpp
+++ b/test/test-lex.cpp
@@ -178,6 +178,16 @@ TEST(test_lex, fail_lex_binary_number_no_digits) {
       });
 }
 
+TEST(test_lex, fail_lex_binary_number) {
+  check_tokens_with_errors(
+      u8"0b1.1", {token_type::number},
+      [](padded_string_view input, const auto& errors) {
+        EXPECT_THAT(errors, ElementsAre(ERROR_TYPE_FIELD(
+                                error_unexpected_characters_in_number,
+                                characters, offsets_matcher(input, 3, 5))));
+      });
+}
+
 TEST(test_lex, lex_octal_numbers_strict) {
   check_single_token(u8"000", token_type::number);
   check_single_token(u8"001", token_type::number);

--- a/test/test-lex.cpp
+++ b/test/test-lex.cpp
@@ -169,6 +169,21 @@ TEST(test_lex, fail_lex_binary_number_no_digits) {
                                 error_no_digits_in_binary_number, characters,
                                 offsets_matcher(input, 0, 2))));
       });
+  check_tokens_with_errors(
+      u8"0b;", {token_type::number, token_type::semicolon},
+      [](padded_string_view input, const auto& errors) {
+        EXPECT_THAT(errors, ElementsAre(ERROR_TYPE_FIELD(
+                                error_no_digits_in_binary_number, characters,
+                                offsets_matcher(input, 0, 2))));
+      });
+  check_tokens_with_errors(
+      u8"[0b]",
+      {token_type::left_square, token_type::number, token_type::right_square},
+      [](padded_string_view input, const auto& errors) {
+        EXPECT_THAT(errors, ElementsAre(ERROR_TYPE_FIELD(
+                                error_no_digits_in_binary_number, characters,
+                                offsets_matcher(input, 1, 3))));
+      });
 }
 
 TEST(test_lex, fail_lex_binary_number) {
@@ -205,6 +220,21 @@ TEST(test_lex, fail_lex_octal_number_no_digits) {
         EXPECT_THAT(errors, ElementsAre(ERROR_TYPE_FIELD(
                                 error_no_digits_in_octal_number, characters,
                                 offsets_matcher(input, 0, 2))));
+      });
+  check_tokens_with_errors(
+      u8"0o;", {token_type::number, token_type::semicolon},
+      [](padded_string_view input, const auto& errors) {
+        EXPECT_THAT(errors, ElementsAre(ERROR_TYPE_FIELD(
+                                error_no_digits_in_octal_number, characters,
+                                offsets_matcher(input, 0, 2))));
+      });
+  check_tokens_with_errors(
+      u8"[0o]",
+      {token_type::left_square, token_type::number, token_type::right_square},
+      [](padded_string_view input, const auto& errors) {
+        EXPECT_THAT(errors, ElementsAre(ERROR_TYPE_FIELD(
+                                error_no_digits_in_octal_number, characters,
+                                offsets_matcher(input, 1, 3))));
       });
 }
 
@@ -259,6 +289,21 @@ TEST(test_lex, fail_lex_hex_number_no_digits) {
         EXPECT_THAT(errors, ElementsAre(ERROR_TYPE_FIELD(
                                 error_no_digits_in_hex_number, characters,
                                 offsets_matcher(input, 0, 2))));
+      });
+  check_tokens_with_errors(
+      u8"0x;", {token_type::number, token_type::semicolon},
+      [](padded_string_view input, const auto& errors) {
+        EXPECT_THAT(errors, ElementsAre(ERROR_TYPE_FIELD(
+                                error_no_digits_in_hex_number, characters,
+                                offsets_matcher(input, 0, 2))));
+      });
+  check_tokens_with_errors(
+      u8"[0x]",
+      {token_type::left_square, token_type::number, token_type::right_square},
+      [](padded_string_view input, const auto& errors) {
+        EXPECT_THAT(errors, ElementsAre(ERROR_TYPE_FIELD(
+                                error_no_digits_in_hex_number, characters,
+                                offsets_matcher(input, 1, 3))));
       });
 }
 

--- a/test/test-lex.cpp
+++ b/test/test-lex.cpp
@@ -176,7 +176,7 @@ TEST(test_lex, fail_lex_binary_number) {
       u8"0b1.1", {token_type::number},
       [](padded_string_view input, const auto& errors) {
         EXPECT_THAT(errors, ElementsAre(ERROR_TYPE_FIELD(
-                                error_unexpected_characters_in_number,
+                                error_unexpected_characters_in_binary_number,
                                 characters, offsets_matcher(input, 3, 5))));
       });
 }
@@ -262,6 +262,16 @@ TEST(test_lex, fail_lex_hex_number_no_digits) {
       });
 }
 
+TEST(test_lex, fail_lex_hex_number) {
+  check_tokens_with_errors(
+      u8"0xf.f", {token_type::number},
+      [](padded_string_view input, const auto& errors) {
+        EXPECT_THAT(errors, ElementsAre(ERROR_TYPE_FIELD(
+                                error_unexpected_characters_in_hex_number,
+                                characters, offsets_matcher(input, 3, 5))));
+      });
+}
+
 TEST(test_lex, lex_number_with_trailing_garbage) {
   check_tokens_with_errors(
       u8"123abcd", {token_type::number},
@@ -289,21 +299,21 @@ TEST(test_lex, lex_number_with_trailing_garbage) {
       u8"0b01234", {token_type::number},
       [](padded_string_view input, const auto& errors) {
         EXPECT_THAT(errors, ElementsAre(ERROR_TYPE_FIELD(
-                                error_unexpected_characters_in_number,
+                                error_unexpected_characters_in_binary_number,
                                 characters, offsets_matcher(input, 4, 7))));
       });
   check_tokens_with_errors(
       u8"0b0h0lla", {token_type::number},
       [](padded_string_view input, const auto& errors) {
         EXPECT_THAT(errors, ElementsAre(ERROR_TYPE_FIELD(
-                                error_unexpected_characters_in_number,
+                                error_unexpected_characters_in_binary_number,
                                 characters, offsets_matcher(input, 3, 8))));
       });
   check_tokens_with_errors(
       u8"0xabjjw", {token_type::number},
       [](padded_string_view input, const auto& errors) {
         EXPECT_THAT(errors, ElementsAre(ERROR_TYPE_FIELD(
-                                error_unexpected_characters_in_number,
+                                error_unexpected_characters_in_hex_number,
                                 characters, offsets_matcher(input, 4, 7))));
       });
   check_tokens_with_errors(

--- a/test/test-lex.cpp
+++ b/test/test-lex.cpp
@@ -166,15 +166,15 @@ TEST(test_lex, fail_lex_binary_number_no_digits) {
       u8"0b", {token_type::number},
       [](padded_string_view input, const auto& errors) {
         EXPECT_THAT(errors, ElementsAre(ERROR_TYPE_FIELD(
-                                error_no_digits_in_binary_number,
-                                characters, offsets_matcher(input, 2, 2))));
+                                error_no_digits_in_binary_number, characters,
+                                offsets_matcher(input, 2, 2))));
       });
   check_tokens_with_errors(
       u8"0b ", {token_type::number},
       [](padded_string_view input, const auto& errors) {
         EXPECT_THAT(errors, ElementsAre(ERROR_TYPE_FIELD(
-                                error_no_digits_in_binary_number,
-                                characters, offsets_matcher(input, 2, 2))));
+                                error_no_digits_in_binary_number, characters,
+                                offsets_matcher(input, 2, 2))));
       });
 }
 

--- a/test/test-lex.cpp
+++ b/test/test-lex.cpp
@@ -169,13 +169,6 @@ TEST(test_lex, fail_lex_binary_number_no_digits) {
                                 error_no_digits_in_binary_number, characters,
                                 offsets_matcher(input, 2, 2))));
       });
-  check_tokens_with_errors(
-      u8"0b ", {token_type::number},
-      [](padded_string_view input, const auto& errors) {
-        EXPECT_THAT(errors, ElementsAre(ERROR_TYPE_FIELD(
-                                error_no_digits_in_binary_number, characters,
-                                offsets_matcher(input, 2, 2))));
-      });
 }
 
 TEST(test_lex, fail_lex_binary_number) {
@@ -208,13 +201,6 @@ TEST(test_lex, lex_octal_numbers_lax) {
 TEST(test_lex, fail_lex_octal_number_no_digits) {
   check_tokens_with_errors(
       u8"0o", {token_type::number},
-      [](padded_string_view input, const auto& errors) {
-        EXPECT_THAT(errors, ElementsAre(ERROR_TYPE_FIELD(
-                                error_no_digits_in_octal_number, characters,
-                                offsets_matcher(input, 2, 2))));
-      });
-  check_tokens_with_errors(
-      u8"0o ", {token_type::number},
       [](padded_string_view input, const auto& errors) {
         EXPECT_THAT(errors, ElementsAre(ERROR_TYPE_FIELD(
                                 error_no_digits_in_octal_number, characters,
@@ -269,13 +255,6 @@ TEST(test_lex, lex_hex_numbers) {
 TEST(test_lex, fail_lex_hex_number_no_digits) {
   check_tokens_with_errors(
       u8"0x", {token_type::number},
-      [](padded_string_view input, const auto& errors) {
-        EXPECT_THAT(errors, ElementsAre(ERROR_TYPE_FIELD(
-                                error_no_digits_in_hex_number, characters,
-                                offsets_matcher(input, 2, 2))));
-      });
-  check_tokens_with_errors(
-      u8"0x ", {token_type::number},
       [](padded_string_view input, const auto& errors) {
         EXPECT_THAT(errors, ElementsAre(ERROR_TYPE_FIELD(
                                 error_no_digits_in_hex_number, characters,

--- a/test/test-lex.cpp
+++ b/test/test-lex.cpp
@@ -205,6 +205,23 @@ TEST(test_lex, lex_octal_numbers_lax) {
   check_single_token(u8"058.9", token_type::number);
 }
 
+TEST(test_lex, fail_lex_octal_number_no_digits) {
+  check_tokens_with_errors(
+      u8"0o", {token_type::number},
+      [](padded_string_view input, const auto& errors) {
+        EXPECT_THAT(errors, ElementsAre(ERROR_TYPE_FIELD(
+                                error_no_digits_in_octal_number, characters,
+                                offsets_matcher(input, 2, 2))));
+      });
+  check_tokens_with_errors(
+      u8"0o ", {token_type::number},
+      [](padded_string_view input, const auto& errors) {
+        EXPECT_THAT(errors, ElementsAre(ERROR_TYPE_FIELD(
+                                error_no_digits_in_octal_number, characters,
+                                offsets_matcher(input, 2, 2))));
+      });
+}
+
 TEST(test_lex, fail_lex_octal_numbers) {
   check_tokens_with_errors(
       u8"0123n", {token_type::number},

--- a/test/test-lex.cpp
+++ b/test/test-lex.cpp
@@ -266,6 +266,23 @@ TEST(test_lex, lex_hex_numbers) {
   check_single_token(u8"0X123_4567_89AB_CDEF", token_type::number);
 }
 
+TEST(test_lex, fail_lex_hex_number_no_digits) {
+  check_tokens_with_errors(
+      u8"0x", {token_type::number},
+      [](padded_string_view input, const auto& errors) {
+        EXPECT_THAT(errors, ElementsAre(ERROR_TYPE_FIELD(
+                                error_no_digits_in_hex_number, characters,
+                                offsets_matcher(input, 2, 2))));
+      });
+  check_tokens_with_errors(
+      u8"0x ", {token_type::number},
+      [](padded_string_view input, const auto& errors) {
+        EXPECT_THAT(errors, ElementsAre(ERROR_TYPE_FIELD(
+                                error_no_digits_in_hex_number, characters,
+                                offsets_matcher(input, 2, 2))));
+      });
+}
+
 TEST(test_lex, lex_number_with_trailing_garbage) {
   check_tokens_with_errors(
       u8"123abcd", {token_type::number},

--- a/test/test-lex.cpp
+++ b/test/test-lex.cpp
@@ -167,7 +167,7 @@ TEST(test_lex, fail_lex_binary_number_no_digits) {
       [](padded_string_view input, const auto& errors) {
         EXPECT_THAT(errors, ElementsAre(ERROR_TYPE_FIELD(
                                 error_no_digits_in_binary_number, characters,
-                                offsets_matcher(input, 2, 2))));
+                                offsets_matcher(input, 0, 2))));
       });
 }
 
@@ -204,7 +204,7 @@ TEST(test_lex, fail_lex_octal_number_no_digits) {
       [](padded_string_view input, const auto& errors) {
         EXPECT_THAT(errors, ElementsAre(ERROR_TYPE_FIELD(
                                 error_no_digits_in_octal_number, characters,
-                                offsets_matcher(input, 2, 2))));
+                                offsets_matcher(input, 0, 2))));
       });
 }
 
@@ -258,7 +258,7 @@ TEST(test_lex, fail_lex_hex_number_no_digits) {
       [](padded_string_view input, const auto& errors) {
         EXPECT_THAT(errors, ElementsAre(ERROR_TYPE_FIELD(
                                 error_no_digits_in_hex_number, characters,
-                                offsets_matcher(input, 2, 2))));
+                                offsets_matcher(input, 0, 2))));
       });
 }
 


### PR DESCRIPTION
This pull request is for trying to resolve #43.  

- [x] binary
- [x] octal
- [x] hex
