### PR TITLE
 Distinguish warnings from errors

### DIFF
--- a/src/byte-buffer.cpp
+++ b/src/byte-buffer.cpp
@@ -35,6 +35,11 @@ void byte_buffer::append_copy(string8_view data) {
   std::memcpy(out, data.data(), data.size());
 }
 
+void byte_buffer::append_copy(char8 data) {
+  void* out = this->append(1);
+  std::memcpy(out, &data, 1);
+}
+
 byte_buffer::size_type byte_buffer::size() const noexcept {
   size_type total_size = 0;
   for (std::size_t chunk_index = 0; chunk_index < this->chunks_.size() - 1;

--- a/src/lsp-error-reporter.cpp
+++ b/src/lsp-error-reporter.cpp
@@ -102,7 +102,10 @@ void lsp_error_formatter::write_before_message(severity sev,
   this->output_.append_decimal_integer(r.end.line);
   this->output_.append_copy(u8",\"character\":");
   this->output_.append_decimal_integer(r.end.character);
-  this->output_.append_copy(u8"}},\"severity\":1,\"message\":\"");
+  if (sev == severity::error)
+    this->output_.append_copy(u8"}},\"severity\":1,\"message\":\"");
+  else if(sev == severity::warning)
+    this->output_.append_copy(u8"}},\"severity\":2,\"message\":\"");
 }
 
 void lsp_error_formatter::write_message_part(severity sev,

--- a/src/lsp-error-reporter.cpp
+++ b/src/lsp-error-reporter.cpp
@@ -97,10 +97,7 @@ void lsp_error_formatter::write_before_message(severity sev,
   case severity::warning:
     severity_value = 2;
     break;
-  default:
-    // TODO: handel undifined serverity case.
-    return;
-  }
+  }  // TODO: handel undifined serverity case.
 
   lsp_range r = this->locator_.range(origin);
   this->output_.append_copy(u8"{\"range\":{\"start\":");

--- a/src/lsp-error-reporter.cpp
+++ b/src/lsp-error-reporter.cpp
@@ -86,8 +86,19 @@ lsp_error_formatter::lsp_error_formatter(byte_buffer &output,
 
 void lsp_error_formatter::write_before_message(severity sev,
                                                const source_code_span &origin) {
-  if (sev == severity::note) {
+  int severity_value{};
+  switch (sev) {
+  case severity::note:
     // Don't write notes. Only write the main message.
+    return;
+  case severity::error:
+    severity_value = 1;
+    break;
+  case severity::warning:
+    severity_value = 2;
+    break;
+  default:
+    // TODO: handel undifined serverity case.
     return;
   }
 
@@ -102,10 +113,9 @@ void lsp_error_formatter::write_before_message(severity sev,
   this->output_.append_decimal_integer(r.end.line);
   this->output_.append_copy(u8",\"character\":");
   this->output_.append_decimal_integer(r.end.character);
-  if (sev == severity::error)
-    this->output_.append_copy(u8"}},\"severity\":1,\"message\":\"");
-  else if(sev == severity::warning)
-    this->output_.append_copy(u8"}},\"severity\":2,\"message\":\"");
+  this->output_.append_copy(u8"}},\"severity\":");
+  this->output_.append_decimal_integer(severity_value);
+  this->output_.append_copy(u8",\"message\":\"");
 }
 
 void lsp_error_formatter::write_message_part(severity sev,

--- a/src/lsp-error-reporter.cpp
+++ b/src/lsp-error-reporter.cpp
@@ -86,7 +86,7 @@ lsp_error_formatter::lsp_error_formatter(byte_buffer &output,
 
 void lsp_error_formatter::write_before_message(severity sev,
                                                const source_code_span &origin) {
-  char8 severity_type;
+  char8 severity_type{};
   switch (sev) {
   case severity::error:
     severity_type = u8'1';

--- a/src/lsp-error-reporter.cpp
+++ b/src/lsp-error-reporter.cpp
@@ -86,18 +86,18 @@ lsp_error_formatter::lsp_error_formatter(byte_buffer &output,
 
 void lsp_error_formatter::write_before_message(severity sev,
                                                const source_code_span &origin) {
-  int severity_value{};
+  char8 severity_type;
   switch (sev) {
+  case severity::error:
+    severity_type = u8'1';
+    break;
   case severity::note:
     // Don't write notes. Only write the main message.
     return;
-  case severity::error:
-    severity_value = 1;
-    break;
   case severity::warning:
-    severity_value = 2;
+    severity_type = u8'2';
     break;
-  }  // TODO: handel undifined serverity case.
+  }
 
   lsp_range r = this->locator_.range(origin);
   this->output_.append_copy(u8"{\"range\":{\"start\":");
@@ -111,7 +111,7 @@ void lsp_error_formatter::write_before_message(severity sev,
   this->output_.append_copy(u8",\"character\":");
   this->output_.append_decimal_integer(r.end.character);
   this->output_.append_copy(u8"}},\"severity\":");
-  this->output_.append_decimal_integer(severity_value);
+  this->output_.append_copy(severity_type);
   this->output_.append_copy(u8",\"message\":\"");
 }
 

--- a/src/lsp-error-reporter.cpp
+++ b/src/lsp-error-reporter.cpp
@@ -112,7 +112,7 @@ void lsp_error_formatter::write_before_message(severity sev,
   this->output_.append_decimal_integer(r.end.character);
   this->output_.append_copy(u8"}},\"severity\":");
   this->output_.append_copy(severity_type);
-  this->output_.append_copy(u8"\"source\":\"quick-lint-js\",");
+  this->output_.append_copy(u8",\"source\":\"quick-lint-js\"");
   this->output_.append_copy(u8",\"message\":\"");
 }
 

--- a/src/quick-lint-js/byte-buffer.h
+++ b/src/quick-lint-js/byte-buffer.h
@@ -53,6 +53,7 @@ class byte_buffer {
   }
 
   void append_copy(string8_view data);
+  void append_copy(char8 data);
 
   size_type size() const noexcept;
 

--- a/src/quick-lint-js/error-formatter.h
+++ b/src/quick-lint-js/error-formatter.h
@@ -59,9 +59,9 @@ class error_formatter {
   // void write_after_message(severity, const source_code_span &origin);
 
   enum class severity {
-    warning,
     error,
     note,
+    warning,
   };
 
   template <class... Args>

--- a/src/quick-lint-js/error-formatter.h
+++ b/src/quick-lint-js/error-formatter.h
@@ -59,9 +59,16 @@ class error_formatter {
   // void write_after_message(severity, const source_code_span &origin);
 
   enum class severity {
+    warning,
     error,
     note,
   };
+
+  template <class... Args>
+  error_formatter &warning(const char8 *message, Args... parameters) {
+    this->add(severity::warning, message, std::forward<Args>(parameters)...);
+    return *this;
+  }
 
   template <class... Args>
   error_formatter &error(const char8 *message, Args... parameters) {

--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -65,8 +65,8 @@
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
       error_assignment_to_undeclared_variable, { identifier assignment; },     \
-      .warning(QLJS_TRANSLATE(                                                 \
-                  "assignment to undeclared variable"), assignment))           \
+      .warning(QLJS_TRANSLATE("assignment to undeclared variable"),            \
+               assignment))                                                    \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
       error_big_int_literal_contains_decimal_point,                            \

--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -64,7 +64,8 @@
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
       error_assignment_to_undeclared_variable, { identifier assignment; },     \
-      .error(QLJS_TRANSLATE("assignment to undeclared variable"), assignment)) \
+      .warning(QLJS_TRANSLATE(                                                 \
+                  "assignment to undeclared variable"), assignment))           \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
       error_big_int_literal_contains_decimal_point,                            \
@@ -314,7 +315,7 @@
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
       error_use_of_undeclared_variable, { identifier name; },                  \
-      .error(QLJS_TRANSLATE("use of undeclared variable: {0}"), name))         \
+      .warning(QLJS_TRANSLATE("use of undeclared variable: {0}"), name))       \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
       error_variable_used_before_declaration,                                  \

--- a/src/text-error-reporter.cpp
+++ b/src/text-error-reporter.cpp
@@ -81,6 +81,9 @@ void text_error_formatter::write_before_message(
   this->output_ << this->file_path_ << ":" << p.line_number << ":"
                 << p.column_number << ": ";
   switch (sev) {
+  case severity::warning:
+    this->output_ << "warning: ";
+    break;
   case severity::error:
     this->output_ << "error: ";
     break;

--- a/src/text-error-reporter.cpp
+++ b/src/text-error-reporter.cpp
@@ -82,14 +82,14 @@ void text_error_formatter::write_before_message(
   this->output_ << this->file_path_ << ":" << p.line_number << ":"
                 << p.column_number << ": ";
   switch (sev) {
-  case severity::warning:
-    this->output_ << "warning: ";
-    break;
   case severity::error:
     this->output_ << "error: ";
     break;
   case severity::note:
     this->output_ << "note: ";
+    break;
+  case severity::warning:
+    this->output_ << "warning: ";
     break;
   }
 }

--- a/src/vim-qflist-json-error-reporter.cpp
+++ b/src/vim-qflist-json-error-reporter.cpp
@@ -120,7 +120,7 @@ vim_qflist_json_error_formatter::vim_qflist_json_error_formatter(
 
 void vim_qflist_json_error_formatter::write_before_message(
     severity sev, const source_code_span &origin) {
-  std::string_view severity_type;
+  std::string_view severity_type{};
   switch (sev) {
   case severity::error:
     severity_type = "E";

--- a/src/vim-qflist-json-error-reporter.cpp
+++ b/src/vim-qflist-json-error-reporter.cpp
@@ -120,25 +120,25 @@ vim_qflist_json_error_formatter::vim_qflist_json_error_formatter(
 
 void vim_qflist_json_error_formatter::write_before_message(
     severity sev, const source_code_span &origin) {
-  std::string_view severity_value{};
+  std::string_view severity_type;
   switch (sev) {
+  case severity::error:
+    severity_type = "E";
+    break;
   case severity::note:
     // Don't write notes. Only write the main message.
     return;
-  case severity::error:
-    severity_value = "E";
-    break;
   case severity::warning:
-    severity_value = "W";
+    severity_type = "W";
     break;
-  }  // TODO: handel undifined serverity case.
+  }
 
   vim_source_range r = this->locator_.range(origin);
   auto end_col = origin.begin() == origin.end() ? r.begin.col : (r.end.col - 1);
   this->output_ << "{\"col\": " << r.begin.col << ", \"lnum\": " << r.begin.lnum
                 << ", \"end_col\": " << end_col
                 << ", \"end_lnum\": " << r.end.lnum << ", \"type\": \""
-                << severity_value << "\", \"vcol\": 0, \"text\": \"";
+                << severity_type << "\", \"vcol\": 0, \"text\": \"";
 }
 
 void vim_qflist_json_error_formatter::write_message_part(severity sev,

--- a/src/vim-qflist-json-error-reporter.cpp
+++ b/src/vim-qflist-json-error-reporter.cpp
@@ -120,8 +120,19 @@ vim_qflist_json_error_formatter::vim_qflist_json_error_formatter(
 
 void vim_qflist_json_error_formatter::write_before_message(
     severity sev, const source_code_span &origin) {
-  if (sev == severity::note) {
+  std::string_view sev_value{};
+  switch (sev) {
+  case severity::note:
     // Don't write notes. Only write the main message.
+    return;
+  case severity::error:
+    sev_value = "E";
+    break;
+  case severity::warning:
+    sev_value = "W";
+    break;
+  default:
+    // TODO: handel undifined serverity case.
     return;
   }
 
@@ -129,8 +140,8 @@ void vim_qflist_json_error_formatter::write_before_message(
   auto end_col = origin.begin() == origin.end() ? r.begin.col : (r.end.col - 1);
   this->output_ << "{\"col\": " << r.begin.col << ", \"lnum\": " << r.begin.lnum
                 << ", \"end_col\": " << end_col
-                << ", \"end_lnum\": " << r.end.lnum
-                << ", \"vcol\": 0, \"text\": \"";
+                << ", \"end_lnum\": " << r.end.lnum << ", \"type\": \""
+                << sev_value << "\", \"vcol\": 0, \"text\": \"";
 }
 
 void vim_qflist_json_error_formatter::write_message_part(severity sev,

--- a/src/vim-qflist-json-error-reporter.cpp
+++ b/src/vim-qflist-json-error-reporter.cpp
@@ -120,28 +120,25 @@ vim_qflist_json_error_formatter::vim_qflist_json_error_formatter(
 
 void vim_qflist_json_error_formatter::write_before_message(
     severity sev, const source_code_span &origin) {
-  std::string_view sev_value{};
+  std::string_view severity_value{};
   switch (sev) {
   case severity::note:
     // Don't write notes. Only write the main message.
     return;
   case severity::error:
-    sev_value = "E";
+    severity_value = "E";
     break;
   case severity::warning:
-    sev_value = "W";
+    severity_value = "W";
     break;
-  default:
-    // TODO: handel undifined serverity case.
-    return;
-  }
+  }  // TODO: handel undifined serverity case.
 
   vim_source_range r = this->locator_.range(origin);
   auto end_col = origin.begin() == origin.end() ? r.begin.col : (r.end.col - 1);
   this->output_ << "{\"col\": " << r.begin.col << ", \"lnum\": " << r.begin.lnum
                 << ", \"end_col\": " << end_col
                 << ", \"end_lnum\": " << r.end.lnum << ", \"type\": \""
-                << sev_value << "\", \"vcol\": 0, \"text\": \"";
+                << severity_value << "\", \"vcol\": 0, \"text\": \"";
 }
 
 void vim_qflist_json_error_formatter::write_message_part(severity sev,

--- a/test/test-lsp-error-reporter.cpp
+++ b/test/test-lsp-error-reporter.cpp
@@ -114,8 +114,7 @@ TEST_F(test_lsp_error_reporter, assignment_to_undeclared_variable) {
   EXPECT_EQ(diagnostics[0]["range"]["end"]["line"], 0);
   EXPECT_EQ(diagnostics[0]["range"]["end"]["character"], 1);
   EXPECT_EQ(diagnostics[0]["severity"], lsp_warning_severity);
-  EXPECT_EQ(diagnostics[0]["message"],
-            "assignment to undeclared variable");
+  EXPECT_EQ(diagnostics[0]["message"], "assignment to undeclared variable");
 }
 
 TEST_F(test_lsp_error_reporter, multiple_errors) {

--- a/test/test-lsp-error-reporter.cpp
+++ b/test/test-lsp-error-reporter.cpp
@@ -27,7 +27,7 @@
 namespace quick_lint_js {
 namespace {
 constexpr int lsp_error_severity = 1;
-constexpr int lsp_warning_severity = 2;
+//constexpr int lsp_warning_severity = 2;
 
 class test_lsp_error_reporter : public ::testing::Test {
  protected:

--- a/test/test-lsp-error-reporter.cpp
+++ b/test/test-lsp-error-reporter.cpp
@@ -27,6 +27,7 @@
 namespace quick_lint_js {
 namespace {
 constexpr int lsp_error_severity = 1;
+constexpr int lsp_warning_severity = 2;
 
 class test_lsp_error_reporter : public ::testing::Test {
  protected:

--- a/test/test-text-error-reporter.cpp
+++ b/test/test-text-error-reporter.cpp
@@ -111,7 +111,7 @@ TEST_F(test_text_error_reporter, assignment_to_undeclared_variable) {
   this->make_reporter(&input).report(
       error_assignment_to_undeclared_variable{identifier(uhoh_span)});
   EXPECT_EQ(this->get_output(),
-            "FILE:1:1: error: assignment to undeclared variable\n");
+            "FILE:1:1: warning: assignment to undeclared variable\n");
 }
 
 TEST_F(test_text_error_reporter, big_int_literal_contains_decimal_point) {
@@ -326,7 +326,7 @@ TEST_F(test_text_error_reporter, use_of_undeclared_variable) {
   this->make_reporter(&input).report(
       error_use_of_undeclared_variable{identifier(myvar_span)});
   EXPECT_EQ(this->get_output(),
-            "FILE:1:1: error: use of undeclared variable: myvar\n");
+            "FILE:1:1: warning: use of undeclared variable: myvar\n");
 }
 
 TEST_F(test_text_error_reporter, variable_used_before_declaration) {

--- a/test/test-vim-qflist-json-error-reporter.cpp
+++ b/test/test-vim-qflist-json-error-reporter.cpp
@@ -73,6 +73,7 @@ TEST_F(test_vim_qflist_json_error_reporter,
   EXPECT_EQ(qflist[0]["end_col"], 6);
   EXPECT_EQ(qflist[0]["end_lnum"], 1);
   EXPECT_EQ(qflist[0]["lnum"], 1);
+  EXPECT_EQ(qflist[0]["type"], "E");
   EXPECT_EQ(qflist[0]["text"], "BigInt literal contains decimal point");
 }
 
@@ -97,6 +98,7 @@ TEST_F(test_vim_qflist_json_error_reporter,
   EXPECT_EQ(qflist[0]["end_col"], 1);
   EXPECT_EQ(qflist[0]["end_lnum"], 1);
   EXPECT_EQ(qflist[0]["lnum"], 1);
+  EXPECT_EQ(qflist[0]["type"], "E");
   EXPECT_EQ(qflist[0]["text"], "variable assigned before its declaration");
 }
 
@@ -116,6 +118,7 @@ TEST_F(test_vim_qflist_json_error_reporter, big_int_literal_contains_exponent) {
   EXPECT_EQ(qflist[0]["end_col"], 4);
   EXPECT_EQ(qflist[0]["end_lnum"], 1);
   EXPECT_EQ(qflist[0]["lnum"], 1);
+  EXPECT_EQ(qflist[0]["type"], "E");
   EXPECT_EQ(qflist[0]["text"], "BigInt literal contains exponent");
 }
 
@@ -247,6 +250,7 @@ TEST_F(test_vim_qflist_json_error_reporter,
   EXPECT_EQ(qflist[0]["end_col"], 11);
   EXPECT_EQ(qflist[0]["end_lnum"], 1);
   EXPECT_EQ(qflist[0]["lnum"], 1);
+  EXPECT_EQ(qflist[0]["type"], "E");
   EXPECT_EQ(qflist[0]["text"], "assignment to const global variable");
   EXPECT_EQ(qflist[0]["vcol"], 0);
 }
@@ -271,6 +275,7 @@ TEST_F(test_vim_qflist_json_error_reporter, assignment_to_const_variable) {
   EXPECT_EQ(qflist[0]["end_col"], 11);
   EXPECT_EQ(qflist[0]["end_lnum"], 1);
   EXPECT_EQ(qflist[0]["lnum"], 1);
+  EXPECT_EQ(qflist[0]["type"], "E");
   EXPECT_EQ(qflist[0]["text"], "assignment to const variable");
   EXPECT_EQ(qflist[0]["vcol"], 0);
 }
@@ -292,6 +297,7 @@ TEST_F(test_vim_qflist_json_error_reporter, assignment_to_undeclared_variable) {
   EXPECT_EQ(qflist[0]["end_col"], 4);
   EXPECT_EQ(qflist[0]["end_lnum"], 1);
   EXPECT_EQ(qflist[0]["lnum"], 1);
+  EXPECT_EQ(qflist[0]["type"], "W");
   EXPECT_EQ(qflist[0]["text"], "assignment to undeclared variable");
 }
 
@@ -311,6 +317,7 @@ TEST_F(test_vim_qflist_json_error_reporter, invalid_binding_in_let_statement) {
   EXPECT_EQ(qflist[0]["end_col"], 5);
   EXPECT_EQ(qflist[0]["end_lnum"], 1);
   EXPECT_EQ(qflist[0]["lnum"], 1);
+  EXPECT_EQ(qflist[0]["type"], "E");
   EXPECT_EQ(qflist[0]["text"], "invalid binding in let statement");
 }
 
@@ -331,6 +338,7 @@ TEST_F(test_vim_qflist_json_error_reporter,
   EXPECT_EQ(qflist[0]["end_col"], 1);
   EXPECT_EQ(qflist[0]["end_lnum"], 1);
   EXPECT_EQ(qflist[0]["lnum"], 1);
+  EXPECT_EQ(qflist[0]["type"], "E");
   EXPECT_EQ(qflist[0]["text"], "invalid expression left of assignment");
 }
 
@@ -350,6 +358,7 @@ TEST_F(test_vim_qflist_json_error_reporter, let_with_no_bindings) {
   EXPECT_EQ(qflist[0]["end_col"], 3);
   EXPECT_EQ(qflist[0]["end_lnum"], 1);
   EXPECT_EQ(qflist[0]["lnum"], 1);
+  EXPECT_EQ(qflist[0]["type"], "E");
   EXPECT_EQ(qflist[0]["text"], "let with no bindings");
 }
 
@@ -373,6 +382,7 @@ TEST_F(test_vim_qflist_json_error_reporter,
   EXPECT_EQ(qflist[0]["end_col"], 3);
   EXPECT_EQ(qflist[0]["end_lnum"], 1);
   EXPECT_EQ(qflist[0]["lnum"], 1);
+  EXPECT_EQ(qflist[0]["type"], "E");
   EXPECT_EQ(qflist[0]["text"], "missing comma between object literal entries");
 }
 
@@ -392,6 +402,7 @@ TEST_F(test_vim_qflist_json_error_reporter, missing_operand_for_operator) {
   EXPECT_EQ(qflist[0]["end_col"], 3);
   EXPECT_EQ(qflist[0]["end_lnum"], 1);
   EXPECT_EQ(qflist[0]["lnum"], 1);
+  EXPECT_EQ(qflist[0]["type"], "E");
   EXPECT_EQ(qflist[0]["text"], "missing operand for operator");
 }
 
@@ -415,6 +426,7 @@ TEST_F(test_vim_qflist_json_error_reporter,
   EXPECT_EQ(qflist[0]["end_col"], 4);
   EXPECT_EQ(qflist[0]["end_lnum"], 1);
   EXPECT_EQ(qflist[0]["lnum"], 1);
+  EXPECT_EQ(qflist[0]["type"], "E");
   EXPECT_EQ(qflist[0]["text"], "missing semicolon after expression");
 }
 
@@ -435,6 +447,7 @@ TEST_F(test_vim_qflist_json_error_reporter, redeclaration_of_global_variable) {
   EXPECT_EQ(qflist[0]["end_col"], 11);
   EXPECT_EQ(qflist[0]["end_lnum"], 1);
   EXPECT_EQ(qflist[0]["lnum"], 1);
+  EXPECT_EQ(qflist[0]["type"], "E");
   EXPECT_EQ(qflist[0]["text"], "redeclaration of global variable");
 }
 
@@ -457,6 +470,7 @@ TEST_F(test_vim_qflist_json_error_reporter, redeclaration_of_variable) {
   EXPECT_EQ(qflist[0]["end_col"], 20);
   EXPECT_EQ(qflist[0]["end_lnum"], 1);
   EXPECT_EQ(qflist[0]["lnum"], 1);
+  EXPECT_EQ(qflist[0]["type"], "E");
   EXPECT_EQ(qflist[0]["text"], "redeclaration of variable: myvar");
 }
 
@@ -476,6 +490,7 @@ TEST_F(test_vim_qflist_json_error_reporter, stray_comma_in_let_statement) {
   EXPECT_EQ(qflist[0]["end_col"], 9);
   EXPECT_EQ(qflist[0]["end_lnum"], 1);
   EXPECT_EQ(qflist[0]["lnum"], 1);
+  EXPECT_EQ(qflist[0]["type"], "E");
   EXPECT_EQ(qflist[0]["text"], "stray comma in let statement");
 }
 
@@ -495,6 +510,7 @@ TEST_F(test_vim_qflist_json_error_reporter, unclosed_block_comment) {
   EXPECT_EQ(qflist[0]["end_col"], 8);
   EXPECT_EQ(qflist[0]["end_lnum"], 1);
   EXPECT_EQ(qflist[0]["lnum"], 1);
+  EXPECT_EQ(qflist[0]["type"], "E");
   EXPECT_EQ(qflist[0]["text"], "unclosed block comment");
 }
 
@@ -514,6 +530,7 @@ TEST_F(test_vim_qflist_json_error_reporter, unclosed_regexp_literal) {
   EXPECT_EQ(qflist[0]["end_col"], 6);
   EXPECT_EQ(qflist[0]["end_lnum"], 1);
   EXPECT_EQ(qflist[0]["lnum"], 1);
+  EXPECT_EQ(qflist[0]["type"], "E");
   EXPECT_EQ(qflist[0]["text"], "unclosed regexp literal");
 }
 
@@ -533,6 +550,7 @@ TEST_F(test_vim_qflist_json_error_reporter, unclosed_string_literal) {
   EXPECT_EQ(qflist[0]["end_col"], 6);
   EXPECT_EQ(qflist[0]["end_lnum"], 1);
   EXPECT_EQ(qflist[0]["lnum"], 1);
+  EXPECT_EQ(qflist[0]["type"], "E");
   EXPECT_EQ(qflist[0]["text"], "unclosed string literal");
 }
 
@@ -552,6 +570,7 @@ TEST_F(test_vim_qflist_json_error_reporter, unclosed_template) {
   EXPECT_EQ(qflist[0]["end_col"], 6);
   EXPECT_EQ(qflist[0]["end_lnum"], 1);
   EXPECT_EQ(qflist[0]["lnum"], 1);
+  EXPECT_EQ(qflist[0]["type"], "E");
   EXPECT_EQ(qflist[0]["text"], "unclosed template");
 }
 
@@ -571,6 +590,7 @@ TEST_F(test_vim_qflist_json_error_reporter, unexpected_characters_in_number) {
   EXPECT_EQ(qflist[0]["end_col"], 9);
   EXPECT_EQ(qflist[0]["end_lnum"], 1);
   EXPECT_EQ(qflist[0]["lnum"], 1);
+  EXPECT_EQ(qflist[0]["type"], "E");
   EXPECT_EQ(qflist[0]["text"], "unexpected characters in number literal");
 }
 
@@ -590,6 +610,7 @@ TEST_F(test_vim_qflist_json_error_reporter, unexpected_hash_character) {
   EXPECT_EQ(qflist[0]["end_col"], 1);
   EXPECT_EQ(qflist[0]["end_lnum"], 1);
   EXPECT_EQ(qflist[0]["lnum"], 1);
+  EXPECT_EQ(qflist[0]["type"], "E");
   EXPECT_EQ(qflist[0]["text"], "unexpected '#'");
 }
 
@@ -609,6 +630,7 @@ TEST_F(test_vim_qflist_json_error_reporter, unexpected_identifier) {
   EXPECT_EQ(qflist[0]["end_col"], 7);
   EXPECT_EQ(qflist[0]["end_lnum"], 1);
   EXPECT_EQ(qflist[0]["lnum"], 1);
+  EXPECT_EQ(qflist[0]["type"], "E");
   EXPECT_EQ(qflist[0]["text"], "unexpected identifier");
 }
 
@@ -628,6 +650,7 @@ TEST_F(test_vim_qflist_json_error_reporter, unmatched_parenthesis) {
   EXPECT_EQ(qflist[0]["end_col"], 2);
   EXPECT_EQ(qflist[0]["end_lnum"], 1);
   EXPECT_EQ(qflist[0]["lnum"], 1);
+  EXPECT_EQ(qflist[0]["type"], "E");
   EXPECT_EQ(qflist[0]["text"], "unmatched parenthesis");
 }
 
@@ -647,6 +670,7 @@ TEST_F(test_vim_qflist_json_error_reporter, use_of_undeclared_variable) {
   EXPECT_EQ(qflist[0]["end_col"], 5);
   EXPECT_EQ(qflist[0]["end_lnum"], 1);
   EXPECT_EQ(qflist[0]["lnum"], 1);
+  EXPECT_EQ(qflist[0]["type"], "W");
   EXPECT_EQ(qflist[0]["text"], "use of undeclared variable: myvar");
 }
 
@@ -669,6 +693,7 @@ TEST_F(test_vim_qflist_json_error_reporter, variable_used_before_declaration) {
   EXPECT_EQ(qflist[0]["end_col"], 5);
   EXPECT_EQ(qflist[0]["end_lnum"], 1);
   EXPECT_EQ(qflist[0]["lnum"], 1);
+  EXPECT_EQ(qflist[0]["type"], "E");
   EXPECT_EQ(qflist[0]["text"], "variable used before declaration: myvar");
 }
 


### PR DESCRIPTION
* [X]  text_error_reporter: say "warning:" instead of "error:"

* [x]  vim_qflist_json_error_reporter: set error type to "W" instead of "E"

* [X]  lsp_error_reporter: set [severity](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#diagnostic) to Warning (2) instead of Error (1)