### PR TITLE
Update building documentation

### DIFF
--- a/.github/workflows/build-and-test-dev.yml
+++ b/.github/workflows/build-and-test-dev.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: 1. Configure with CMake
         run: |
-          mkdir build ; cd build ; ${{ matrix.toolchain.extra_environment }} cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug .. ; cd -
+          mkdir build ; cd build ; ${{ matrix.toolchain.extra_environment }} cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug .. ; cd "$OLDPWD"
           if ! [ -f docs/BUILDING.md ]; then
             printf 'error: cwd changed unexpectedly\n' >&2
             exit 1

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -58,11 +58,11 @@ dependencies:
 
 Run the following command to create a directory called `build`:
 
-    $ mkdir build ; cd build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug .. ; cd -
+    $ mkdir build ; cd build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug .. ; cd "$OLDPWD"
 
 For Ubuntu 18.04 Bionic, instead run the following command:
 
-    $ mkdir build ; cd build ; CC=gcc-8 CXX=g++-8 cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug .. ; cd -
+    $ mkdir build ; cd build ; CC=gcc-8 CXX=g++-8 cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug .. ; cd "$OLDPWD"
 
 #### 2. Build
 
@@ -105,7 +105,7 @@ Before building quick-lint-js, install the following third-party dependencies:
 
 Run the following command to create a directory called `build`:
 
-    $ mkdir build ; cd build ; cmake -G 'Unix Makefiles' -DCMAKE_BUILD_TYPE=Debug .. ; cd -
+    $ mkdir build ; cd build ; cmake -G 'Unix Makefiles' -DCMAKE_BUILD_TYPE=Debug .. ; cd "$OLDPWD"
 
 #### 2. Build
 


### PR DESCRIPTION
The building documentation now uses `cd "$OLDPWD"` over `cd -`. This change stops the redundant printing of the current working directory that `cd -` performs.

The build and test dev workflow that follows the building documentation has been updated to match this change.