### PR TITLE
fix for template literals in object keys

### DIFF
--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -849,6 +849,16 @@ expression_ptr parser::parse_object_literal() {
       QLJS_PARSER_UNIMPLEMENTED();
     }
     switch (this->peek().type) {
+    case token_type::complete_template:
+    case token_type::incomplete_template:
+      this->skip();
+      if (this->peek().type == token_type::colon) {
+        const char8 *backtick_location = this->lexer_.end_of_previous_token();
+        this->error_reporter_->report(error_unexpected_template_string{
+            source_code_span(backtick_location, backtick_location)});
+        this->skip();
+        break;
+      }
     case token_type::comma:
     case token_type::end_of_file:
     case token_type::right_curly:

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -746,7 +746,7 @@ next:
 template <class... Args>
 expression_ptr parser::parse_arrow_function_body(
     function_attributes attributes, const char8 *parameter_list_begin,
-    Args &&...args) {
+    Args &&... args) {
   function_guard guard = this->enter_function(attributes);
   if (this->peek().type == token_type::left_curly) {
     buffering_visitor *v = this->expressions_.make_buffering_visitor();

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -746,7 +746,7 @@ next:
 template <class... Args>
 expression_ptr parser::parse_arrow_function_body(
     function_attributes attributes, const char8 *parameter_list_begin,
-    Args &&... args) {
+    Args &&...args) {
   function_guard guard = this->enter_function(attributes);
   if (this->peek().type == token_type::left_curly) {
     buffering_visitor *v = this->expressions_.make_buffering_visitor();
@@ -857,8 +857,8 @@ expression_ptr parser::parse_object_literal() {
         this->error_reporter_->report(error_unexpected_template_string{
             source_code_span(backtick_location, backtick_location)});
         this->skip();
-        break;
       }
+      break;
     case token_type::comma:
     case token_type::end_of_file:
     case token_type::right_curly:

--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -382,11 +382,9 @@
           .note(QLJS_TRANSLATABLE("variable declared here"), declaration))     \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
-      error_unexpected_template_string, "E061",                                \
-      { source_code_span where; },                                             \
-      .error(                                                                  \
-          QLJS_TRANSLATABLE("cannot use template string as key in object"),    \
-          where))                                                              \
+      error_unexpected_template_string, "E061", { source_code_span where; },   \
+      .error(QLJS_TRANSLATABLE("cannot use template string as key in object"), \
+             where))                                                           \
                                                                                \
   /* END */
 

--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -380,6 +380,14 @@
       },                                                                       \
       .error(QLJS_TRANSLATABLE("variable used before declaration: {0}"), use)  \
           .note(QLJS_TRANSLATABLE("variable declared here"), declaration))     \
+                                                                               \
+  QLJS_ERROR_TYPE(                                                             \
+      error_unexpected_template_string, "E061",                                \
+      { source_code_span where; },                                             \
+      .error(                                                                  \
+          QLJS_TRANSLATABLE("cannot use template string as key in object"),    \
+          where))                                                              \
+                                                                               \
   /* END */
 
 namespace quick_lint_js {

--- a/test/test-parse-expression.cpp
+++ b/test/test-parse-expression.cpp
@@ -1442,6 +1442,21 @@ TEST_F(test_parse_expression, malformed_object_literal) {
                                 error_invalid_lone_literal_in_object_literal,
                                 where, offsets_matcher(p.locator, 1, 4))));
   }
+
+  {
+    test_parser p(u8"{`key`: 1};"_sv);
+    expression_ptr ast = p.parse_expression();
+    EXPECT_EQ(summarize(ast), "object(literal, ?)");
+    EXPECT_THAT(
+        p.errors(),
+        ElementsAre(
+            ERROR_TYPE_FIELD(error_unexpected_template_string, where,
+                             offsets_matcher(p.locator, 6, 6)),
+            ERROR_TYPE_FIELD(error_missing_comma_between_object_literal_entries,
+                             where, offsets_matcher(p.locator, 7, 7)),
+            ERROR_TYPE_FIELD(error_invalid_lone_literal_in_object_literal,
+                             where, offsets_matcher(p.locator, 8, 9))));
+  }
 }
 
 TEST_F(test_parse_expression, parse_comma_expression) {


### PR DESCRIPTION
Hey, @strager . Made a PR for this [issue](https://github.com/quick-lint/quick-lint-js/issues/124). First time contributing to a c++ project. 

I'm a little unsure if the implementation is what's desired, with multiple errors being returned for this template literal in object (see tests). 

Tests passed locally, and formatted with `clang-format`. 

Let me know if I missed anything. 