### PR TITLE
Allow escaped newlines with CRLF

### DIFF
--- a/src/lex.cpp
+++ b/src/lex.cpp
@@ -607,6 +607,13 @@ const char8* lexer::parse_string_literal() noexcept {
           ++c;
           break;
         }
+        break;
+      case '\r':
+        ++c;
+        if (*c == '\n') {
+          ++c;
+        }
+        break;
       case 'x':
         ++c;
         for (int i = 0; i < 2; ++i) {

--- a/test/test-lex.cpp
+++ b/test/test-lex.cpp
@@ -550,7 +550,6 @@ TEST_F(test_lex, lex_strings) {
   this->check_tokens(u8"\"hello\\\nworld\"", {token_type::string});
   this->check_tokens(u8"'hello\\x0aworld'", {token_type::string});
   this->check_tokens(u8R"('\x68\x65\x6c\x6C\x6f')", {token_type::string});
-  this->check_tokens(u8"'hello\\\r\nworld'", {token_type::string});
 
   this->check_tokens_with_errors(
       u8R"("unterminated)", {token_type::string},
@@ -559,6 +558,15 @@ TEST_F(test_lex, lex_strings) {
                                 error_unclosed_string_literal, string_literal,
                                 offsets_matcher(input, 0, 13))));
       });
+
+  for (string8_view line_terminator : line_terminators) {
+    for (const char8* quotation_mark : {u8"'", u8"\""}) {
+      padded_string input(quotation_mark +
+                          (u8"line1\\" + string8(line_terminator) + u8"line2") +
+                          quotation_mark);
+      this->check_tokens(&input, {token_type::string});
+    }
+  }
 
   for (string8_view line_terminator : line_terminators_except_ls_ps) {
     error_collector v;

--- a/test/test-lex.cpp
+++ b/test/test-lex.cpp
@@ -550,6 +550,7 @@ TEST_F(test_lex, lex_strings) {
   this->check_tokens(u8"\"hello\\\nworld\"", {token_type::string});
   this->check_tokens(u8"'hello\\x0aworld'", {token_type::string});
   this->check_tokens(u8R"('\x68\x65\x6c\x6C\x6f')", {token_type::string});
+  this->check_tokens(u8"'hello\\\r\nworld'", {token_type::string});
 
   this->check_tokens_with_errors(
       u8R"("unterminated)", {token_type::string},


### PR DESCRIPTION
Resolves a lingering issue in #10 

Currently in a multi-line string literal, if the line ends with CRLF, quick-lint incorrectly reports 'unclosed string literal'.
```javascript
let a = 'hello \
         world.'
```
This removes the error.

Also add a test to ensure that all line ending types are allowed in a string literal if escaped with a backslash.