### PR TITLE
Report warnings for misuse of --lsp-server

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,6 +39,7 @@ class any_error_reporter {
   static any_error_reporter make(output_format format,
                                  compiled_error_list *exit_fail_on) {
     switch (format) {
+    case output_format::default_format:
     case output_format::gnu_like:
       return any_error_reporter(error_tape<text_error_reporter>(
           text_error_reporter(std::cerr), exit_fail_on));

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -201,6 +201,10 @@ done_parsing_options:
 
 bool options::dump_errors(std::ostream& out) const {
   bool have_errors = false;
+  if (this->lsp_server &&
+      this->output_format != output_format::default_format) {
+    out << "warning: --output-format ignored with --lsp-server\n";
+  }
   for (const auto& option : this->error_unrecognized_options) {
     out << "error: unrecognized option: " << option << '\n';
     have_errors = true;

--- a/src/quick-lint-js/options.h
+++ b/src/quick-lint-js/options.h
@@ -11,6 +11,7 @@
 
 namespace quick_lint_js {
 enum class output_format {
+  default_format,
   gnu_like,
   vim_qflist_json,
 };
@@ -26,7 +27,7 @@ struct options {
   bool print_parser_visits = false;
   bool lsp_server = false;
   quick_lint_js::output_format output_format =
-      quick_lint_js::output_format::gnu_like;
+      quick_lint_js::output_format::default_format;
   std::vector<file_to_lint> files_to_lint;
   compiled_error_list exit_fail_on;
 


### PR DESCRIPTION
We should warn when the option `--lsp-server` and one of the output formats are chosen since the option is incompatible and therefore ignored.
To detect if an option was given, a new enum value `default_format` was added.

There are no tests for this, mainly since I couldn't find a test that targets the `o.files_to_lint` check right below, nor a test for `handle_options` at all.

Feedback about this approach is welcomed.

Fixes #202