### PR TITLE
reports error message when missing rhs of compound assignment operator

### DIFF
--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -737,6 +737,7 @@ next:
     default:
       QLJS_UNREACHABLE();
     }
+    source_code_span operator_span = this->peek().span();
     this->skip();
     expression* lhs = build_expression();
     switch (lhs->kind()) {
@@ -756,6 +757,11 @@ next:
     }
     expression* rhs = this->parse_expression(
         precedence{.commas = false, .in_operator = prec.in_operator});
+    if (rhs->kind() == expression_kind::_invalid) {
+      this->error_reporter_->report(error_missing_operand_for_operator{
+          .where = operator_span,
+      });
+    }
     children.clear();
     children.emplace_back(
         this->make_expression<expression::assignment>(kind, lhs, rhs));

--- a/test/test-parse-expression-statement.cpp
+++ b/test/test-parse-expression-statement.cpp
@@ -132,6 +132,20 @@ TEST(test_parse, parse_invalid_math_expression) {
             ERROR_TYPE_FIELD(error_unmatched_parenthesis, where,
                              offsets_matcher(&code, strlen(u8"2 * "), u8"("))));
   }
+
+  {
+    padded_string code(u8"x += ;"_sv);
+    spy_visitor v;
+    parser p(&code, &v);
+    p.parse_and_visit_expression(v);
+    EXPECT_THAT(v.visits,
+                ElementsAre("visit_variable_use", "visit_variable_assignment"));
+    EXPECT_THAT(v.variable_uses,
+                ElementsAre(spy_visitor::visited_variable_use{u8"x"}));
+    EXPECT_THAT(v.errors, ElementsAre(ERROR_TYPE_FIELD(
+                              error_missing_operand_for_operator, where,
+                              offsets_matcher(&code, strlen(u8"x "), u8"+="))));
+  }
 }
 
 TEST(test_parse, stray_right_parenthesis) {


### PR DESCRIPTION
Attempts to fix issue #179.

I'm not entirely confident that just reporting an invalid right-hand side should catch all the cases, but for all the compound assignment operators it seems to work and does not conflict with previous tests.