### PR TITLE
Refactor files_to_lint warning into dump_errors + test

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -143,10 +143,6 @@ void handle_options(quick_lint_js::options o) {
   }
   if (o.lsp_server) {
     quick_lint_js::run_lsp_server();
-    if (!o.files_to_lint.empty()) {
-      std::cerr << "warning: ignoring files given on command line in "
-                   "--lsp-server mode\n";
-    }
     std::exit(EXIT_SUCCESS);
   }
   if (o.files_to_lint.empty()) {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -201,9 +201,14 @@ done_parsing_options:
 
 bool options::dump_errors(std::ostream& out) const {
   bool have_errors = false;
-  if (this->lsp_server &&
-      this->output_format != output_format::default_format) {
-    out << "warning: --output-format ignored with --lsp-server\n";
+  if (this->lsp_server) {
+    if (this->output_format != output_format::default_format) {
+      out << "warning: --output-format ignored with --lsp-server\n";
+    }
+    if (!this->files_to_lint.empty()) {
+      out << "warning: ignoring files given on command line in "
+             "--lsp-server mode\n";
+    }
   }
   for (const auto& option : this->error_unrecognized_options) {
     out << "error: unrecognized option: " << option << '\n';

--- a/test/test-options.cpp
+++ b/test/test-options.cpp
@@ -349,6 +349,24 @@ TEST(test_options, dump_errors) {
                 "warning: --output-format ignored with --lsp-server\n");
     }
   }
+
+  {
+    const file_to_lint file = {
+        .path = "file.js",
+        .vim_bufnr = std::optional<int>(),
+    };
+
+    options o;
+    o.lsp_server = true;
+    o.files_to_lint.emplace_back(file);
+
+    std::ostringstream dumped_errors;
+    bool have_errors = o.dump_errors(dumped_errors);
+    EXPECT_FALSE(have_errors);
+    EXPECT_EQ(dumped_errors.str(),
+              "warning: ignoring files given on command line in "
+              "--lsp-server mode\n");
+  }
 }
 }
 }


### PR DESCRIPTION
When I was working on #208, I noticed another warning that is in a suboptimal location and is untested. This PR addresses that.