### PR TITLE
warn when --exit-fail-on is used with --lsp-server

### DIFF
--- a/src/error-list.cpp
+++ b/src/error-list.cpp
@@ -207,6 +207,10 @@ bool compiled_error_list::is_present(const char* error_code) const noexcept {
   }
   return present;
 }
+
+bool compiled_error_list::is_user_provided() const noexcept {
+  return !parsed_error_lists_.empty();
+}
 }
 
 // quick-lint-js finds bugs in JavaScript programs.

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -202,6 +202,9 @@ done_parsing_options:
 bool options::dump_errors(std::ostream& out) const {
   bool have_errors = false;
   if (this->lsp_server) {
+    if (this->exit_fail_on.is_user_provided()) {
+      out << "warning: --exit-fail-on ignored with --lsp-server\n";
+    }
     if (this->output_format != output_format::default_format) {
       out << "warning: --output-format ignored with --lsp-server\n";
     }

--- a/src/quick-lint-js/error-list.h
+++ b/src/quick-lint-js/error-list.h
@@ -34,6 +34,8 @@ class compiled_error_list {
   template <class Error>
   bool is_present() const noexcept;
 
+  bool is_user_provided() const noexcept;
+
  private:
   bool is_present(const char* error_code) const noexcept;
 

--- a/test/test-options.cpp
+++ b/test/test-options.cpp
@@ -367,6 +367,18 @@ TEST(test_options, dump_errors) {
               "warning: ignoring files given on command line in "
               "--lsp-server mode\n");
   }
+
+  {
+    options o;
+    o.lsp_server = true;
+    o.exit_fail_on.add(parse_error_list("E001"));
+
+    std::ostringstream dumped_errors;
+    bool have_errors = o.dump_errors(dumped_errors);
+    EXPECT_FALSE(have_errors);
+    EXPECT_EQ(dumped_errors.str(),
+              "warning: --exit-fail-on ignored with --lsp-server\n");
+  }
 }
 }
 }


### PR DESCRIPTION
Yet another parameter that should warn when `--lsp-server` is used.
A part of https://github.com/quick-lint/quick-lint-js/pull/208 and https://github.com/quick-lint/quick-lint-js/issues/202