### PR TITLE
Highlight installation commands with one click

### DIFF
--- a/website/install.html
+++ b/website/install.html
@@ -106,6 +106,10 @@
         text-indent: -6ch;
         white-space: normal;
       }
+
+      code kbd::before {
+        content: '$ ';
+      }
     </style>
   </head>
   <body>
@@ -724,8 +728,8 @@
           <img class="os-logo" src="macos.svg" alt="" />&nbsp;macOS with npm
         </h4>
         <blockquote>
-          <pre><code>$ <kbd>npm install quick-lint-js --save-dev --save-exact</kbd>
-$ <kbd>node_modules/.bin/quick-lint-js --help</kbd></code></pre>
+          <pre><code><kbd>npm install quick-lint-js --save-dev --save-exact</kbd>
+<kbd>node_modules/.bin/quick-lint-js --help</kbd></code></pre>
         </blockquote>
 
         <h4>
@@ -733,16 +737,16 @@ $ <kbd>node_modules/.bin/quick-lint-js --help</kbd></code></pre>
           <img class="os-logo" src="macos.svg" alt="" />&nbsp;macOS with yarn
         </h4>
         <blockquote>
-          <pre><code>$ <kbd>yarn add quick-lint-js --dev --exact</kbd>
-$ <kbd>node_modules/.bin/quick-lint-js --help</kbd></code></pre>
+          <pre><code><kbd>yarn add quick-lint-js --dev --exact</kbd>
+<kbd>node_modules/.bin/quick-lint-js --help</kbd></code></pre>
         </blockquote>
 
         <h4>
           <img class="os-logo" src="windows.svg" alt="" />&nbsp;Windows with npm
         </h4>
         <blockquote>
-          <pre><code>$ <kbd>npm install quick-lint-js --save-dev --save-exact</kbd>
-$ <kbd>node_modules\.bin\quick-lint-js.cmd --help</kbd></code></pre>
+          <pre><code><kbd>npm install quick-lint-js --save-dev --save-exact</kbd>
+<kbd>node_modules\.bin\quick-lint-js.cmd --help</kbd></code></pre>
         </blockquote>
 
         <h4>
@@ -750,8 +754,8 @@ $ <kbd>node_modules\.bin\quick-lint-js.cmd --help</kbd></code></pre>
           yarn
         </h4>
         <blockquote>
-          <pre><code>$ <kbd>yarn add quick-lint-js --dev --exact</kbd>
-$ <kbd>node_modules\.bin\quick-lint-js.cmd --help</kbd></code></pre>
+          <pre><code><kbd>yarn add quick-lint-js --dev --exact</kbd>
+<kbd>node_modules\.bin\quick-lint-js.cmd --help</kbd></code></pre>
         </blockquote>
 
         <h3>Install globally</h3>
@@ -764,14 +768,14 @@ $ <kbd>node_modules\.bin\quick-lint-js.cmd --help</kbd></code></pre>
           <img class="os-logo" src="macos.svg" alt="" />&nbsp;macOS
         </h4>
         <blockquote>
-          <pre><code>$ <kbd>sudo npm install --global --unsafe-perm quick-lint-js</kbd>
-$ <kbd>quick-lint-js --help</kbd></code></pre>
+          <pre><code><kbd>sudo npm install --global --unsafe-perm quick-lint-js</kbd>
+<kbd>quick-lint-js --help</kbd></code></pre>
         </blockquote>
 
         <h4><img class="os-logo" src="windows.svg" alt="" />&nbsp;Windows</h4>
         <blockquote>
-          <pre><code>$ <kbd>npm install --global quick-lint-js</kbd>
-$ <kbd>quick-lint-js.cmd --help</kbd></code></pre>
+          <pre><code><kbd>npm install --global quick-lint-js</kbd>
+<kbd>quick-lint-js.cmd --help</kbd></code></pre>
         </blockquote>
       </article>
 
@@ -799,7 +803,7 @@ $ <kbd>quick-lint-js.cmd --help</kbd></code></pre>
           quick-lint-js' tap to your Homebrew installation:
         </p>
         <blockquote>
-          <pre><code>$ <kbd>brew tap quick-lint/quick-lint-js https://github.com/quick-lint/quick-lint-js.git</kbd></code></pre>
+          <pre><code><kbd>brew tap quick-lint/quick-lint-js https://github.com/quick-lint/quick-lint-js.git</kbd></code></pre>
         </blockquote>
 
         <p>
@@ -807,7 +811,7 @@ $ <kbd>quick-lint-js.cmd --help</kbd></code></pre>
           quick-lint-js:
         </p>
         <blockquote>
-          <pre><code>$ <kbd>brew install --HEAD quick-lint-js</kbd></code></pre>
+          <pre><code><kbd>brew install --HEAD quick-lint-js</kbd></code></pre>
         </blockquote>
 
         <p>
@@ -815,7 +819,7 @@ $ <kbd>quick-lint-js.cmd --help</kbd></code></pre>
           user path:
         </p>
         <blockquote>
-          <pre><code>$ <kbd>quick-lint-js --help</kbd></code></pre>
+          <pre><code><kbd>quick-lint-js --help</kbd></code></pre>
         </blockquote>
       </article>
 
@@ -836,20 +840,20 @@ $ <kbd>quick-lint-js.cmd --help</kbd></code></pre>
 
         <p>Open a terminal, and run the following commands:</p>
         <blockquote>
-          <pre><code>$ <kbd>curl https://c.quick-lint-js.com/quick-lint-js-release.key | sudo apt-key add -</kbd>
-<div class="long-shell-command-line">$ <kbd>printf '\n# https://quick-lint-js.com/install.html#debian\ndeb https://c.quick-lint-js.com/debian experimental main\n' | sudo tee -a /etc/apt/sources.list.d/quick-lint-js.list</kbd></div>
-$ <kbd>sudo apt-get update</kbd>
+          <pre><code><kbd>curl https://c.quick-lint-js.com/quick-lint-js-release.key | sudo apt-key add -</kbd>
+<div class="long-shell-command-line"><kbd>printf '\n# https://quick-lint-js.com/install.html#debian\ndeb https://c.quick-lint-js.com/debian experimental main\n' | sudo tee -a /etc/apt/sources.list.d/quick-lint-js.list</kbd></div>
+<kbd>sudo apt-get update</kbd>
 
 # <img class="install-logo" src="gnome-terminal.svg" alt="" /> CLI and LSP server
-$ <kbd>sudo apt-get install quick-lint-js</kbd>
+<kbd>sudo apt-get install quick-lint-js</kbd>
 
 # <img class="install-logo" src="vim.gif" alt="" /> Vim plugin
-$ <kbd>sudo apt-get install quick-lint-js-vim</kbd></code></pre>
+<kbd>sudo apt-get install quick-lint-js-vim</kbd></code></pre>
         </blockquote>
 
         <p>Verify that quick-lint-js is installed:</p>
         <blockquote>
-          <pre><code>$ <kbd>quick-lint-js --version</kbd>
+          <pre><code><kbd>quick-lint-js --version</kbd>
 quick-lint-js version 0.2.0</code></pre>
         </blockquote>
       </article>
@@ -877,7 +881,7 @@ quick-lint-js version 0.2.0</code></pre>
         <blockquote>
           <pre
             class="long-shell-command-line"
-          ><code>$ <kbd>nix-env -f https://github.com/quick-lint/quick-lint-js/archive/0.2.0.tar.gz -iA quick-lint-js</kbd></code></pre>
+          ><code><kbd>nix-env -f https://github.com/quick-lint/quick-lint-js/archive/0.2.0.tar.gz -iA quick-lint-js</kbd></code></pre>
         </blockquote>
 
         <p>
@@ -885,7 +889,7 @@ quick-lint-js version 0.2.0</code></pre>
           user profile:
         </p>
         <blockquote>
-          <pre><code>$ <kbd>quick-lint-js --version</kbd>
+          <pre><code><kbd>quick-lint-js --version</kbd>
 quick-lint-js version 0.2.0</code></pre>
         </blockquote>
       </article>


### PR DESCRIPTION
This change allows users to select installation commands using only one click and it avoids selecting the leading `$`.
One downside is that users won't be able to select a portion of the installation command.
Not sure if this would be appropriate for the entire site so I put it inside of the style element for the HTML.

### Before:

https://user-images.githubusercontent.com/32761424/114309850-aa7d5d00-9ab6-11eb-91fe-8faf75a4c487.mp4

### After:

https://user-images.githubusercontent.com/32761424/114309853-ac472080-9ab6-11eb-8095-d7a6ef6496dd.mp4