### PR TITLE
Website: Synchronize demo's pre and textarea sizing

### DIFF
--- a/website/demo/index.html
+++ b/website/demo/index.html
@@ -100,7 +100,6 @@
     * Scrolling in general works poorly when sub-pixel scrolling (e.g. when
       zoomed in).
     * Scrolling horizontally sometimes doesn't scroll the highlights.
-    * Resizing the editor breaks highlights.
     * Browser text search finds text in the shadow code input in addition to
       text in the user code input.
 
@@ -152,6 +151,8 @@ console.log(`Welcome, ${ocupation}!`);
         });
         synchronizeContent();
 
+        new ResizeObserver(synchronizeSize).observe(codeInputElement);
+
         loadQuickLintJS()
           .then((quickLintJS) => {
             function lintAndUpdate() {
@@ -180,6 +181,11 @@ console.log(`Welcome, ${ocupation}!`);
         function synchronizeScrolling() {
           shadowCodeInputElement.scrollLeft = codeInputElement.scrollLeft;
           shadowCodeInputElement.scrollTop = codeInputElement.scrollTop;
+        }
+
+        function synchronizeSize() {
+          shadowCodeInputElement.style.width = codeInputElement.style.width;
+          shadowCodeInputElement.style.height = codeInputElement.style.height;
         }
       </script>
     </main>


### PR DESCRIPTION


https://user-images.githubusercontent.com/32761424/115054415-2f4cea00-9eae-11eb-9034-0e7e471d6f07.mp4





https://user-images.githubusercontent.com/32761424/115054442-34aa3480-9eae-11eb-9bc6-a98fba9f0a50.mp4





There seems to be some misalignment if you make the height too small. (potential "bug" not worth caring about)

I wasn't sure if the comment from the known bugs section referred to the fix I've implemented so I gave it it's own commit.
If it is referring to the fix, that commit should be fixup'd. If not, that commit should be dropped.