### PR TITLE
Asciidoctor

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -10,7 +10,7 @@ Follow the following steps to release a new version of quick-lint-js:
    * dist/nix/quick-lint-js.nix
    * dist/npm/BUILDING.md
    * dist/npm/package.json
-   * docs/quick-lint-js.1
+   * docs/cli.adoc
    * plugin/vscode-lsp/README.md
    * plugin/vscode-lsp/package.json
    * plugin/vscode/BUILDING.md

--- a/docs/cli.adoc
+++ b/docs/cli.adoc
@@ -1,0 +1,208 @@
+// Copyright (C) 2020  Matthew Glazar
+// See end of file for extended copyright information.
+
+= quick-lint-js(1)
+:version: 0.2.0
+:mansource: quick-lint-js version {version}
+:toc:
+:reproducible:
+:stylesheet: main.css
+:linkcss:
+
+== Name
+
+quick-lint-js - find bugs in JavaScript programs
+
+== Synopsis
+
+*quick-lint-js* [*--output-format*=_format_] [<options>] _file_ [_file_...] +
+*quick-lint-js* *--lsp-server* [<options>]
+
+== Description
+
+*quick-lint-js* reads JavaScript files and reports syntax errors and other bugs.
+
+This command has two modes:
+
+*quick-lint-js* [<options>] _file_ [_file_...]::
+  Batch mode (default).
+  Check the given files, and report errors to the terminal (standard error).
+  --output-format can be used to customize how errors look.
+
+*quick-lint-js* --lsp-server::
+  LSP server mode.
+  Start a Language Server Protocol server, communicating using standard input and standard output.
+  Use this mode to integrate with code editors supporting LSP.
+
+== Options
+
+*--output-format*=_format_::
+  Customize how errors are printed. _format_ is one of the following:
++
+pass:[-] *gnu-like* (default): a human-readable format similar to GCC.
++
+pass:[-] *vim-qflist-json*: machine-readable JSON which can be given to Vim's _setqflist_ function.
++
+Incompatible with *--lsp-server*.
+
+*--vim-file-bufnr*=_number_::
+  Set the _bufnr_ property for errors printed with the *--output-format=vim-qflist-json* option.
+  *--vim-file-bufnr* applies only to files which are given later in the command line.
+  Therefore, if multiple files are given, *--vim-file-bufnr* can be specified multiple times.
+
+*--exit-fail-on*=_errors_::
+  Cause *quick-lint-js* to exit with a non-zero exit code if any of the discovered errors is listed in _errors_.
++
+See the "ERROR LISTS" section for a description of the format for _errors_.
++
+Incompatible with *--lsp-server*.
+
+*--lsp*::
+*--lsp-server*::
+  Run *quick-lint-js* in LSP server mode.
+  Use this mode to integrate with code editors supporting LSP.
+  An editor can send LSP requests and notifications to *quick-lint-js* via standard input, and receive LSP responses and notifications from standard output.
++
+Incompatible with *--output-format*.
+
+*-h*::
+*--help*::
+  Print a help message and exit.
++
+The output format is not intended to be machine-parsable and may change in the future.
+
+*-v*::
+*--version*::
+  Print version information and exit.
++
+The output format is not intended to be machine-parsable and may change in the future.
+
+== Error lists
+
+Some options, such as *--exit-fail-on*, accept an error list.
+An error list is a comma-separated list of error code predicates and error category predicates.
+
+An error lists can contain any number of include, exclude, and default predicates.
+An include predicate is a '+' followed by the name of an error code or error category.
+An exclude predicate is a '-' followed by the name of an error code or error category.
+An default predicate is the name of an error code or error category with no sigil.
+
+An error list containing only include and exclude predicates modifies a default set of error codes.
+The default set is decided by the option, but is often the set of all error codes.
+An error list containing at least one default predicate empties the set of error codes, then treats the default predicates as if they were include predicates.
+
+The order of predicates within an error list does not matter.
+Included predicates are processed first, adding to the set of error codes.
+Excluded predicates are processed second, removing from the set of error codes.
+
+Error codes have the form *E000*, where _000_ is three decimal digits (0-9).
+
+The following error categories are supported:
+
+*all*::
+  All error codes.
+
+Example error lists:
+
+*E102,E110*::
+  Only error codes E102 and E110, excluding all other error codes.
+
+*-E102*::
+  The default set of error codes, except for error code E102.
+
+*+E102*::
+  The default set of error codes, and also error code E102.
+
+*all,-E102*::
+  All error codes, except for error code E102.
+
+*E100,-E100,+E200*::
+  Only error code E200, excluding all other error codes.
+
+*+E200,-E100,E100*::
+  Only error code E200, excluding all other error codes.
+
+== Exit status
+
+*0*::
+  Batch mode: Linting succeeded with no errors or warnings.
++
+LSP server mode: The LSP client requested that the server shut down.
+This exit status may change in the future.
+
+*non-0*::
+  Batch mode: Linting failed with at least one error or warning, or at least one _file_ could not be opened and read.
++
+The specific status code may change in the future.
+
+== Environment
+
+*LC_ALL*::
+*LC_MESSAGES*::
+  Change the language used for error and warning messages.
+  For example, set *LC_ALL=en* to see messages written in United States English.
+
+== Example
+
+To lint a file called _lib/index.js_, writing error messages to the terminal:
+____
+[subs=+quotes]
+----
+$ *quick-lint-js* lib/index.js
+lib/index.js:1:20: error: variable used before declaration: language [E058]
+lib/index.js:2:7: note: variable declared here [E058]
+lib/index.js:3:1: error: assignment to const variable [E003]
+lib/index.js:1:7: note: const variable declared here [E003]
+lib/index.js:5:25: warning: use of undeclared variable: ocupation [E057]
+----
+____
+
+To lint three files, writing machine-readable messages to _/tmp/vim-qflist.json_:
+____
+[subs=+quotes]
+----
+$ *quick-lint-js* --output-format=vim-qflist-json \
+    --vim-bufnr=3 lib/pizza-dough.js \
+    --vim-bufnr=4 lib/pizza-sauce.js \
+    --vim-bufnr=6 lib/pineapple.js \
+    >/tmp/vim-qflist.json
+----
+____
+Errors for _lib/pizza-dough.js_ will include _"bufnr":3_ in the output and errors for _lib/pineapple.js_ will include _"bufnr":6_.
+
+To lint a file called _bad.js_, but don't fail on use-of-undeclared-variable errors:
+____
+[subs=+quotes]
+----
+$ *quick-lint-js* --exit-fail-on=-E057 bad.js
+bad.js:5:25: warning: use of undeclared variable: $ [E057]
+$ echo $?
+0
+----
+____
+
+ifdef::backend-manpage[]
+
+== See also
+
+*eslint*(1)
+
+endif::backend-manpage[]
+
+// quick-lint-js finds bugs in JavaScript programs.
+// Copyright (C) 2020  Matthew Glazar
+//
+// This file is part of quick-lint-js.
+//
+// quick-lint-js is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// quick-lint-js is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with quick-lint-js.  If not, see <https://www.gnu.org/licenses/>.

--- a/docs/quick-lint-js.1
+++ b/docs/quick-lint-js.1
@@ -1,141 +1,123 @@
 .\" Copyright (C) 2020  Matthew Glazar
 .\" See end of file for extended copyright information.
+.\" This file was generated using generate-cli-docs.
 .
 .\" Manual page for the 'man' utility.
 .
 .
-.TH QUICK\-LINT\-JS 1 "" "quick\-lint\-js version 0.2.0"
-.
-.
-.\" BEGIN_AN_EXT_TMAC -----------------------------------------------------------
-.\" The following macros are taken from groff's an-ext.tmac file.
-.\" Copyright (C) 2007-2018 Free Software Foundation, Inc.
-.\" Written by Eric S. Raymond <esr@thyrsus.com>
-.\"            Werner Lemberg <wl@gnu.org>
-.\" You may freely use, modify and/or distribute portions of this file between
-.\" BEGIN_AN_EXT_TMAC and END_AN_EXT_TMAC.
-.
-.\" Continuation line for .TP header.
-.de TQ
-.  br
-.  ns
-.  TP \\$1\" no doublequotes around argument!
+'\" t
+.\"     Title: quick-lint-js
+.\"    Author: [see the "AUTHOR(S)" section]
+.\" Generator: Asciidoctor 2.0.14
+.\"    Manual: \ \&
+.\"    Source: quick-lint-js version 0.2.0
+.\"  Language: English
+.\"
+.TH "QUICK\-LINT\-JS" "1" "" "quick\-lint\-js version 0.2.0" "\ \&"
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.ss \n[.ss] 0
+.nh
+.ad l
+.de URL
+\fI\\$2\fP <\\$1>\\$3
 ..
-.
-.\" Start example.
-.de EX
-.  do ds mF \\n[.fam]
-.  nr mE \\n(.f
-.  nf
-.  nh
-.  do fam C
-.  ft CW
-..
-.
-.\" End example.
-.de EE
-.  do fam \\*(mF
-.  ft \\n(mE
-.  fi
-.  hy \\n(HY
-..
-.\" END_AN_EXT_TMAC -------------------------------------------------------------
-.
-.
-.SH NAME
-.B quick\-lint\-js
-\- find bugs in JavaScript programs
-.
-.
-.SH SYNOPSIS
-.nf
-\fBquick\-lint\-js\fR [\fB\-\-output\-format\fR=\fIformat\fR] [<options>] \fIfile\fR [\fIfile\fR...]
-\fBquick\-lint\-js\fR \fB\-\-lsp\-server\fR [<options>]
-.fi
-.
-.
-.SH DESCRIPTION
-\fBquick\-lint\-js\fR reads JavaScript files and reports syntax errors and other bugs.
-.PP
+.als MTO URL
+.if \n[.g] \{\
+.  mso www.tmac
+.  am URL
+.    ad l
+.  .
+.  am MTO
+.    ad l
+.  .
+.  LINKSTYLE blue R < >
+.\}
+.SH "NAME"
+quick-lint-js \- find bugs in JavaScript programs
+.SH "SYNOPSIS"
+.sp
+\fBquick\-lint\-js\fP [\fB\-\-output\-format\fP=\fIformat\fP] [<options>] \fIfile\fP [\fIfile\fP...]
+.br
+\fBquick\-lint\-js\fP \fB\-\-lsp\-server\fP [<options>]
+.SH "DESCRIPTION"
+.sp
+\fBquick\-lint\-js\fP reads JavaScript files and reports syntax errors and other bugs.
+.sp
 This command has two modes:
-.
-.TP
-.nf
-\fBquick\-lint\-js\fR [<options>] \fIfile\fR [\fIfile\fR...]
-.fi
+.sp
+\fBquick\-lint\-js\fP [<options>] \fIfile\fP [\fIfile\fP...]
+.RS 4
 Batch mode (default).
 Check the given files, and report errors to the terminal (standard error).
 \-\-output\-format can be used to customize how errors look.
-.
-.TP
-.nf
-\fBquick\-lint\-js\fR \-\-lsp\-server
-.fi
+.RE
+.sp
+\fBquick\-lint\-js\fP \-\-lsp\-server
+.RS 4
 LSP server mode.
 Start a Language Server Protocol server, communicating using standard input and standard output.
 Use this mode to integrate with code editors supporting LSP.
 .RE
-.
-.
-.SH OPTIONS
-.TP
-.BR \-\-output\-format\fR=\fIformat\fR
-Customize how errors are printed. \fIformat\fR is one of the following:
-.RS
-.IP \- 2
-\fBgnu-like\fR (default): a human-readable format similar to GCC.
-.IP \- 2
-\fBvim-qflist-json\fR: machine-readable JSON which can be given to Vim's \fIsetqflist\fR function.
-.RE
-.RS
+.SH "OPTIONS"
 .sp
-Incompatible with \fB\-\-lsp\-server\fR.
-.RE
-.
-.TP
-.BR \-\-vim-file-bufnr\fR=\fInumber\fR
-Set the \fIbufnr\fR property for errors printed with the \fB\-\-output\-format=vim-qflist-json\fR option.
-\fB\-\-vim\-file\-bufnr\fR applies only to files which are given later in the command line.
-Therefore, if multiple files are given, \fB-\-vim\-file\-bufnr\fR can be specified multiple times.
-.
-.TP
-.BR \-\-exit\-fail\-on\fR=\fIerrors\fR
-Cause \fBquick\-lint\-js\fR to exit with a non-zero exit code if any of the discovered errors is listed in \fIerrors\fR.
+\fB\-\-output\-format\fP=\fIformat\fP
+.RS 4
+Customize how errors are printed. \fIformat\fP is one of the following:
 .sp
-See the "ERROR LISTS" section for a description of the format for \fIerrors\fR.
+\- \fBgnu\-like\fP (default): a human\-readable format similar to GCC.
 .sp
-Incompatible with \fB\-\-lsp\-server\fR.
+\- \fBvim\-qflist\-json\fP: machine\-readable JSON which can be given to Vim\(cqs \fIsetqflist\fP function.
+.sp
+Incompatible with \fB\-\-lsp\-server\fP.
 .RE
-.
-.TP
-.BR \-\-lsp ", " \-\-lsp-server
-Run \fBquick\-lint\-js\fR in LSP server mode.
+.sp
+\fB\-\-vim\-file\-bufnr\fP=\fInumber\fP
+.RS 4
+Set the \fIbufnr\fP property for errors printed with the \fB\-\-output\-format=vim\-qflist\-json\fP option.
+\fB\-\-vim\-file\-bufnr\fP applies only to files which are given later in the command line.
+Therefore, if multiple files are given, \fB\-\-vim\-file\-bufnr\fP can be specified multiple times.
+.RE
+.sp
+\fB\-\-exit\-fail\-on\fP=\fIerrors\fP
+.RS 4
+Cause \fBquick\-lint\-js\fP to exit with a non\-zero exit code if any of the discovered errors is listed in \fIerrors\fP.
+.sp
+See the "ERROR LISTS" section for a description of the format for \fIerrors\fP.
+.sp
+Incompatible with \fB\-\-lsp\-server\fP.
+.RE
+.sp
+\fB\-\-lsp\fP, \fB\-\-lsp\-server\fP
+.RS 4
+Run \fBquick\-lint\-js\fP in LSP server mode.
 Use this mode to integrate with code editors supporting LSP.
-An editor can send LSP requests and notifications to \fBquick\-lint\-js\fR via standard input, and receive LSP responses and notifications from standard output.
+An editor can send LSP requests and notifications to \fBquick\-lint\-js\fP via standard input, and receive LSP responses and notifications from standard output.
 .sp
-Incompatible with \fB\-\-output\-format\fR.
-.
-.TP
-.BR \-h ", " \-\-help
+Incompatible with \fB\-\-output\-format\fP.
+.RE
+.sp
+\fB\-h\fP, \fB\-\-help\fP
+.RS 4
 Print a help message and exit.
 .sp
-The output format is not intended to be machine-parsable and may change in the future.
-.
-.TP
-.BR \-v ", " \-\-version
+The output format is not intended to be machine\-parsable and may change in the future.
+.RE
+.sp
+\fB\-v\fP, \fB\-\-version\fP
+.RS 4
 Print version information and exit.
 .sp
-The output format is not intended to be machine-parsable and may change in the future.
+The output format is not intended to be machine\-parsable and may change in the future.
 .RE
-.
-.
-.SH ERROR LISTS
-Some options, such as \fB\-\-exit\-fail\-on\fR, accept an error list.
-An error list is a comma-separated list of error code predicates and error category predicates.
+.SH "ERROR LISTS"
+.sp
+Some options, such as \fB\-\-exit\-fail\-on\fP, accept an error list.
+An error list is a comma\-separated list of error code predicates and error category predicates.
 .sp
 An error lists can contain any number of include, exclude, and default predicates.
-An include predicate is a '+' followed by the name of an error code or error category.
-An exclude predicate is a '\-' followed by the name of an error code or error category.
+An include predicate is a \(aq+\(aq followed by the name of an error code or error category.
+An exclude predicate is a \(aq\-\(aq followed by the name of an error code or error category.
 An default predicate is the name of an error code or error category with no sigil.
 .sp
 An error list containing only include and exclude predicates modifies a default set of error codes.
@@ -146,104 +128,132 @@ The order of predicates within an error list does not matter.
 Included predicates are processed first, adding to the set of error codes.
 Excluded predicates are processed second, removing from the set of error codes.
 .sp
-Error codes have the form \fBE000\fR, where \fI000\fR is three decimal digits (0-9).
+Error codes have the form \fBE000\fP, where \fI000\fP is three decimal digits (0\-9).
 .sp
 The following error categories are supported:
-.TP
-.B all
+.sp
+\fBall\fP
+.RS 4
 All error codes.
 .RE
 .sp
 Example error lists:
-.TP
-.B "E102,E110"
+.sp
+\fBE102,E110\fP
+.RS 4
 Only error codes E102 and E110, excluding all other error codes.
-.TP
-.B "-E102"
+.RE
+.sp
+\fB\-E102\fP
+.RS 4
 The default set of error codes, except for error code E102.
-.TP
-.B "+E102"
+.RE
+.sp
+\fB+E102\fP
+.RS 4
 The default set of error codes, and also error code E102.
-.TP
-.B "all,-E102"
+.RE
+.sp
+\fBall,\-E102\fP
+.RS 4
 All error codes, except for error code E102.
-.TP
-.B "E100,-E100,+E200"
-Only error code E200, excluding all other error codes.
-.TP
-.B "+E200,-E100,E100"
+.RE
+.sp
+\fBE100,\-E100,+E200\fP
+.RS 4
 Only error code E200, excluding all other error codes.
 .RE
-.
-.
-.SH EXIT STATUS
-.TP
-.B 0
+.sp
+\fB+E200,\-E100,E100\fP
+.RS 4
+Only error code E200, excluding all other error codes.
+.RE
+.SH "EXIT STATUS"
+.sp
+\fB0\fP
+.RS 4
 Batch mode: Linting succeeded with no errors or warnings.
 .sp
 LSP server mode: The LSP client requested that the server shut down.
 This exit status may change in the future.
-.
-.TP
-.B non-0
-Batch mode: Linting failed with at least one error or warning, or at least one \fIfile\fR could not be opened and read.
+.RE
+.sp
+\fBnon\-0\fP
+.RS 4
+Batch mode: Linting failed with at least one error or warning, or at least one \fIfile\fP could not be opened and read.
 .sp
 The specific status code may change in the future.
-.
-.
-.SH ENVIRONMENT
-.TP
-.B LC_ALL
-.TQ
-.B LC_MESSAGES
+.RE
+.SH "ENVIRONMENT"
+.sp
+\fBLC_ALL\fP, \fBLC_MESSAGES\fP
+.RS 4
 Change the language used for error and warning messages.
-For example, set \fBLC_ALL=en\fR to see messages written in United States English.
-.
-.
-.SH EXAMPLE
-To lint a file called \fIlib/index.js\fR, writing error messages to the terminal:
-.PP
-.RS
-.EX
-$ \fBquick-lint-js\fR lib/index.js
+For example, set \fBLC_ALL=en\fP to see messages written in United States English.
+.RE
+.SH "EXAMPLE"
+.sp
+To lint a file called \fIlib/index.js\fP, writing error messages to the terminal:
+.RS 3
+.ll -.6i
+.sp
+.if n .RS 4
+.nf
+.fam C
+$ \fBquick\-lint\-js\fP lib/index.js
 lib/index.js:1:20: error: variable used before declaration: language [E058]
 lib/index.js:2:7: note: variable declared here [E058]
 lib/index.js:3:1: error: assignment to const variable [E003]
 lib/index.js:1:7: note: const variable declared here [E003]
 lib/index.js:5:25: warning: use of undeclared variable: ocupation [E057]
-.EE
+.fam
+.fi
+.if n .RE
+.br
 .RE
-.
-.PP
-To lint three files, writing machine-readable messages to \fI/tmp/vim\-qflist.json\fR:
-.PP
-.RS
-.EX
-$ \fBquick-lint-js\fR --output-format=vim-qflist-json \\
-    --vim-bufnr=3 lib/pizza-dough.js \\
-    --vim-bufnr=4 lib/pizza-sauce.js \\
-    --vim-bufnr=6 lib/pineapple.js \\
-    >/tmp/vim-qflist.json
-.EE
+.ll
+.sp
+To lint three files, writing machine\-readable messages to \fI/tmp/vim\-qflist.json\fP:
+.RS 3
+.ll -.6i
+.sp
+.if n .RS 4
+.nf
+.fam C
+$ \fBquick\-lint\-js\fP \-\-output\-format=vim\-qflist\-json \(rs
+    \-\-vim\-bufnr=3 lib/pizza\-dough.js \(rs
+    \-\-vim\-bufnr=4 lib/pizza\-sauce.js \(rs
+    \-\-vim\-bufnr=6 lib/pineapple.js \(rs
+    >/tmp/vim\-qflist.json
+.fam
+.fi
+.if n .RE
+.br
 .RE
-.PP
-Errors for \fIlib/pizza\-dough.js\fR will include \fI"bufnr":3\fR in the output and errors for \fIlib/pineapple.js\fR will include \fI"bufnr":6\fR.
-.
-.PP
-To lint a file called \fIbad.js\fR, but don't fail on use-of-undeclared-variable errors:
-.PP
-.RS
-.EX
-$ \fBquick-lint-js\fR --exit-fail-on=-E057 bad.js
+.ll
+.sp
+Errors for \fIlib/pizza\-dough.js\fP will include \fI"bufnr":3\fP in the output and errors for \fIlib/pineapple.js\fP will include \fI"bufnr":6\fP.
+.sp
+To lint a file called \fIbad.js\fP, but don\(cqt fail on use\-of\-undeclared\-variable errors:
+.RS 3
+.ll -.6i
+.sp
+.if n .RS 4
+.nf
+.fam C
+$ \fBquick\-lint\-js\fP \-\-exit\-fail\-on=\-E057 bad.js
 bad.js:5:25: warning: use of undeclared variable: $ [E057]
 $ echo $?
 0
-.EE
+.fam
+.fi
+.if n .RE
+.br
 .RE
-.
-.
-.SH SEE ALSO
-.BR eslint (1)
+.ll
+.SH "SEE ALSO"
+.sp
+\fBeslint\fP(1)
 
 .\" quick-lint-js finds bugs in JavaScript programs.
 .\" Copyright (C) 2020  Matthew Glazar

--- a/tools/generate-cli-docs
+++ b/tools/generate-cli-docs
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2020  Matthew Glazar
+# See end of file for extended copyright information.
+
+import os
+import subprocess
+import re
+import pathlib
+
+
+def main():
+    qljs_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+    os.chdir(qljs_dir)
+
+    subprocess.check_output(
+        [
+            "asciidoctor",
+            "-b",
+            "manpage",
+            "-D",
+            "docs/",
+            "-o",
+            "quick-lint-js.1",
+            "docs/cli.adoc",
+        ]
+    )
+    subprocess.check_output(
+        [
+            "asciidoctor",
+            "-b",
+            "html5",
+            "-D",
+            "website/",
+            "-o",
+            "cli.html",
+            "docs/cli.adoc",
+        ]
+    )
+
+    process_man()
+    process_html()
+
+
+def process_man():
+    file_path = pathlib.Path("docs/quick-lint-js.1")
+    contents = file_path.read_text()
+
+    top = """.\\" Copyright (C) 2020  Matthew Glazar
+.\\" See end of file for extended copyright information.
+.\\" This file was generated using generate-cli-docs.
+.
+.\\" Manual page for the 'man' utility.
+.
+.
+"""
+    bottom = """
+
+.\\" quick-lint-js finds bugs in JavaScript programs.
+.\\" Copyright (C) 2020  Matthew Glazar
+.\\"
+.\\" This file is part of quick-lint-js.
+.\\"
+.\\" quick-lint-js is free software: you can redistribute it and/or modify
+.\\" it under the terms of the GNU General Public License as published by
+.\\" the Free Software Foundation, either version 3 of the License, or
+.\\" (at your option) any later version.
+.\\"
+.\\" quick-lint-js is distributed in the hope that it will be useful,
+.\\" but WITHOUT ANY WARRANTY; without even the implied warranty of
+.\\" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+.\\" GNU General Public License for more details.
+.\\"
+.\\" You should have received a copy of the GNU General Public License
+.\\" along with quick-lint-js.  If not, see <https://www.gnu.org/licenses/>.
+"""
+    contents = top + contents + bottom
+
+    file_path.write_text(contents)
+
+
+def process_html():
+    file_path = pathlib.Path("website/cli.html")
+    contents = file_path.read_text()
+
+    top = """<!-- Copyright (C) 2020  Matthew Glazar -->
+<!-- See end of file for extended copyright information. -->
+<!-- This file was generated using generate-cli-docs. -->
+"""
+    bottom = """
+
+<!--
+quick-lint-js finds bugs in JavaScript programs.
+Copyright (C) 2020  Matthew Glazar
+
+This file is part of quick-lint-js.
+
+quick-lint-js is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+quick-lint-js is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with quick-lint-js.  If not, see <https://www.gnu.org/licenses/>.
+-->
+"""
+    head = """<head>
+  <title>quick-lint-js: CLI documentation</title>
+  <meta charset="utf-8" />
+  <link href="main.css" rel="stylesheet" />
+</head>"""
+    header = """<header>
+  <h1><a href=".">quick-lint-js</a></h1>
+  <nav>
+    <ul>
+      <li>
+        <a href="https://github.com/quick-lint/quick-lint-js">source code on GitHub</a>
+      </li>
+    </ul>
+  </nav>
+</header>
+<p>This page documents the quick-lint-js command-line interface (CLI).</p>"""
+    footer = """<footer>
+  <nav>
+    <ul>
+      <li><a href=".">quick-lint-js home page</a></li>
+      <li><a href="hiring.html">we're hiring! get paid to code</a></li>
+      <li><a href="benchmarks/">benchmarks vs other linters</a></li>
+      <li><a href="demo/">try quick-lint-js in your browser</a></li>
+      <li>
+        <a href="https://github.com/quick-lint/quick-lint-js">source code on GitHub</a>
+      </li>
+      <li><a href="license.html">copyright and license information</a></li>
+    </ul>
+  </nav>
+</footer>"""
+
+    l = len("<!DOCTYPE html>")
+    contents = contents[: l + 1] + top + contents[l + 1 :] + bottom
+    contents = re.sub(r"(?s)<head>(.*?)</head>", head, contents)
+    contents = re.sub(r"(?s)<h1>(.*?)</h1>", header, contents)
+    contents = re.sub(r'(?s)<div id="footer">(.*?)</div>\n</div>', footer, contents)
+
+    file_path.write_text(contents)
+
+
+if __name__ == "__main__":
+    main()
+
+# quick-lint-js finds bugs in JavaScript programs.
+# Copyright (C) 2020  Matthew Glazar
+#
+# This file is part of quick-lint-js.
+#
+# quick-lint-js is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# quick-lint-js is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with quick-lint-js.  If not, see <https://www.gnu.org/licenses/>.

--- a/website/cli.html
+++ b/website/cli.html
@@ -1,0 +1,458 @@
+<!DOCTYPE html>
+<!-- Copyright (C) 2020  Matthew Glazar -->
+<!-- See end of file for extended copyright information. -->
+<!-- This file was generated using generate-cli-docs. -->
+<html lang="en">
+  <head>
+    <title>quick-lint-js: CLI documentation</title>
+    <meta charset="utf-8" />
+    <link href="main.css" rel="stylesheet" />
+  </head>
+  <body class="article">
+    <div id="header">
+      <header>
+        <h1><a href=".">quick-lint-js</a></h1>
+        <nav>
+          <ul>
+            <li>
+              <a href="https://github.com/quick-lint/quick-lint-js"
+                >source code on GitHub</a
+              >
+            </li>
+          </ul>
+        </nav>
+      </header>
+      <p>This page documents the quick-lint-js command-line interface (CLI).</p>
+      <div id="toc" class="toc">
+        <div id="toctitle">Table of Contents</div>
+        <ul class="sectlevel1">
+          <li><a href="#_name">Name</a></li>
+          <li><a href="#_synopsis">Synopsis</a></li>
+          <li><a href="#_description">Description</a></li>
+          <li><a href="#_options">Options</a></li>
+          <li><a href="#_error_lists">Error lists</a></li>
+          <li><a href="#_exit_status">Exit status</a></li>
+          <li><a href="#_environment">Environment</a></li>
+          <li><a href="#_example">Example</a></li>
+        </ul>
+      </div>
+    </div>
+    <div id="content">
+      <div class="sect1">
+        <h2 id="_name">Name</h2>
+        <div class="sectionbody">
+          <div class="paragraph">
+            <p>quick-lint-js - find bugs in JavaScript programs</p>
+          </div>
+        </div>
+      </div>
+      <div class="sect1">
+        <h2 id="_synopsis">Synopsis</h2>
+        <div class="sectionbody">
+          <div class="paragraph">
+            <p>
+              <strong>quick-lint-js</strong>
+              [<strong>--output-format</strong>=<em>format</em>]
+              [&lt;options&gt;]
+              <em>file</em> [<em>file</em>&#8230;&#8203;]<br />
+              <strong>quick-lint-js</strong>
+              <strong>--lsp-server</strong> [&lt;options&gt;]
+            </p>
+          </div>
+        </div>
+      </div>
+      <div class="sect1">
+        <h2 id="_description">Description</h2>
+        <div class="sectionbody">
+          <div class="paragraph">
+            <p>
+              <strong>quick-lint-js</strong> reads JavaScript files and reports
+              syntax errors and other bugs.
+            </p>
+          </div>
+          <div class="paragraph">
+            <p>This command has two modes:</p>
+          </div>
+          <div class="dlist">
+            <dl>
+              <dt class="hdlist1">
+                <strong>quick-lint-js</strong> [&lt;options&gt;]
+                <em>file</em> [<em>file</em>&#8230;&#8203;]
+              </dt>
+              <dd>
+                <p>
+                  Batch mode (default). Check the given files, and report errors
+                  to the terminal (standard error). --output-format can be used
+                  to customize how errors look.
+                </p>
+              </dd>
+              <dt class="hdlist1">
+                <strong>quick-lint-js</strong> --lsp-server
+              </dt>
+              <dd>
+                <p>
+                  LSP server mode. Start a Language Server Protocol server,
+                  communicating using standard input and standard output. Use
+                  this mode to integrate with code editors supporting LSP.
+                </p>
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+      <div class="sect1">
+        <h2 id="_options">Options</h2>
+        <div class="sectionbody">
+          <div class="dlist">
+            <dl>
+              <dt class="hdlist1">
+                <strong>--output-format</strong>=<em>format</em>
+              </dt>
+              <dd>
+                <p>
+                  Customize how errors are printed. <em>format</em> is one of
+                  the following:
+                </p>
+                <div class="paragraph">
+                  <p>
+                    - <strong>gnu-like</strong> (default): a human-readable
+                    format similar to GCC.
+                  </p>
+                </div>
+                <div class="paragraph">
+                  <p>
+                    - <strong>vim-qflist-json</strong>: machine-readable JSON
+                    which can be given to Vim&#8217;s
+                    <em>setqflist</em> function.
+                  </p>
+                </div>
+                <div class="paragraph">
+                  <p>Incompatible with <strong>--lsp-server</strong>.</p>
+                </div>
+              </dd>
+              <dt class="hdlist1">
+                <strong>--vim-file-bufnr</strong>=<em>number</em>
+              </dt>
+              <dd>
+                <p>
+                  Set the <em>bufnr</em> property for errors printed with the
+                  <strong>--output-format=vim-qflist-json</strong> option.
+                  <strong>--vim-file-bufnr</strong> applies only to files which
+                  are given later in the command line. Therefore, if multiple
+                  files are given, <strong>--vim-file-bufnr</strong> can be
+                  specified multiple times.
+                </p>
+              </dd>
+              <dt class="hdlist1">
+                <strong>--exit-fail-on</strong>=<em>errors</em>
+              </dt>
+              <dd>
+                <p>
+                  Cause <strong>quick-lint-js</strong> to exit with a non-zero
+                  exit code if any of the discovered errors is listed in
+                  <em>errors</em>.
+                </p>
+                <div class="paragraph">
+                  <p>
+                    See the "ERROR LISTS" section for a description of the
+                    format for <em>errors</em>.
+                  </p>
+                </div>
+                <div class="paragraph">
+                  <p>Incompatible with <strong>--lsp-server</strong>.</p>
+                </div>
+              </dd>
+              <dt class="hdlist1"><strong>--lsp</strong></dt>
+              <dt class="hdlist1"><strong>--lsp-server</strong></dt>
+              <dd>
+                <p>
+                  Run <strong>quick-lint-js</strong> in LSP server mode. Use
+                  this mode to integrate with code editors supporting LSP. An
+                  editor can send LSP requests and notifications to
+                  <strong>quick-lint-js</strong> via standard input, and receive
+                  LSP responses and notifications from standard output.
+                </p>
+                <div class="paragraph">
+                  <p>Incompatible with <strong>--output-format</strong>.</p>
+                </div>
+              </dd>
+              <dt class="hdlist1"><strong>-h</strong></dt>
+              <dt class="hdlist1"><strong>--help</strong></dt>
+              <dd>
+                <p>Print a help message and exit.</p>
+                <div class="paragraph">
+                  <p>
+                    The output format is not intended to be machine-parsable and
+                    may change in the future.
+                  </p>
+                </div>
+              </dd>
+              <dt class="hdlist1"><strong>-v</strong></dt>
+              <dt class="hdlist1"><strong>--version</strong></dt>
+              <dd>
+                <p>Print version information and exit.</p>
+                <div class="paragraph">
+                  <p>
+                    The output format is not intended to be machine-parsable and
+                    may change in the future.
+                  </p>
+                </div>
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+      <div class="sect1">
+        <h2 id="_error_lists">Error lists</h2>
+        <div class="sectionbody">
+          <div class="paragraph">
+            <p>
+              Some options, such as <strong>--exit-fail-on</strong>, accept an
+              error list. An error list is a comma-separated list of error code
+              predicates and error category predicates.
+            </p>
+          </div>
+          <div class="paragraph">
+            <p>
+              An error lists can contain any number of include, exclude, and
+              default predicates. An include predicate is a '+' followed by the
+              name of an error code or error category. An exclude predicate is a
+              '-' followed by the name of an error code or error category. An
+              default predicate is the name of an error code or error category
+              with no sigil.
+            </p>
+          </div>
+          <div class="paragraph">
+            <p>
+              An error list containing only include and exclude predicates
+              modifies a default set of error codes. The default set is decided
+              by the option, but is often the set of all error codes. An error
+              list containing at least one default predicate empties the set of
+              error codes, then treats the default predicates as if they were
+              include predicates.
+            </p>
+          </div>
+          <div class="paragraph">
+            <p>
+              The order of predicates within an error list does not matter.
+              Included predicates are processed first, adding to the set of
+              error codes. Excluded predicates are processed second, removing
+              from the set of error codes.
+            </p>
+          </div>
+          <div class="paragraph">
+            <p>
+              Error codes have the form <strong>E000</strong>, where
+              <em>000</em> is three decimal digits (0-9).
+            </p>
+          </div>
+          <div class="paragraph">
+            <p>The following error categories are supported:</p>
+          </div>
+          <div class="dlist">
+            <dl>
+              <dt class="hdlist1"><strong>all</strong></dt>
+              <dd>
+                <p>All error codes.</p>
+              </dd>
+            </dl>
+          </div>
+          <div class="paragraph">
+            <p>Example error lists:</p>
+          </div>
+          <div class="dlist">
+            <dl>
+              <dt class="hdlist1"><strong>E102,E110</strong></dt>
+              <dd>
+                <p>
+                  Only error codes E102 and E110, excluding all other error
+                  codes.
+                </p>
+              </dd>
+              <dt class="hdlist1"><strong>-E102</strong></dt>
+              <dd>
+                <p>
+                  The default set of error codes, except for error code E102.
+                </p>
+              </dd>
+              <dt class="hdlist1"><strong>+E102</strong></dt>
+              <dd>
+                <p>The default set of error codes, and also error code E102.</p>
+              </dd>
+              <dt class="hdlist1"><strong>all,-E102</strong></dt>
+              <dd>
+                <p>All error codes, except for error code E102.</p>
+              </dd>
+              <dt class="hdlist1"><strong>E100,-E100,+E200</strong></dt>
+              <dd>
+                <p>Only error code E200, excluding all other error codes.</p>
+              </dd>
+              <dt class="hdlist1"><strong>+E200,-E100,E100</strong></dt>
+              <dd>
+                <p>Only error code E200, excluding all other error codes.</p>
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+      <div class="sect1">
+        <h2 id="_exit_status">Exit status</h2>
+        <div class="sectionbody">
+          <div class="dlist">
+            <dl>
+              <dt class="hdlist1"><strong>0</strong></dt>
+              <dd>
+                <p>Batch mode: Linting succeeded with no errors or warnings.</p>
+                <div class="paragraph">
+                  <p>
+                    LSP server mode: The LSP client requested that the server
+                    shut down. This exit status may change in the future.
+                  </p>
+                </div>
+              </dd>
+              <dt class="hdlist1"><strong>non-0</strong></dt>
+              <dd>
+                <p>
+                  Batch mode: Linting failed with at least one error or warning,
+                  or at least one <em>file</em> could not be opened and read.
+                </p>
+                <div class="paragraph">
+                  <p>The specific status code may change in the future.</p>
+                </div>
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+      <div class="sect1">
+        <h2 id="_environment">Environment</h2>
+        <div class="sectionbody">
+          <div class="dlist">
+            <dl>
+              <dt class="hdlist1"><strong>LC_ALL</strong></dt>
+              <dt class="hdlist1"><strong>LC_MESSAGES</strong></dt>
+              <dd>
+                <p>
+                  Change the language used for error and warning messages. For
+                  example, set <strong>LC_ALL=en</strong> to see messages
+                  written in United States English.
+                </p>
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+      <div class="sect1">
+        <h2 id="_example">Example</h2>
+        <div class="sectionbody">
+          <div class="paragraph">
+            <p>
+              To lint a file called <em>lib/index.js</em>, writing error
+              messages to the terminal:
+            </p>
+          </div>
+          <div class="quoteblock">
+            <blockquote>
+              <div class="listingblock">
+                <div class="content">
+                  <pre>
+$ <strong>quick-lint-js</strong> lib/index.js
+lib/index.js:1:20: error: variable used before declaration: language [E058]
+lib/index.js:2:7: note: variable declared here [E058]
+lib/index.js:3:1: error: assignment to const variable [E003]
+lib/index.js:1:7: note: const variable declared here [E003]
+lib/index.js:5:25: warning: use of undeclared variable: ocupation [E057]</pre
+                  >
+                </div>
+              </div>
+            </blockquote>
+          </div>
+          <div class="paragraph">
+            <p>
+              To lint three files, writing machine-readable messages to
+              <em>/tmp/vim-qflist.json</em>:
+            </p>
+          </div>
+          <div class="quoteblock">
+            <blockquote>
+              <div class="listingblock">
+                <div class="content">
+                  <pre>
+$ <strong>quick-lint-js</strong> --output-format=vim-qflist-json \
+    --vim-bufnr=3 lib/pizza-dough.js \
+    --vim-bufnr=4 lib/pizza-sauce.js \
+    --vim-bufnr=6 lib/pineapple.js \
+    &gt;/tmp/vim-qflist.json</pre
+                  >
+                </div>
+              </div>
+            </blockquote>
+          </div>
+          <div class="paragraph">
+            <p>
+              Errors for <em>lib/pizza-dough.js</em> will include
+              <em>"bufnr":3</em> in the output and errors for
+              <em>lib/pineapple.js</em> will include <em>"bufnr":6</em>.
+            </p>
+          </div>
+          <div class="paragraph">
+            <p>
+              To lint a file called <em>bad.js</em>, but don&#8217;t fail on
+              use-of-undeclared-variable errors:
+            </p>
+          </div>
+          <div class="quoteblock">
+            <blockquote>
+              <div class="listingblock">
+                <div class="content">
+                  <pre>
+$ <strong>quick-lint-js</strong> --exit-fail-on=-E057 bad.js
+bad.js:5:25: warning: use of undeclared variable: $ [E057]
+$ echo $?
+0</pre
+                  >
+                </div>
+              </div>
+            </blockquote>
+          </div>
+        </div>
+      </div>
+    </div>
+    <footer>
+      <nav>
+        <ul>
+          <li><a href=".">quick-lint-js home page</a></li>
+          <li><a href="hiring.html">we're hiring! get paid to code</a></li>
+          <li><a href="benchmarks/">benchmarks vs other linters</a></li>
+          <li><a href="demo/">try quick-lint-js in your browser</a></li>
+          <li>
+            <a href="https://github.com/quick-lint/quick-lint-js"
+              >source code on GitHub</a
+            >
+          </li>
+          <li><a href="license.html">copyright and license information</a></li>
+        </ul>
+      </nav>
+    </footer>
+  </body>
+</html>
+
+<!--
+quick-lint-js finds bugs in JavaScript programs.
+Copyright (C) 2020  Matthew Glazar
+
+This file is part of quick-lint-js.
+
+quick-lint-js is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+quick-lint-js is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with quick-lint-js.  If not, see <https://www.gnu.org/licenses/>.
+-->

--- a/website/index.html
+++ b/website/index.html
@@ -510,6 +510,7 @@
           <li><a href="demo/">try quick-lint-js in your browser</a></li>
           <li><a href="hiring.html">we're hiring! get paid to code</a></li>
           <li><a href="benchmarks/">benchmarks vs other linters</a></li>
+          <li><a href="cli.html">CLI documentation</a></li>
           <li>
             <a href="https://github.com/quick-lint/quick-lint-js"
               >source code on GitHub</a

--- a/website/prepare-for-publish
+++ b/website/prepare-for-publish
@@ -13,6 +13,7 @@ output_directory="$(cd "${output_directory}" && pwd)"
 cd "$(dirname "${0}")"
 
 cp atom.svg "${output_directory}/"
+cp cli.html "${output_directory}/"
 cp debian.svg "${output_directory}/"
 cp emacs.svg "${output_directory}/"
 cp gnome-terminal.svg "${output_directory}/"


### PR DESCRIPTION
Closes #224 

Notes:
* ~~The generate script requires you to be inside of the tools directory. Obviously not ideal.~~
* ~~I've added the generated documentation (cli.html, quick-lint-js.1) for ease of viewing. I don't expect this to stay.~~
* I've gone with using the default CSS (main.css).
* ~~The CSS file is inlined into the generated HTML.~~
* ~~There should probably be copyright notices in the generated documentation.~~
* There are ~~many~~ minor differences between the old man page and this new one. ~~The most notable is nested indentation. I'm not sure if this is bad for man pages.~~ quick-lint-js isn't bolded in the name section. The commas in the options are bolded.
* ~~The generated HTML currently does not contain the navigation bar footer.~~
* ~~[GitHub's adoc preview is not impressed with my hacks](https://github.com/erlliam/quick-lint-js/blob/asciidoctor/docs/cli.adoc)~~.
![image](https://user-images.githubusercontent.com/32761424/115948833-8bab9d00-a49e-11eb-8975-47a986705f31.png)
* For simplicity's sake we are probably fine without the indentation stuff (wasn't in the original man page anyways)
* Not sure what the HTML title should be. I have figured out how to change the title so this will be easy to change.
* Not sure what the HTML description should be.