### PR TITLE
Performance tracing implementation for vscode plugin

### DIFF
--- a/plugin/vscode/extension.js
+++ b/plugin/vscode/extension.js
@@ -5,12 +5,15 @@
 
 let assert = require("assert");
 let vscode = require("vscode");
+let process = require("process");
+
 let {
   DiagnosticSeverity,
   ProcessCrashed,
   createProcessFactoryAsync,
 } = require("quick-lint-js-wasm/quick-lint-js.js");
 
+let PerformanceWriter = require("./performance-writer");
 // TODO(strager): Allow developers to reload the .wasm file.
 let processFactoryPromise = createProcessFactoryAsync();
 
@@ -48,10 +51,11 @@ class DocumentLinterDisposed extends Error {}
 exports.DocumentLinterDisposed = DocumentLinterDisposed;
 
 class DocumentLinter {
-  constructor(document, diagnosticCollection) {
+  constructor(document, diagnosticCollection, performanceWriter) {
     this._document = document;
     this._diagnosticCollection = diagnosticCollection;
     this._state = DocumentLinterState.NO_PARSER;
+    this._performanceWriter = performanceWriter;
 
     // Used only in states: CREATING_PARSER
     this._parserPromise = null;
@@ -182,8 +186,12 @@ class DocumentLinter {
           }
           this._pendingChanges.length = 0;
           // END CRITICAL SECTION (no awaiting above)
-
+          let startTime = process.hrtime.bigint();
           let diags = this._parser.lint();
+          this._performanceWriter.initiateLogging(
+            process.hrtime.bigint() - startTime,
+            this._document.fileName
+          );
           this._updateDocumentDiagnostics(diags);
         } catch (e) {
           // END CRITICAL SECTION (no awaiting above)
@@ -226,8 +234,7 @@ class DocumentLinter {
       this._pendingChanges.length = 0;
       this._state = DocumentLinterState.PARSER_LOADED;
       // END CRITICAL SECTION (no awaiting above)
-
-      let diags = this._parser.lint();
+      let diags = this._parser.lint(this._performanceWriter);
       this._updateDocumentDiagnostics(diags);
     } catch (e) {
       if (e instanceof ProcessCrashed) {
@@ -322,9 +329,9 @@ class DocumentLinter {
 }
 
 class DocumentLinterCollection {
-  constructor(diagnosticCollection) {
+  constructor(diagnosticCollection, performanceWriter) {
     this._diagnosticCollection = diagnosticCollection;
-
+    this._performanceWriter = performanceWriter;
     // Mapping from URI string to DocumentLinter.
     this._linters = new Map();
   }
@@ -333,7 +340,11 @@ class DocumentLinterCollection {
     let documentURIString = document.uri.toString();
     let linter = this._linters.get(documentURIString);
     if (typeof linter === "undefined") {
-      linter = new DocumentLinter(document, this._diagnosticCollection);
+      linter = new DocumentLinter(
+        document,
+        this._diagnosticCollection,
+        this._performanceWriter
+      );
       this._linters.set(documentURIString, linter);
     }
     return linter;
@@ -358,6 +369,7 @@ class DocumentLinterCollection {
   dispose() {
     logAsyncErrors(async () => {
       await this.disposeAsync();
+      this._performanceWriter.writeToFile();
     });
   }
 }
@@ -365,11 +377,11 @@ exports.DocumentLinterCollection = DocumentLinterCollection;
 
 let toDispose = [];
 
-async function activateAsync() {
+async function activateAsync(ExtensionContext) {
   let diagnostics = vscode.languages.createDiagnosticCollection();
   toDispose.push(diagnostics);
-
-  let linters = new DocumentLinterCollection(diagnostics);
+  let performanceWriter = new PerformanceWriter(ExtensionContext);
+  let linters = new DocumentLinterCollection(diagnostics, performanceWriter);
   toDispose.push(linters);
 
   toDispose.push(

--- a/plugin/vscode/performance-writer.js
+++ b/plugin/vscode/performance-writer.js
@@ -1,0 +1,114 @@
+// Copyright (C) 2020  Matthew Glazar
+// See end of file for extended copyright information.
+
+const fs = require("fs");
+const path = require("path");
+const process = require("process");
+
+class PerformanceWriter {
+  constructor(extensionContext) {
+    this._extensionContext = extensionContext;
+    this._dataAttributes = {
+      columns: ["timestamp", "file-ref", "event-id", "file-name-or-duration"],
+    };
+    this._tmpLogLines = [];
+    this._fileIndex = 0;
+    this._writeToFileTimer = null;
+    this._timerActivated = false;
+    if (!fs.existsSync(this._extensionContext.logUri.fsPath)) {
+      fs.mkdirSync(this._extensionContext.logUri.fsPath);
+      console.log(this._extensionContext.logUri.fsPath);
+      this.writeHeaderLine();
+    }
+    this._performanceTxtPath = path.join(
+      this._extensionContext.logUri.fsPath,
+      "qljsPerformanceTrace.txt"
+    );
+    this._writableStream = fs.createWriteStream(this._performanceTxtPath, {
+      encoding: "utf8",
+      flags: "a",
+    });
+    this._currentSessionMap = {};
+  }
+
+  fileNameOptimizer(fileName) {
+    if (
+      Object.prototype.hasOwnProperty.call(this._currentSessionMap, fileName)
+    ) {
+      this._fileIndex = this._currentSessionMap[fileName];
+    } else {
+      this._fileIndex++;
+      this._currentSessionMap[fileName] = this._fileIndex;
+      this.writeNewFileLine(fileName);
+    }
+  }
+
+  initiateLogging(timeTaken, fileName) {
+    this.fileNameOptimizer(fileName);
+    this.writeExistingFileLine(timeTaken);
+    this.setWriteToFileTimer();
+  }
+
+  writeHeaderLine() {
+    this._tmpLogLines.push(...this._dataAttributes.columns);
+  }
+
+  writeNewFileLine(fileName) {
+    this._tmpLogLines.push(Date.now(), this._fileIndex, "n", fileName);
+  }
+
+  writeExistingFileLine(timeTaken) {
+    this._tmpLogLines.push(Date.now(), this._fileIndex, "p", timeTaken);
+  }
+
+  setWriteToFileTimer() {
+    if (!this._timerActivated) {
+      this._timerActivated = true;
+      this._writeToFileTimer = setInterval(() => {
+        this._armTimer();
+      }, 2000);
+    }
+  }
+
+  _armTimer() {
+    if (this._tmpLogLines.length === 0) {
+      this._timerActivated = false;
+      clearInterval(this._writeToFileTimer);
+    } else {
+      this.writeToFile();
+    }
+  }
+
+  writeToFile() {
+    while (this._tmpLogLines.length > 0) {
+      let tracingLine = this._tmpLogLines.splice(0, 4);
+      if (typeof tracingLine[0] === "string") {
+        tracingLine = tracingLine.join(",");
+      } else {
+        tracingLine = "\n" + tracingLine.join(",");
+      }
+
+      this._writableStream.write(tracingLine);
+    }
+  }
+}
+
+module.exports = PerformanceWriter;
+
+// quick-lint-js finds bugs in JavaScript programs.
+// Copyright (C) 2020  Matthew Glazar
+//
+// This file is part of quick-lint-js.
+//
+// quick-lint-js is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// quick-lint-js is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with quick-lint-js.  If not, see <https://www.gnu.org/licenses/>.


### PR DESCRIPTION
Issue Ref: #196
Implementation details:
Satisfies requirements to trace performance of linter and have the format specified in the original issue. Every new file using qljs is indexed via persistent[ vscode extension property global storage utility method](https://code.visualstudio.com/api/references/vscode-api#ExtensionContext.globalState)

Added a new column called "event-id". This is meant to be a utility column that can store events that are occurring within qljs other than performance of parser. For example, currently we only have 2 different event-id, a "n" which denotes a new file has qljs attached. Another potential one could be if the file name changes, currently it still detects this as a new file but we could make another event name for this. The other event-id we have is "blank" which measure the speed of parser.lint() (i.e. every character addition/deletion + initial parse when file open)
