### PR TITLE
7$: E024 mentions 'let' even when using 'var' or 'const' #234

### DIFF
--- a/plugin/vscode/test/other-tests.js
+++ b/plugin/vscode/test/other-tests.js
@@ -426,6 +426,8 @@ let tests = {
           assert.strictEqual(messages.length, 1, messages);
           assert.ok(
             messages[0] === "let with no bindings" ||
+              messages[0] === "const with no bindings" ||
+              messages[0] === "var with no bindings" ||
               messages[0] === "redeclaration of variable: x",
             messages
           );

--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -503,7 +503,7 @@
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
       error_let_with_no_bindings, "E024", { source_code_span where; },         \
-      .error(QLJS_TRANSLATABLE("let with no bindings"), where))                \
+      .error(QLJS_TRANSLATABLE("{0} with no bindings"), where))                \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
       error_lexical_declaration_not_allowed_in_body, "E150",                   \

--- a/test.js
+++ b/test.js
@@ -1,0 +1,7 @@
+
+const
+if (true) {}
+let
+if (true) {}
+var
+if (true) {}

--- a/test.js
+++ b/test.js
@@ -1,7 +1,0 @@
-
-const
-if (true) {}
-let
-if (true) {}
-var
-if (true) {}


### PR DESCRIPTION
Added `{0}` instead of hard-coded `let` therefore const or var with no bindings is reported. 
Not worried about payment `if` this solves it; because it was pretty easy.

