### PR TITLE
10$: Improve diagnostics for var\nvar\nvar #233

### DIFF
--- a/plugin/vscode/test/other-tests.js
+++ b/plugin/vscode/test/other-tests.js
@@ -426,6 +426,8 @@ let tests = {
           assert.strictEqual(messages.length, 1, messages);
           assert.ok(
             messages[0] === "let with no bindings" ||
+              messages[0] === "const with no bindings" ||
+              messages[0] === "var with no bindings" ||
               messages[0] === "redeclaration of variable: x",
             messages
           );

--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -503,7 +503,7 @@
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
       error_let_with_no_bindings, "E024", { source_code_span where; },         \
-      .error(QLJS_TRANSLATABLE("let with no bindings"), where))                \
+      .error(QLJS_TRANSLATABLE("{0} with no bindings"), where))                \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
       error_lexical_declaration_not_allowed_in_body, "E150",                   \

--- a/src/quick-lint-js/parse.h
+++ b/src/quick-lint-js/parse.h
@@ -3037,7 +3037,6 @@ class parser {
 
         switch (this->peek().type) {
         // let switch = 3;  // Invalid.
-        case token_type::end_of_file:
         case token_type::equal:
         case token_type::semicolon:
           this->lexer_.commit_transaction(std::move(transaction));

--- a/test.js
+++ b/test.js
@@ -1,0 +1,7 @@
+
+const
+if (true) {}
+let
+if (true) {}
+var
+if (true) {}

--- a/test.js
+++ b/test.js
@@ -1,7 +1,0 @@
-
-const
-if (true) {}
-let
-if (true) {}
-var
-if (true) {}


### PR DESCRIPTION
Removing case `token_type::end_of_file:` from error report E124: `error_cannot_declare_variable_with_keyword_name` gives the expected output. 
```
test.js:1:1: error: var with no bindings [E024]
test.js:2:1: error: var with no bindings [E024]
test.js:3:1: error: var with no bindings [E024]
```
Unless there is cases where you want that error at the end of file?

Note: I have my commits from issue 234 because it's a related issue and it's not merged yet.
