### PR TITLE
CI: prevent mismatch between workflows and checkout

### DIFF
--- a/.github/workflows/build-and-test-dev-env-nix.yml
+++ b/.github/workflows/build-and-test-dev-env-nix.yml
@@ -14,13 +14,7 @@ jobs:
     # TODO(strager): Use ghcr.io/quick-lint/quick-lint-js-github-builder.
     steps:
       - name: checkout
-        if: ${{ github.event_name == 'push' }}
         uses: actions/checkout@v2
-      - name: checkout
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: install nix
         uses: cachix/install-nix-action@v12

--- a/.github/workflows/build-and-test-dev.yml
+++ b/.github/workflows/build-and-test-dev.yml
@@ -27,13 +27,7 @@ jobs:
 
     steps:
       - name: checkout
-        if: ${{ github.event_name == 'push' }}
         uses: actions/checkout@v2
-      - name: checkout
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: 0. Install build dependencies
         run: ${{ matrix.toolchain.install_dependencies_script }}

--- a/.github/workflows/build-and-test-plugin-vscode.yml
+++ b/.github/workflows/build-and-test-plugin-vscode.yml
@@ -19,13 +19,7 @@ jobs:
         with:
           version: 2.0.4
       - name: checkout
-        if: ${{ github.event_name == 'push' }}
         uses: actions/checkout@v2
-      - name: checkout
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: install build dependencies
         run: |

--- a/.github/workflows/build-and-test-web-demo.yml
+++ b/.github/workflows/build-and-test-web-demo.yml
@@ -19,13 +19,7 @@ jobs:
         with:
           version: 2.0.4
       - name: checkout
-        if: ${{ github.event_name == 'push' }}
         uses: actions/checkout@v2
-      - name: checkout
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: install build dependencies
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,13 +48,7 @@ jobs:
 
     steps:
       - name: checkout
-        if: ${{ github.event_name == 'push' }}
         uses: actions/checkout@v2
-      - name: checkout
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: configure
         run: |

--- a/.github/workflows/build-static.yml
+++ b/.github/workflows/build-static.yml
@@ -32,13 +32,7 @@ jobs:
 
     steps:
       - name: checkout
-        if: ${{ github.event_name == 'push' }}
         uses: actions/checkout@v2
-      - name: checkout
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: configure
         run: |
@@ -137,13 +131,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        if: ${{ github.event_name == 'push' }}
         uses: actions/checkout@v2
-      - name: checkout
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/check-copyright.yml
+++ b/.github/workflows/check-copyright.yml
@@ -13,12 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ghcr.io/quick-lint/quick-lint-js-github-builder:v1
     steps:
-      - if: ${{ github.event_name == 'push' }}
-        uses: actions/checkout@v2
-      - if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/checkout@v2
 
       - run: |
           if ! ./tools/check-file-copyrights; then

--- a/.github/workflows/check-error-docs.yml
+++ b/.github/workflows/check-error-docs.yml
@@ -13,12 +13,7 @@ jobs:
     runs-on: ubuntu-18.04
     container: ghcr.io/quick-lint/quick-lint-js-github-builder:v1
     steps:
-      - if: ${{ github.event_name == 'push' }}
-        uses: actions/checkout@v2
-      - if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/checkout@v2
 
       - name: configure
         run: CC=gcc-8 CXX=g++-8 cmake -DBUILD_TESTING=NO -S . -B build

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -13,12 +13,7 @@ jobs:
     runs-on: ubuntu-18.04
     container: ghcr.io/quick-lint/quick-lint-js-github-builder:v1
     steps:
-      - if: ${{ github.event_name == 'push' }}
-        uses: actions/checkout@v2
-      - if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/checkout@v2
 
       - run: clang-format --version
       - run: ./tools/format

--- a/.github/workflows/debian-package.yml
+++ b/.github/workflows/debian-package.yml
@@ -14,13 +14,7 @@ jobs:
     container: ghcr.io/quick-lint/quick-lint-js-github-builder:v1
     steps:
       - name: checkout
-        if: ${{ github.event_name == 'push' }}
         uses: actions/checkout@v2
-      - name: checkout
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: build
         run: ./dist/debian/build.sh

--- a/.github/workflows/simple-build.yml
+++ b/.github/workflows/simple-build.yml
@@ -26,13 +26,7 @@ jobs:
 
     steps:
       - name: checkout
-        if: ${{ github.event_name == 'push' }}
         uses: actions/checkout@v2
-      - name: checkout
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: build
         # Keep in sync with "quick build" in docs/BUILDING.md.

--- a/.github/workflows/test-benchmark-lsp.yml
+++ b/.github/workflows/test-benchmark-lsp.yml
@@ -14,13 +14,7 @@ jobs:
     container: ghcr.io/quick-lint/quick-lint-js-github-builder:v1
     steps:
       - name: checkout
-        if: ${{ github.event_name == 'push' }}
         uses: actions/checkout@v2
-      - name: checkout
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: haskell/actions/setup@v1
         with:

--- a/.github/workflows/test-emacs-plugin.yml
+++ b/.github/workflows/test-emacs-plugin.yml
@@ -14,13 +14,7 @@ jobs:
     container: ghcr.io/quick-lint/quick-lint-js-github-builder:v2
     steps:
       - name: checkout
-        if: ${{ github.event_name == 'push' }}
         uses: actions/checkout@v2
-      - name: checkout
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: configure
         run: cmake -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8 -DBUILD_TESTING=OFF -S . -B .

--- a/.github/workflows/test-homebrew-package.yml
+++ b/.github/workflows/test-homebrew-package.yml
@@ -23,13 +23,7 @@ jobs:
 
     steps:
       - name: checkout
-        if: ${{ github.event_name == 'push' }}
         uses: actions/checkout@v2
-      - name: checkout
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: brew tap
         run: brew tap quick-lint/quick-lint-js .

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -14,13 +14,7 @@ jobs:
     container: ghcr.io/quick-lint/quick-lint-js-github-builder:v1
     steps:
       - name: checkout
-        if: ${{ github.event_name == 'push' }}
         uses: actions/checkout@v2
-      - name: checkout
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: configure
         run: cmake -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8 -DBUILD_TESTING=OFF -S . -B .

--- a/.github/workflows/test-nix-install.yml
+++ b/.github/workflows/test-nix-install.yml
@@ -14,13 +14,8 @@ jobs:
     # TODO(strager): Use ghcr.io/quick-lint/quick-lint-js-github-builder.
     steps:
       - name: checkout
-        if: ${{ github.event_name == 'push' }}
         uses: actions/checkout@v2
       - name: checkout
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: install nix
         uses: cachix/install-nix-action@v12

--- a/.github/workflows/test-vim-plugin.yml
+++ b/.github/workflows/test-vim-plugin.yml
@@ -20,13 +20,7 @@ jobs:
     container: ghcr.io/quick-lint/quick-lint-js-github-builder:v1
     steps:
       - name: checkout
-        if: ${{ github.event_name == 'push' }}
         uses: actions/checkout@v2
-      - name: checkout
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: version
         run: ${{ matrix.vim.version_command }}


### PR DESCRIPTION
As of commit cadbfbb1db664e1016a76e7cc9b2ffcc55243e6f, GitHub Actions CI
does the following on pull requests:

1. Merge the pull request source with the destination
2. If the merge succeeded:
   a. Read workflow files from the merged commit
   b. Run each workflow:
      i. 'git clone', creating a checkout at the pull request source

Importantly, the Git commit used for the workflow files is different
from the Git commit used for the checkout. This causes problems with a
workflow file assumes a newer checkout. (For example, commit
52ed8937c74ca839f317e6a4eeb3679eae73aaaa changed a workflow file and the
checkout such that the workflow fails without an updated checkout.)

I don't know of a way to coerce GitHub to use the workflow files of the
pull request source.

Change our workflows to use GitHub's defaults: read workflow files from
the merged commit, and create a checkout from the merged commit. This
means that CI won't test the code seen in the pull request, but I think
that behavior is slightly better in the common case than the current
behavior.