### PR TITLE
Fix crash on destructuring assignment with async

### DIFF
--- a/test/test-parse-var.cpp
+++ b/test/test-parse-var.cpp
@@ -1349,6 +1349,18 @@ TEST(test_parse, variables_can_be_named_contextual_keywords) {
     }
 
     {
+      spy_visitor v =
+          parse_and_visit_statement(u8"let {" + name + u8" = 10 } = initial;",
+                                    function_attributes::normal);
+      EXPECT_THAT(v.visits,
+                  ElementsAre("visit_variable_use",            // initial
+                              "visit_variable_declaration"));  // (name)
+      ASSERT_EQ(v.variable_declarations.size(), 1);
+      EXPECT_EQ(v.variable_declarations[0].name, name);
+      EXPECT_EQ(v.variable_declarations[0].kind, variable_kind::_let);
+    }
+
+    {
       spy_visitor v = parse_and_visit_statement(
           u8"const " + name + u8" = initial;", function_attributes::normal);
       EXPECT_THAT(v.visits,


### PR DESCRIPTION
The following code doesn't make quick-lint-js to crash now:

    let { async = 3, get = 4, set = 5 } = {};

Fix issue: #96 