### PR TITLE
Fix conditional operator after typeof

### DIFF
--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -220,7 +220,8 @@ expression* parser::parse_primary_expression(precedence prec) {
     expression* child = this->parse_expression(
         precedence{.binary_operators = true,
                    .math_or_logical_or_assignment = false,
-                   .commas = false});
+                   .commas = false,
+                   .is_typeof = (type == token_type::kw_typeof)});
     if (child->kind() == expression_kind::_invalid) {
       this->error_reporter_->report(error_missing_operand_for_operator{
           .where = operator_span,
@@ -985,6 +986,9 @@ next:
 
   // x ? y : z  // Conditional operator.
   case token_type::question: {
+    if (prec.is_typeof) {
+      break;
+    }
     source_code_span question_span = this->peek().span();
     this->skip();
 

--- a/src/quick-lint-js/parse.h
+++ b/src/quick-lint-js/parse.h
@@ -741,9 +741,18 @@ class parser {
     }
     case expression_kind::_typeof: {
       expression *child = ast->child_0();
-      if (child->kind() == expression_kind::variable) {
+      switch (child->kind()) {
+      case expression_kind::conditional: {
+        if (child->child_0()->kind() == expression_kind::variable) {
+          v.visit_variable_typeof_use(child->child_0()->variable_identifier());
+        }
+        break;
+      }
+      case expression_kind::variable: {
         v.visit_variable_typeof_use(child->variable_identifier());
-      } else {
+        break;
+      }
+      default:
         this->visit_expression(child, v, context);
       }
       break;

--- a/src/quick-lint-js/parse.h
+++ b/src/quick-lint-js/parse.h
@@ -741,18 +741,9 @@ class parser {
     }
     case expression_kind::_typeof: {
       expression *child = ast->child_0();
-      switch (child->kind()) {
-      case expression_kind::conditional: {
-        if (child->child_0()->kind() == expression_kind::variable) {
-          v.visit_variable_typeof_use(child->child_0()->variable_identifier());
-        }
-        break;
-      }
-      case expression_kind::variable: {
+      if (child->kind() == expression_kind::variable) {
         v.visit_variable_typeof_use(child->variable_identifier());
-        break;
-      }
-      default:
+      } else {
         this->visit_expression(child, v, context);
       }
       break;
@@ -3267,6 +3258,7 @@ class parser {
     // If true, parse unexpected trailing identifiers as part of the expression
     // (and emit an error).
     bool trailing_identifiers = false;
+    bool is_typeof = false;
   };
 
   template <QLJS_PARSE_VISITOR Visitor>

--- a/test/test-lint-parse.cpp
+++ b/test/test-lint-parse.cpp
@@ -83,6 +83,19 @@ TEST(test_lint,
 
   EXPECT_THAT(v.errors, IsEmpty());
 }
+
+TEST(test_lint, typeof_with_conditional_operator) {
+  {
+    padded_string input(u8"typeof x ? 10 : 20;"_sv);
+    error_collector v;
+    linter l(&v);
+    parser p(&input, &v);
+    p.parse_and_visit_module(l);
+    l.visit_end_of_module();
+
+    EXPECT_THAT(v.errors, IsEmpty());
+  }
+}
 }
 
 // quick-lint-js finds bugs in JavaScript programs.

--- a/test/test-parse-expression-statement.cpp
+++ b/test/test-parse-expression-statement.cpp
@@ -557,6 +557,22 @@ TEST(test_parse, parse_typeof_with_non_variable) {
   }
 }
 
+TEST(test_parse, parse_typeof_with_conditional_operator) {
+  {
+    spy_visitor v = parse_and_visit_expression(u8"typeof x ? 10 : 20"_sv);
+    EXPECT_THAT(v.visits, ElementsAre("visit_variable_typeof_use"));
+    EXPECT_THAT(v.variable_uses,
+                ElementsAre(spy_visitor::visited_variable_use{u8"x"}));
+  }
+
+  {
+    spy_visitor v = parse_and_visit_expression(u8"typeof x.y ? 10 : 20"_sv);
+    EXPECT_THAT(v.visits, ElementsAre("visit_variable_use"));
+    EXPECT_THAT(v.variable_uses,
+                ElementsAre(spy_visitor::visited_variable_use{u8"x"}));
+  }
+}
+
 TEST(test_parse, parse_array_subscript) {
   {
     spy_visitor v = parse_and_visit_expression(u8"array[index]"_sv);

--- a/test/test-parse-expression.cpp
+++ b/test/test-parse-expression.cpp
@@ -404,6 +404,13 @@ TEST_F(test_parse_expression, parse_typeof_unary_operator) {
   }
 }
 
+TEST_F(test_parse_expression, parse_typeof_conditional_operator) {
+  {
+    expression* ast = this->parse_expression(u8"typeof o ? 10 : 20"_sv);
+    EXPECT_EQ(summarize(ast), "cond(typeof(var o), literal, literal)");
+  }
+}
+
 TEST_F(test_parse_expression, delete_unary_operator) {
   {
     test_parser p(u8"delete variable");


### PR DESCRIPTION
The following code should not produce a warning (E057):
     'undefined' === typeof foo ? 3 : 4;

Fix: #306 