### PR TITLE
Suggest `async` when `await` is followed by arrow function.

### DIFF
--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -683,11 +683,37 @@ expression* parser::parse_await_expression(token await_token, precedence prec) {
         [[fallthrough]];
       case token_type::complete_template:
       case token_type::incomplete_template:
-      case token_type::left_paren:
       case token_type::left_square:
       case token_type::minus:
       case token_type::plus:
         return !this->in_top_level_;
+
+      case token_type::left_paren: {
+        source_code_span operator_span = await_token.span();
+        buffering_error_reporter temp_error_reporter;
+        error_reporter* old_error_reporter =
+            std::exchange(this->error_reporter_, &temp_error_reporter);
+        lexer_transaction transaction = this->lexer_.begin_transaction();
+
+        // Try to parse as an arrow function
+        expression* ast = this->parse_expression(prec);
+
+        this->lexer_.roll_back_transaction(std::move(transaction));
+        this->error_reporter_ = old_error_reporter;
+
+        switch (ast->kind()) {
+        case expression_kind::arrow_function_with_statements:
+        case expression_kind::arrow_function_with_expression:
+          this->error_reporter_->report(error_await_creating_arrow_function{
+              .await_operator = operator_span,
+          });
+          break;
+        default:
+          break;
+        }
+
+        return !this->in_top_level_;
+      }
 
       case token_type::bang:
       case token_type::dot_dot_dot:

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -727,11 +727,25 @@ expression* parser::parse_await_expression(token await_token, precedence prec) {
     }
 
     expression* child = this->parse_expression(prec);
-    if (child->kind() == expression_kind::_invalid) {
+
+    switch (child->kind()) {
+    case expression_kind::arrow_function_with_statements:
+    case expression_kind::arrow_function_with_expression:
+      if (child->attributes() != function_attributes::async) {
+        this->error_reporter_->report(error_await_creating_arrow_function{
+            .await_operator = operator_span,
+        });
+      }
+      break;
+    case expression_kind::_invalid:
       this->error_reporter_->report(error_missing_operand_for_operator{
           .where = operator_span,
       });
+      break;
+    default:
+      break;
     }
+
     return this->make_expression<expression::await>(child, operator_span);
   }
 }

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -722,17 +722,17 @@ expression* parser::parse_await_expression(token await_token, precedence prec) {
         std::exchange(this->error_reporter_, &temp_error_reporter);
     lexer_transaction transaction = this->lexer_.begin_transaction();
 
-    // Try to parse as an arrow function
+    // Try to parse leading ( as arrow function.
     expression* ast = this->parse_expression(prec);
 
     this->lexer_.roll_back_transaction(std::move(transaction));
     this->error_reporter_ = old_error_reporter;
 
-    bool is_arrow =
+    bool is_arrow_kind =
         (ast->kind() == expression_kind::arrow_function_with_statements) ||
         (ast->kind() == expression_kind::arrow_function_with_expression);
 
-    if (is_arrow) {
+    if (is_arrow_kind) {
       this->error_reporter_->report(error_await_creating_arrow_function{
           .await_operator = operator_span,
       });

--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -70,7 +70,7 @@
       error_await_creating_arrow_function, "E???",                             \
       { source_code_span await_operator; },                                    \
       .error(QLJS_TRANSLATABLE("'await' does not create an async arrow "       \
-                               "function; use 'async' instead [E???]"),        \
+                               "function; use 'async' instead"),               \
              await_operator))                                                  \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \

--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -67,6 +67,13 @@
              await_operator))                                                  \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
+      error_await_creating_arrow_function, "E???",                             \
+      { source_code_span await_operator; },                                    \
+      .error(QLJS_TRANSLATABLE("'await' does not create an async arrow "       \
+                               "function; use 'async' instead [E???]"),        \
+             await_operator))                                                  \
+                                                                               \
+  QLJS_ERROR_TYPE(                                                             \
       error_big_int_literal_contains_decimal_point, "E005",                    \
       { source_code_span where; },                                             \
       .error(QLJS_TRANSLATABLE("BigInt literal contains decimal point"),       \

--- a/test/test-parse-expression.cpp
+++ b/test/test-parse-expression.cpp
@@ -887,6 +887,7 @@ TEST_F(test_parse_expression, await_unary_operator_inside_async_functions) {
     test_parser p(u8"await () => {}"_sv);
     auto guard = p.parser().enter_function(function_attributes::normal);
     expression* ast = p.parse_expression();
+    EXPECT_EQ(ast->kind(), expression_kind::binary_operator);
     EXPECT_THAT(
         p.errors(),
         ElementsAre(

--- a/test/test-parse-expression.cpp
+++ b/test/test-parse-expression.cpp
@@ -874,6 +874,9 @@ TEST_F(test_parse_expression, await_unary_operator_inside_async_functions) {
     test_parser p(u8"await () => {}"_sv);
     auto guard = p.parser().enter_function(function_attributes::async);
     expression* ast = p.parse_expression();
+    EXPECT_EQ(ast->kind(), expression_kind::await);
+    EXPECT_EQ(ast->child_0()->kind(),
+              expression_kind::arrow_function_with_statements);
     EXPECT_THAT(p.errors(),
                 ElementsAre(ERROR_TYPE_FIELD(
                     error_await_creating_arrow_function, await_operator,

--- a/test/test-parse-expression.cpp
+++ b/test/test-parse-expression.cpp
@@ -882,6 +882,21 @@ TEST_F(test_parse_expression, await_unary_operator_inside_async_functions) {
                     error_await_creating_arrow_function, await_operator,
                     offsets_matcher(p.code(), 0, u8"await"))));
   }
+
+  {
+    test_parser p(u8"await () => {}"_sv);
+    auto guard = p.parser().enter_function(function_attributes::normal);
+    expression* ast = p.parse_expression();
+    EXPECT_THAT(
+        p.errors(),
+        ElementsAre(
+            ERROR_TYPE_FIELD(error_await_creating_arrow_function,
+                             await_operator,
+                             offsets_matcher(p.code(), 0, u8"await")),
+            ERROR_TYPE_FIELD(
+                error_missing_operator_between_expression_and_arrow_function,
+                where, offsets_matcher(p.code(), 0, u8"await ("))));
+  }
 }
 
 TEST_F(test_parse_expression,

--- a/test/test-parse-expression.cpp
+++ b/test/test-parse-expression.cpp
@@ -869,6 +869,16 @@ TEST_F(test_parse_expression, await_unary_operator_inside_async_functions) {
     EXPECT_EQ(summarize(ast), "await(var x)");
     EXPECT_THAT(p.errors(), IsEmpty());
   }
+
+  {
+    test_parser p(u8"await () => {}"_sv);
+    auto guard = p.parser().enter_function(function_attributes::async);
+    expression* ast = p.parse_expression();
+    EXPECT_THAT(p.errors(),
+                ElementsAre(ERROR_TYPE_FIELD(
+                    error_await_creating_arrow_function, await_operator,
+                    offsets_matcher(p.code(), 0, u8"await"))));
+  }
 }
 
 TEST_F(test_parse_expression,


### PR DESCRIPTION
Attempts to fix issues #279 and #278.

In both cases we can check if `await (` is followed by an arrow function, suggest changing it to `async` and then rollback. 

For the expression beginning with `await (` inside an `async` function the expression following it is parsed twice, this happens because we have no way to know beforehand if we want that expression to be parsed and `await` might be an identifier or something else. 