### PR TITLE
Attempts to fix issue #266

### DIFF
--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -215,6 +215,13 @@
              else_token))                                                      \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
+      error_else_with_conditional_missing_if, "E???",                          \
+      { source_code_span else_token; },                                        \
+      .warning(QLJS_TRANSLATABLE("'else' with condition followed by block; "   \
+                                 "maybe 'else if' was intended"),              \
+               else_token))                                                    \
+                                                                               \
+  QLJS_ERROR_TYPE(                                                             \
       error_escaped_character_disallowed_in_identifiers, "E012",               \
       { source_code_span escape_sequence; },                                   \
       .error(QLJS_TRANSLATABLE(                                                \


### PR DESCRIPTION
We do this by treating `else (` separately. If `else` is followed by
a (conditional + block) pattern, maybe the intention was to use an
`else if` instead and a warning is emitted.