### PR TITLE
Pin to working version of eshost for test-all-js-engines

### DIFF
--- a/tools/test-all-js-engines
+++ b/tools/test-all-js-engines
@@ -23,7 +23,7 @@ main() {
 
 install_tools() {
   if ! [ -f "${node_bin}/eshost" -a -f "${node_bin}/jsvu" ]; then
-    printf '%s\n' '{"dependencies": {"eshost-cli": "*", "jsvu": "*"}}' >"${HOME}/package.json"
+    printf '%s\n' '{"dependencies": {"eshost-cli": "7.6.0", "jsvu": "*"}}' >"${HOME}/package.json"
     (cd "${HOME}" && npm install --no-audit --no-optional --no-package-lock)
   fi
 }


### PR DESCRIPTION
test-all-js-engines uses the latest published eshost version. It seems
that version 8.0.0 is broken. test-all-js-engines used to report an
error for the following JavaScript code, but doesn't any more:

    if (true)

Version 7.6.0 seems to work better. Use that working version.