### PR TITLE
More validation errors

### DIFF
--- a/website/public/benchmarks/index.ejs.html
+++ b/website/public/benchmarks/index.ejs.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <!-- Copyright (C) 2020  Matthew "strager" Glazar -->
 <!-- See end of file for extended copyright information. -->
-<html>
+<html lang="en">
   <head>
     <%- await include("../common-head.ejs.html") %>
     <script>
@@ -23,11 +23,11 @@
     <link href="benchmark.css" rel="stylesheet" />
     <style>
       .linter-name {
-        color: hsla(var(--hue), 70%, 40%);
+        color: hsla(var(--hue), 70%, 40%, 1);
       }
       @media (prefers-color-scheme: dark) {
         .linter-name {
-          color: hsla(var(--hue), 85%, 75%);
+          color: hsla(var(--hue), 85%, 75%, 1);
         }
       }
     </style>
@@ -95,29 +95,34 @@
         <p>These benchmarks measure the following linters:</p>
         <ul>
           <li>
-            <strong class="linter-name" style="--hue: 0">quick-lint-js</strong>
+            <strong class="linter-name" style="--hue: 0deg"
+              >quick-lint-js</strong
+            >
             version 0.2.0
           </li>
           <li>
-            <strong class="linter-name" style="--hue: 120">RSLint</strong>
+            <strong class="linter-name" style="--hue: 120deg">RSLint</strong>
             version b7a4eeb69dc00fedfee8&shy;1eaed3cf2ad36bcb2e2e (unreleased)
             (with rustc version 1.51.0)
           </li>
           <li>
-            <strong class="linter-name" style="--hue: 180">Flow</strong> version
-            0.148.0
+            <strong class="linter-name" style="--hue: 180deg">Flow</strong>
+            version 0.148.0
           </li>
           <li>
-            <strong class="linter-name" style="--hue: 60">ESLint</strong>
+            <strong class="linter-name" style="--hue: 60deg">ESLint</strong>
             version 5.16.0 (with eslint-server version 0.1.7 and Node version
             v16.0.0)
           </li>
           <li>
-            <strong class="linter-name" style="--hue: 240">Deno</strong> version
-            1.9.1 (with V8 version 9.1.269.5 and TypeScript version 4.2.2)
+            <strong class="linter-name" style="--hue: 240deg">Deno</strong>
+            version 1.9.1 (with V8 version 9.1.269.5 and TypeScript version
+            4.2.2)
           </li>
           <li>
-            <strong class="linter-name" style="--hue: 300">TypeScript</strong>
+            <strong class="linter-name" style="--hue: 300deg"
+              >TypeScript</strong
+            >
             version 4.2.4 (with Theia's language server version 0.5.1 and Node
             version v16.0.0)
           </li>

--- a/website/public/benchmarks/index.ejs.html
+++ b/website/public/benchmarks/index.ejs.html
@@ -95,9 +95,7 @@
         <p>These benchmarks measure the following linters:</p>
         <ul>
           <li>
-            <strong class="linter-name" style="--hue: 0"
-              >quick-lint-js</strong
-            >
+            <strong class="linter-name" style="--hue: 0">quick-lint-js</strong>
             version 0.2.0
           </li>
           <li>
@@ -120,9 +118,7 @@
             4.2.2)
           </li>
           <li>
-            <strong class="linter-name" style="--hue: 300"
-              >TypeScript</strong
-            >
+            <strong class="linter-name" style="--hue: 300">TypeScript</strong>
             version 4.2.4 (with Theia's language server version 0.5.1 and Node
             version v16.0.0)
           </li>

--- a/website/public/benchmarks/index.ejs.html
+++ b/website/public/benchmarks/index.ejs.html
@@ -23,11 +23,11 @@
     <link href="benchmark.css" rel="stylesheet" />
     <style>
       .linter-name {
-        color: hsla(var(--hue), 70%, 40%, 1);
+        color: hsla(var(--hue), 70%, 40%);
       }
       @media (prefers-color-scheme: dark) {
         .linter-name {
-          color: hsla(var(--hue), 85%, 75%, 1);
+          color: hsla(var(--hue), 85%, 75%);
         }
       }
     </style>
@@ -95,32 +95,32 @@
         <p>These benchmarks measure the following linters:</p>
         <ul>
           <li>
-            <strong class="linter-name" style="--hue: 0deg"
+            <strong class="linter-name" style="--hue: 0"
               >quick-lint-js</strong
             >
             version 0.2.0
           </li>
           <li>
-            <strong class="linter-name" style="--hue: 120deg">RSLint</strong>
+            <strong class="linter-name" style="--hue: 120">RSLint</strong>
             version b7a4eeb69dc00fedfee8&shy;1eaed3cf2ad36bcb2e2e (unreleased)
             (with rustc version 1.51.0)
           </li>
           <li>
-            <strong class="linter-name" style="--hue: 180deg">Flow</strong>
+            <strong class="linter-name" style="--hue: 180">Flow</strong>
             version 0.148.0
           </li>
           <li>
-            <strong class="linter-name" style="--hue: 60deg">ESLint</strong>
+            <strong class="linter-name" style="--hue: 60">ESLint</strong>
             version 5.16.0 (with eslint-server version 0.1.7 and Node version
             v16.0.0)
           </li>
           <li>
-            <strong class="linter-name" style="--hue: 240deg">Deno</strong>
+            <strong class="linter-name" style="--hue: 240">Deno</strong>
             version 1.9.1 (with V8 version 9.1.269.5 and TypeScript version
             4.2.2)
           </li>
           <li>
-            <strong class="linter-name" style="--hue: 300deg"
+            <strong class="linter-name" style="--hue: 300"
               >TypeScript</strong
             >
             version 4.2.4 (with Theia's language server version 0.5.1 and Node

--- a/website/public/hiring/index.ejs.html
+++ b/website/public/hiring/index.ejs.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <!-- Copyright (C) 2020  Matthew "strager" Glazar -->
 <!-- See end of file for extended copyright information. -->
-<html>
+<html lang="en">
   <head>
     <%- await include("../common-head.ejs.html") %>
     <title>quick-lint-js is hiring</title>

--- a/website/public/license/index.ejs.html
+++ b/website/public/license/index.ejs.html
@@ -2180,166 +2180,161 @@ under certain conditions; type `show c' for details.</code></pre>
           of the Source form.
         </p>
 
+        <h4>Permission for Use and Modification Without Distribution</h4>
         <ol type="1">
           <li>
-            <h4>Permission for Use and Modification Without Distribution</h4>
-            <p>
-              You are permitted to use the Standard Version and create and use
-              Modified Versions for any purpose without restriction, provided
-              that you do not Distribute the Modified Version.
-            </p>
+            You are permitted to use the Standard Version and create and use
+            Modified Versions for any purpose without restriction, provided that
+            you do not Distribute the Modified Version.
+          </li>
+        </ol>
+        <h4>Permissions for Redistribution of the Standard Version</h4>
+        <ol type="1" start="2">
+          <li>
+            You may Distribute verbatim copies of the Source form of the
+            Standard Version of this Package in any medium without restriction,
+            either gratis or for a Distributor Fee, provided that you duplicate
+            all of the original copyright notices and associated disclaimers. At
+            your discretion, such verbatim copies may or may not include a
+            Compiled form of the Package.
           </li>
           <li>
-            <h4>Permissions for Redistribution of the Standard Version</h4>
-            <p>
-              You may Distribute verbatim copies of the Source form of the
-              Standard Version of this Package in any medium without
-              restriction, either gratis or for a Distributor Fee, provided that
-              you duplicate all of the original copyright notices and associated
-              disclaimers. At your discretion, such verbatim copies may or may
-              not include a Compiled form of the Package.
-            </p>
-            <p>
-              You may apply any bug fixes, portability changes, and other
-              modifications made available from the Copyright Holder. The
-              resulting Package will still be considered the Standard Version,
-              and as such will be subject to the Original License.
-            </p>
+            You may apply any bug fixes, portability changes, and other
+            modifications made available from the Copyright Holder. The
+            resulting Package will still be considered the Standard Version, and
+            as such will be subject to the Original License.
           </li>
+        </ol>
+        <h4>Distribution of Modified Versions of the Package as Source</h4>
+        <ol type="1" start="4">
           <li>
-            <h4>Distribution of Modified Versions of the Package as Source</h4>
-            <div>
-              <p>
-                You may Distribute your Modified Version as Source (either
-                gratis or for a Distributor Fee, and with or without a Compiled
-                form of the Modified Version) provided that you clearly document
-                how it differs from the Standard Version, including, but not
-                limited to, documenting any non-standard features, executables,
-                or modules, and provided that you do at least ONE of the
-                following:
-              </p>
-              <ol type="a">
-                <li>
-                  make the Modified Version available to the Copyright Holder of
-                  the Standard Version, under the Original License, so that the
-                  Copyright Holder may include your modifications in the
-                  Standard Version.
-                </li>
+            You may Distribute your Modified Version as Source (either gratis or
+            for a Distributor Fee, and with or without a Compiled form of the
+            Modified Version) provided that you clearly document how it differs
+            from the Standard Version, including, but not limited to,
+            documenting any non-standard features, executables, or modules, and
+            provided that you do at least ONE of the following:
+          </li>
+          <ol type="a">
+            <li>
+              make the Modified Version available to the Copyright Holder of the
+              Standard Version, under the Original License, so that the
+              Copyright Holder may include your modifications in the Standard
+              Version.
+            </li>
+
+            <li>
+              ensure that installation of your Modified Version does not prevent
+              the user installing or running the Standard Version. In addition,
+              the Modified Version must bear a name that is different from the
+              name of the Standard Version.
+            </li>
+
+            <li>
+              allow anyone who receives a copy of the Modified Version to make
+              the Source form of the Modified Version available to others under
+              <ol type="i">
+                <li>the Original License or</li>
 
                 <li>
-                  ensure that installation of your Modified Version does not
-                  prevent the user installing or running the Standard Version.
-                  In addition, the Modified Version must bear a name that is
-                  different from the name of the Standard Version.
-                </li>
-
-                <li>
-                  allow anyone who receives a copy of the Modified Version to
-                  make the Source form of the Modified Version available to
-                  others under
-                  <ol type="i">
-                    <li>the Original License or</li>
-
-                    <li>
-                      a license that permits the licensee to freely copy, modify
-                      and redistribute the Modified Version using the same
-                      licensing terms that apply to the copy that the licensee
-                      received, and requires that the Source form of the
-                      Modified Version, and of any works derived from it, be
-                      made freely available in that license fees are prohibited
-                      but Distributor Fees are allowed.
-                    </li>
-                  </ol>
+                  a license that permits the licensee to freely copy, modify and
+                  redistribute the Modified Version using the same licensing
+                  terms that apply to the copy that the licensee received, and
+                  requires that the Source form of the Modified Version, and of
+                  any works derived from it, be made freely available in that
+                  license fees are prohibited but Distributor Fees are allowed.
                 </li>
               </ol>
-            </div>
+            </li>
+          </ol>
+        </ol>
+        <h4>
+          Distribution of Compiled Forms of the Standard Version or Modified
+          Versions without the Source
+        </h4>
+        <ol type="1" start="5">
+          <li>
+            You may Distribute Compiled forms of the Standard Version without
+            the Source, provided that you include complete instructions on how
+            to get the Source of the Standard Version. Such instructions must be
+            valid at the time of your distribution. If these instructions, at
+            any time while you are carrying out such distribution, become
+            invalid, you must provide new instructions on demand or cease
+            further distribution. If you provide valid instructions or cease
+            distribution within thirty days after you become aware that the
+            instructions are invalid, then you do not forfeit any of your rights
+            under this license.
           </li>
           <li>
-            <h4>
-              Distribution of Compiled Forms of the Standard Version or Modified
-              Versions without the Source
-            </h4>
-            <p>
-              You may Distribute Compiled forms of the Standard Version without
-              the Source, provided that you include complete instructions on how
-              to get the Source of the Standard Version. Such instructions must
-              be valid at the time of your distribution. If these instructions,
-              at any time while you are carrying out such distribution, become
-              invalid, you must provide new instructions on demand or cease
-              further distribution. If you provide valid instructions or cease
-              distribution within thirty days after you become aware that the
-              instructions are invalid, then you do not forfeit any of your
-              rights under this license.
-            </p>
-            <p>
-              You may Distribute a Modified Version in Compiled form without the
-              Source, provided that you comply with Section 4 with respect to
-              the Source of the Modified Version.
-            </p>
+            You may Distribute a Modified Version in Compiled form without the
+            Source, provided that you comply with Section 4 with respect to the
+            Source of the Modified Version.
+          </li>
+        </ol>
+        <h4>Aggregating or Linking the Package</h4>
+        <ol type="1" start="7">
+          <li>
+            You may aggregate the Package (either the Standard Version or
+            Modified Version) with other packages and Distribute the resulting
+            aggregation provided that you do not charge a licensing fee for the
+            Package. Distributor Fees are permitted, and licensing fees for
+            other components in the aggregation are permitted. The terms of this
+            license apply to the use and Distribution of the Standard or
+            Modified Versions as included in the aggregation.
           </li>
           <li>
-            <h4>Aggregating or Linking the Package</h4>
-            <p>
-              You may aggregate the Package (either the Standard Version or
-              Modified Version) with other packages and Distribute the resulting
-              aggregation provided that you do not charge a licensing fee for
-              the Package. Distributor Fees are permitted, and licensing fees
-              for other components in the aggregation are permitted. The terms
-              of this license apply to the use and Distribution of the Standard
-              or Modified Versions as included in the aggregation.
-            </p>
-            <p>
-              You are permitted to link Modified and Standard Versions with
-              other works, to embed the Package in a larger work of your own, or
-              to build stand-alone binary or bytecode versions of applications
-              that include the Package, and Distribute the result without
-              restriction, provided the result does not expose a direct
-              interface to the Package.
-            </p>
+            You are permitted to link Modified and Standard Versions with other
+            works, to embed the Package in a larger work of your own, or to
+            build stand-alone binary or bytecode versions of applications that
+            include the Package, and Distribute the result without restriction,
+            provided the result does not expose a direct interface to the
+            Package.
+          </li>
+        </ol>
+        <h4>Items That are Not Considered Part of a Modified Version</h4>
+        <ol type="1" start="9">
+          <li>
+            Works (including, but not limited to, modules and scripts) that
+            merely extend or make use of the Package, do not, by themselves,
+            cause the Package to be a Modified Version. In addition, such works
+            are not considered parts of the Package itself, and are not subject
+            to the terms of this license.
+          </li>
+        </ol>
+        <h4>General Provisions</h4>
+        <ol type="1" start="10">
+          <li>
+            Any use, modification, and distribution of the Standard or Modified
+            Versions is governed by this Artistic License. By using, modifying
+            or distributing the Package, you accept this license. Do not use,
+            modify, or distribute the Package, if you do not accept this
+            license.
           </li>
           <li>
-            <h4>Items That are Not Considered Part of a Modified Version</h4>
-            <p>
-              Works (including, but not limited to, modules and scripts) that
-              merely extend or make use of the Package, do not, by themselves,
-              cause the Package to be a Modified Version. In addition, such
-              works are not considered parts of the Package itself, and are not
-              subject to the terms of this license.
-            </p>
+            If your Modified Version has been derived from a Modified Version
+            made by someone other than you, you are nevertheless required to
+            ensure that your Modified Version complies with the requirements of
+            this license.
           </li>
           <li>
-            <h4>General Provisions</h4>
-            <p>
-              Any use, modification, and distribution of the Standard or
-              Modified Versions is governed by this Artistic License. By using,
-              modifying or distributing the Package, you accept this license. Do
-              not use, modify, or distribute the Package, if you do not accept
-              this license.
-            </p>
-            <p>
-              If your Modified Version has been derived from a Modified Version
-              made by someone other than you, you are nevertheless required to
-              ensure that your Modified Version complies with the requirements
-              of this license.
-            </p>
-            <p>
-              This license does not grant you the right to use any trademark,
-              service mark, tradename, or logo of the Copyright Holder.
-            </p>
-            <p>
-              This license includes the non-exclusive, worldwide, free-of-charge
-              patent license to make, have made, use, offer to sell, sell,
-              import and otherwise transfer the Package with respect to any
-              patent claims licensable by the Copyright Holder that are
-              necessarily infringed by the Package. If you institute patent
-              litigation (including a cross-claim or counterclaim) against any
-              party alleging that the Package constitutes direct or contributory
-              patent infringement, then this Artistic License to you shall
-              terminate on the date that such litigation is filed.
-            </p>
+            This license does not grant you the right to use any trademark,
+            service mark, tradename, or logo of the Copyright Holder.
           </li>
           <li>
-            <h4>Disclaimer of Warranty:</h4>
+            This license includes the non-exclusive, worldwide, free-of-charge
+            patent license to make, have made, use, offer to sell, sell, import
+            and otherwise transfer the Package with respect to any patent claims
+            licensable by the Copyright Holder that are necessarily infringed by
+            the Package. If you institute patent litigation (including a
+            cross-claim or counterclaim) against any party alleging that the
+            Package constitutes direct or contributory patent infringement, then
+            this Artistic License to you shall terminate on the date that such
+            litigation is filed.
+          </li>
+        </ol>
+        <ol type="1" start="14">
+          <li>
+            Disclaimer of Warranty:
             <p>
               THE PACKAGE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS
               "AS IS' AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES. THE IMPLIED

--- a/website/public/license/index.ejs.html
+++ b/website/public/license/index.ejs.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <!-- Copyright (C) 2020  Matthew "strager" Glazar -->
 <!-- See end of file for extended copyright information. -->
-<html>
+<html lang="en">
   <head>
     <%- await include("../common-head.ejs.html") %>
     <title>quick-lint-js: license information</title>
@@ -2181,162 +2181,165 @@ under certain conditions; type `show c' for details.</code></pre>
         </p>
 
         <ol type="1">
-          <p>Permission for Use and Modification Without Distribution</p>
           <li>
-            You are permitted to use the Standard Version and create and use
-            Modified Versions for any purpose without restriction, provided that
-            you do not Distribute the Modified Version.
+            <h4>Permission for Use and Modification Without Distribution</h4>
+            <p>
+              You are permitted to use the Standard Version and create and use
+              Modified Versions for any purpose without restriction, provided
+              that you do not Distribute the Modified Version.
+            </p>
           </li>
-
-          <p>Permissions for Redistribution of the Standard Version</p>
           <li>
-            You may Distribute verbatim copies of the Source form of the
-            Standard Version of this Package in any medium without restriction,
-            either gratis or for a Distributor Fee, provided that you duplicate
-            all of the original copyright notices and associated disclaimers. At
-            your discretion, such verbatim copies may or may not include a
-            Compiled form of the Package.
+            <h4>Permissions for Redistribution of the Standard Version</h4>
+            <p>
+              You may Distribute verbatim copies of the Source form of the
+              Standard Version of this Package in any medium without
+              restriction, either gratis or for a Distributor Fee, provided that
+              you duplicate all of the original copyright notices and associated
+              disclaimers. At your discretion, such verbatim copies may or may
+              not include a Compiled form of the Package.
+            </p>
+            <p>
+              You may apply any bug fixes, portability changes, and other
+              modifications made available from the Copyright Holder. The
+              resulting Package will still be considered the Standard Version,
+              and as such will be subject to the Original License.
+            </p>
           </li>
-
           <li>
-            You may apply any bug fixes, portability changes, and other
-            modifications made available from the Copyright Holder. The
-            resulting Package will still be considered the Standard Version, and
-            as such will be subject to the Original License.
+            <h4>Distribution of Modified Versions of the Package as Source</h4>
+            <div>
+              <p>
+                You may Distribute your Modified Version as Source (either
+                gratis or for a Distributor Fee, and with or without a Compiled
+                form of the Modified Version) provided that you clearly document
+                how it differs from the Standard Version, including, but not
+                limited to, documenting any non-standard features, executables,
+                or modules, and provided that you do at least ONE of the
+                following:
+              </p>
+              <ol type="a">
+                <li>
+                  make the Modified Version available to the Copyright Holder of
+                  the Standard Version, under the Original License, so that the
+                  Copyright Holder may include your modifications in the
+                  Standard Version.
+                </li>
+
+                <li>
+                  ensure that installation of your Modified Version does not
+                  prevent the user installing or running the Standard Version.
+                  In addition, the Modified Version must bear a name that is
+                  different from the name of the Standard Version.
+                </li>
+
+                <li>
+                  allow anyone who receives a copy of the Modified Version to
+                  make the Source form of the Modified Version available to
+                  others under
+                  <ol type="i">
+                    <li>the Original License or</li>
+
+                    <li>
+                      a license that permits the licensee to freely copy, modify
+                      and redistribute the Modified Version using the same
+                      licensing terms that apply to the copy that the licensee
+                      received, and requires that the Source form of the
+                      Modified Version, and of any works derived from it, be
+                      made freely available in that license fees are prohibited
+                      but Distributor Fees are allowed.
+                    </li>
+                  </ol>
+                </li>
+              </ol>
+            </div>
           </li>
-
-          <p>Distribution of Modified Versions of the Package as Source</p>
           <li>
-            You may Distribute your Modified Version as Source (either gratis or
-            for a Distributor Fee, and with or without a Compiled form of the
-            Modified Version) provided that you clearly document how it differs
-            from the Standard Version, including, but not limited to,
-            documenting any non-standard features, executables, or modules, and
-            provided that you do at least ONE of the following:
-
-            <ol type="a">
-              <li>
-                make the Modified Version available to the Copyright Holder of
-                the Standard Version, under the Original License, so that the
-                Copyright Holder may include your modifications in the Standard
-                Version.
-              </li>
-
-              <li>
-                ensure that installation of your Modified Version does not
-                prevent the user installing or running the Standard Version. In
-                addition, the Modified Version must bear a name that is
-                different from the name of the Standard Version.
-              </li>
-
-              <li>
-                allow anyone who receives a copy of the Modified Version to make
-                the Source form of the Modified Version available to others
-                under
-                <ol type="i">
-                  <li>the Original License or</li>
-
-                  <li>
-                    a license that permits the licensee to freely copy, modify
-                    and redistribute the Modified Version using the same
-                    licensing terms that apply to the copy that the licensee
-                    received, and requires that the Source form of the Modified
-                    Version, and of any works derived from it, be made freely
-                    available in that license fees are prohibited but
-                    Distributor Fees are allowed.
-                  </li>
-                </ol>
-              </li>
-            </ol>
+            <h4>
+              Distribution of Compiled Forms of the Standard Version or Modified
+              Versions without the Source
+            </h4>
+            <p>
+              You may Distribute Compiled forms of the Standard Version without
+              the Source, provided that you include complete instructions on how
+              to get the Source of the Standard Version. Such instructions must
+              be valid at the time of your distribution. If these instructions,
+              at any time while you are carrying out such distribution, become
+              invalid, you must provide new instructions on demand or cease
+              further distribution. If you provide valid instructions or cease
+              distribution within thirty days after you become aware that the
+              instructions are invalid, then you do not forfeit any of your
+              rights under this license.
+            </p>
+            <p>
+              You may Distribute a Modified Version in Compiled form without the
+              Source, provided that you comply with Section 4 with respect to
+              the Source of the Modified Version.
+            </p>
           </li>
-
-          <p>
-            Distribution of Compiled Forms of the Standard Version or Modified
-            Versions without the Source
-          </p>
           <li>
-            You may Distribute Compiled forms of the Standard Version without
-            the Source, provided that you include complete instructions on how
-            to get the Source of the Standard Version. Such instructions must be
-            valid at the time of your distribution. If these instructions, at
-            any time while you are carrying out such distribution, become
-            invalid, you must provide new instructions on demand or cease
-            further distribution. If you provide valid instructions or cease
-            distribution within thirty days after you become aware that the
-            instructions are invalid, then you do not forfeit any of your rights
-            under this license.
+            <h4>Aggregating or Linking the Package</h4>
+            <p>
+              You may aggregate the Package (either the Standard Version or
+              Modified Version) with other packages and Distribute the resulting
+              aggregation provided that you do not charge a licensing fee for
+              the Package. Distributor Fees are permitted, and licensing fees
+              for other components in the aggregation are permitted. The terms
+              of this license apply to the use and Distribution of the Standard
+              or Modified Versions as included in the aggregation.
+            </p>
+            <p>
+              You are permitted to link Modified and Standard Versions with
+              other works, to embed the Package in a larger work of your own, or
+              to build stand-alone binary or bytecode versions of applications
+              that include the Package, and Distribute the result without
+              restriction, provided the result does not expose a direct
+              interface to the Package.
+            </p>
           </li>
-
           <li>
-            You may Distribute a Modified Version in Compiled form without the
-            Source, provided that you comply with Section 4 with respect to the
-            Source of the Modified Version.
+            <h4>Items That are Not Considered Part of a Modified Version</h4>
+            <p>
+              Works (including, but not limited to, modules and scripts) that
+              merely extend or make use of the Package, do not, by themselves,
+              cause the Package to be a Modified Version. In addition, such
+              works are not considered parts of the Package itself, and are not
+              subject to the terms of this license.
+            </p>
           </li>
-
-          <p>Aggregating or Linking the Package</p>
           <li>
-            You may aggregate the Package (either the Standard Version or
-            Modified Version) with other packages and Distribute the resulting
-            aggregation provided that you do not charge a licensing fee for the
-            Package. Distributor Fees are permitted, and licensing fees for
-            other components in the aggregation are permitted. The terms of this
-            license apply to the use and Distribution of the Standard or
-            Modified Versions as included in the aggregation.
+            <h4>General Provisions</h4>
+            <p>
+              Any use, modification, and distribution of the Standard or
+              Modified Versions is governed by this Artistic License. By using,
+              modifying or distributing the Package, you accept this license. Do
+              not use, modify, or distribute the Package, if you do not accept
+              this license.
+            </p>
+            <p>
+              If your Modified Version has been derived from a Modified Version
+              made by someone other than you, you are nevertheless required to
+              ensure that your Modified Version complies with the requirements
+              of this license.
+            </p>
+            <p>
+              This license does not grant you the right to use any trademark,
+              service mark, tradename, or logo of the Copyright Holder.
+            </p>
+            <p>
+              This license includes the non-exclusive, worldwide, free-of-charge
+              patent license to make, have made, use, offer to sell, sell,
+              import and otherwise transfer the Package with respect to any
+              patent claims licensable by the Copyright Holder that are
+              necessarily infringed by the Package. If you institute patent
+              litigation (including a cross-claim or counterclaim) against any
+              party alleging that the Package constitutes direct or contributory
+              patent infringement, then this Artistic License to you shall
+              terminate on the date that such litigation is filed.
+            </p>
           </li>
-
           <li>
-            You are permitted to link Modified and Standard Versions with other
-            works, to embed the Package in a larger work of your own, or to
-            build stand-alone binary or bytecode versions of applications that
-            include the Package, and Distribute the result without restriction,
-            provided the result does not expose a direct interface to the
-            Package.
-          </li>
-
-          <p>Items That are Not Considered Part of a Modified Version</p>
-          <li>
-            Works (including, but not limited to, modules and scripts) that
-            merely extend or make use of the Package, do not, by themselves,
-            cause the Package to be a Modified Version. In addition, such works
-            are not considered parts of the Package itself, and are not subject
-            to the terms of this license.
-          </li>
-
-          <p>General Provisions</p>
-          <li>
-            Any use, modification, and distribution of the Standard or Modified
-            Versions is governed by this Artistic License. By using, modifying
-            or distributing the Package, you accept this license. Do not use,
-            modify, or distribute the Package, if you do not accept this
-            license.
-          </li>
-
-          <li>
-            If your Modified Version has been derived from a Modified Version
-            made by someone other than you, you are nevertheless required to
-            ensure that your Modified Version complies with the requirements of
-            this license.
-          </li>
-
-          <li>
-            This license does not grant you the right to use any trademark,
-            service mark, tradename, or logo of the Copyright Holder.
-          </li>
-
-          <li>
-            This license includes the non-exclusive, worldwide, free-of-charge
-            patent license to make, have made, use, offer to sell, sell, import
-            and otherwise transfer the Package with respect to any patent claims
-            licensable by the Copyright Holder that are necessarily infringed by
-            the Package. If you institute patent litigation (including a
-            cross-claim or counterclaim) against any party alleging that the
-            Package constitutes direct or contributory patent infringement, then
-            this Artistic License to you shall terminate on the date that such
-            litigation is filed.
-          </li>
-
-          <li>
-            <p>Disclaimer of Warranty:</p>
+            <h4>Disclaimer of Warranty:</h4>
             <p>
               THE PACKAGE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS
               "AS IS' AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES. THE IMPLIED


### PR DESCRIPTION
Fixed validation errors in /license page where paragraph tag is not allowed to
be a children of an ordered list, and added lang attribute to html element (this
attribute was also added to /hiring and /benchmarks pages) #335. In /benchmarks page, we still get the following validation error `Error CSS: color: 70% is not a valid color 3 or 6 hexadecimals numbers`, which seems to be a validator bug. I have opened up an issue with validator, which can be tracked [here](https://github.com/validator/validator/issues/1160) 