### PR TITLE
Disallow parameter named 'await' in async arrow function

### DIFF
--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -561,6 +561,17 @@ expression* parser::parse_async_expression_only(token async_token) {
                 .arrow = this->peek().span(),
             });
       }
+      for (auto parameter : parameters) {
+        if (parameter->kind() == expression_kind::variable &&
+            parameter->variable_identifier_token_type() ==
+                token_type::kw_await) {
+          // async (await) => {}  // Invalid
+          this->error_reporter_->report(
+              error_cannot_declare_await_in_async_function{
+                  .name = parameter->variable_identifier(),
+              });
+        }
+      }
       // TODO(strager): Should we call maybe_wrap_erroneous_arrow_function?
       return parse_arrow_function_arrow_and_body(std::move(parameters));
     } else {
@@ -597,6 +608,13 @@ expression* parser::parse_async_expression_only(token async_token) {
       goto variable_reference;
     }
 
+    if (this->peek().type == token_type::kw_await) {
+      // async await => {}  // Invalid
+      this->error_reporter_->report(
+          error_cannot_declare_await_in_async_function{
+              .name = this->peek().identifier_name(),
+          });
+    }
     std::array<expression*, 1> parameters = {
         this->make_expression<expression::variable>(
             identifier(this->peek().span()), this->peek().type)};

--- a/test/test-parse-var.cpp
+++ b/test/test-parse-var.cpp
@@ -16,6 +16,7 @@
 #include <quick-lint-js/parse-support.h>
 #include <quick-lint-js/parse.h>
 #include <quick-lint-js/spy-visitor.h>
+#include <quick-lint-js/string-view.h>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -23,6 +24,7 @@
 using ::testing::ElementsAre;
 using ::testing::IsEmpty;
 using ::testing::UnorderedElementsAre;
+using namespace std::literals::string_view_literals;
 
 namespace quick_lint_js {
 namespace {
@@ -1802,13 +1804,18 @@ TEST(test_parse, variables_can_be_named_contextual_keywords) {
                   ElementsAre(spy_visitor::visited_variable_use{name}));
     }
 
-    // TODO(#215): Disallow 'await' as parameter to async arrow function.
     for (string8 code : {
              u8"(async " + name + u8" => null)",
              u8"(async (" + name + u8") => null)",
              u8"(" + name + u8" => null)",
              u8"((" + name + u8") => null)",
          }) {
+      if (name == u8"await" &&
+          quick_lint_js::starts_with(string8_view(code), u8"(async"sv)) {
+        // NOTE(erlliam): await parameter isn't allowed in async functions. See
+        // test_parse.disallow_await_parameter_in_async_arrow_function.
+        continue;
+      }
       SCOPED_TRACE(out_string8(code));
       spy_visitor v =
           parse_and_visit_statement(code, function_attributes::normal);


### PR DESCRIPTION
Resolves #215

What should be done for the broken test in test-parse-var.cpp?
Also I'm not sure what the error message should be so I just wrote random stuff.