### PR TITLE
Report different error for *function f() {}

### DIFF
--- a/docs/errors/E133.md
+++ b/docs/errors/E133.md
@@ -1,0 +1,9 @@
+# E133: error generator function star belongs before name
+
+The following code has misplaced '*'.
+
+    *function f(x) { yield x; }
+
+To fix this error, move the '*' before function name.
+
+    function *f(x) { yield x; }

--- a/docs/errors/E204.md
+++ b/docs/errors/E204.md
@@ -1,0 +1,9 @@
+# E204: error generator function star belongs after keyword function
+
+The following code has misplaced '*'.
+
+    let x = *function(y) { yield y; };
+
+To fix this error, move the '*' after the keyword function.
+
+    let x = function*(y) { yield y; };

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -2043,7 +2043,8 @@ function_attributes parser::parse_generator_star(
       QLJS_ASSERT(false);
       return function_attributes::async_generator;
     case function_attributes::generator:
-      QLJS_ASSERT(false);
+      // @@@ remove
+      // QLJS_ASSERT(false);
       return function_attributes::generator;
     case function_attributes::normal:
       return function_attributes::generator;

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -460,7 +460,7 @@ expression* parser::parse_primary_expression(precedence prec) {
             this->skip();
           }
           expression* function =
-              this->parse_function_expression(attrb, this->peek().begin);
+              this->parse_function_expression(attrb, star_token.begin);
           return function;
         }
       }

--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -438,6 +438,13 @@
               function_keywords, kind_of_statement))                           \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
+      error_generator_function_star_belongs_after_keyword_function, "E204",    \
+      { source_code_span star; },                                              \
+      .error(QLJS_TRANSLATABLE(                                                \
+                 "generator function '*' belongs after keyword function"),     \
+             star))                                                            \
+                                                                               \
+  QLJS_ERROR_TYPE(                                                             \
       error_generator_function_star_belongs_before_name, "E133",               \
       {                                                                        \
         source_code_span function_name;                                        \

--- a/src/quick-lint-js/parse.h
+++ b/src/quick-lint-js/parse.h
@@ -376,7 +376,7 @@ class parser {
             }
             this->parse_and_visit_function_declaration(
                 v, function_attributes_type,
-                /*begin=*/this->peek().begin,
+                /*begin=*/star_token.begin,
                 /*require_name=*/
                 name_requirement::required_for_statement);
             break;

--- a/src/quick-lint-js/parse.h
+++ b/src/quick-lint-js/parse.h
@@ -350,16 +350,14 @@ class parser {
         token star_token = this->peek();
         this->skip();
         if (this->peek().type == token_type::kw_function) {
-          lexer_transaction function_begin_transaction =
-              this->lexer_.begin_transaction();
           this->skip();
           this->error_reporter_->report(
               error_generator_function_star_belongs_before_name{
                   .function_name = this->peek().span(),
                   .star = star_token.span(),
               });
-          this->lexer_.roll_back_transaction(
-              std::move(function_begin_transaction));
+          this->lexer_.roll_back_transaction(std::move(transaction));
+          this->skip();
           this->parse_and_visit_function_declaration(
               v, function_attributes::generator,
               /*begin=*/this->peek().begin,

--- a/src/quick-lint-js/parse.h
+++ b/src/quick-lint-js/parse.h
@@ -343,10 +343,36 @@ class parser {
     case token_type::slash:
     case token_type::slash_equal:
     case token_type::string:
-    case token_type::tilde:
+    case token_type::tilde: {
+      // @@@
+      if (this->peek().type == token_type::star) {
+        lexer_transaction transaction = this->lexer_.begin_transaction();
+        token star_token = this->peek();
+        this->skip();
+        if (this->peek().type == token_type::kw_function) {
+          lexer_transaction function_begin_transaction =
+              this->lexer_.begin_transaction();
+          this->skip();
+          this->error_reporter_->report(
+              error_generator_function_star_belongs_before_name{
+                  .function_name = this->peek().span(),
+                  .star = star_token.span(),
+              });
+          this->lexer_.roll_back_transaction(
+              std::move(function_begin_transaction));
+          this->parse_and_visit_function_declaration(
+              v, function_attributes::generator,
+              /*begin=*/this->peek().begin,
+              /*require_name=*/
+              name_requirement::required_for_statement);
+        } else {
+          this->lexer_.roll_back_transaction(std::move(transaction));
+        }
+      }
       this->parse_and_visit_expression(v);
       parse_expression_end();
       break;
+    }
 
     // await settings.save();
     // await = value;

--- a/test/test-parse-expression.cpp
+++ b/test/test-parse-expression.cpp
@@ -3237,6 +3237,13 @@ TEST_F(test_parse_expression,
   }
 }
 
+TEST_F(test_parse_expression, generator_misplaced_star) {
+  test_parser p(u8"(*function f(){})"_sv);
+  expression* ast = p.parse_expression();
+  EXPECT_EQ(p.range(ast).begin_offset(), 1);
+  EXPECT_EQ(p.range(ast).end_offset(), 16);
+}
+
 std::string summarize(const expression& expression) {
   auto children = [&] {
     std::string result;

--- a/test/test-parse-function.cpp
+++ b/test/test-parse-function.cpp
@@ -658,45 +658,45 @@ TEST(test_parse, generator_function_with_misplaced_star) {
   }
 
   {
-    // @@@
     padded_string code(u8"*function f(x) { yield x; }\nf(10);"_sv);
     spy_visitor v;
     parser p(&code, &v);
-    EXPECT_TRUE(p.parse_and_visit_statement(v));
+    p.parse_and_visit_module(v);
     EXPECT_THAT(v.visits, ElementsAre("visit_variable_declaration",       // f
                                       "visit_enter_function_scope",       //
                                       "visit_variable_declaration",       // x
                                       "visit_enter_function_scope_body",  //
                                       "visit_variable_use",               // x
-                                      "visit_exit_function_scope",
-                                      "visit_variable_use"));  // f
+                                      "visit_exit_function_scope",        //
+                                      "visit_variable_use",               // f
+                                      "visit_end_of_module"));
     EXPECT_THAT(
         v.errors,
         ElementsAre(ERROR_TYPE_2_FIELDS(
             error_generator_function_star_belongs_before_name, function_name,
             offsets_matcher(&code, strlen(u8"*function "), u8"f"), star,
-            offsets_matcher(&code, strlen(u8""), u8"*"))));
+            offsets_matcher(&code, 0, u8"*"))));
   }
 
   {
-    // @@@
-    padded_string code(u8"*\nfunction f(x) { yield x; }\nf(10);"_sv);
+    padded_string code(u8"*async function f(x) { yield x; }\nf(10);"_sv);
     spy_visitor v;
     parser p(&code, &v);
-    EXPECT_TRUE(p.parse_and_visit_statement(v));
+    p.parse_and_visit_module(v);
     EXPECT_THAT(v.visits, ElementsAre("visit_variable_declaration",       // f
                                       "visit_enter_function_scope",       //
                                       "visit_variable_declaration",       // x
                                       "visit_enter_function_scope_body",  //
                                       "visit_variable_use",               // x
-                                      "visit_exit_function_scope",
-                                      "visit_variable_use"));  // f
+                                      "visit_exit_function_scope",        //
+                                      "visit_variable_use",               // f
+                                      "visit_end_of_module"));
     EXPECT_THAT(
         v.errors,
         ElementsAre(ERROR_TYPE_2_FIELDS(
             error_generator_function_star_belongs_before_name, function_name,
-            offsets_matcher(&code, strlen(u8"*\nfunction "), u8"f"), star,
-            offsets_matcher(&code, strlen(u8""), u8"*"))));
+            offsets_matcher(&code, strlen(u8"*async function "), u8"f"), star,
+            offsets_matcher(&code, 0, u8"*"))));
   }
 
   {
@@ -707,25 +707,157 @@ TEST(test_parse, generator_function_with_misplaced_star) {
     EXPECT_THAT(v.visits, IsEmpty());
     EXPECT_THAT(
         v.errors,
-        ElementsAre(ERROR_TYPE_2_FIELDS(
-                        error_generator_function_star_belongs_before_name,
-                        function_name,
-                        offsets_matcher(&code, strlen(u8"*function"), u8""),
-                        star, offsets_matcher(&code, 0, u8"*")),
-                    ERROR_TYPE_FIELD(
-                        error_missing_name_in_function_statement, where,
-                        offsets_matcher(&code, strlen(u8"*"), u8"function"))));
+        ElementsAre(
+            ERROR_TYPE_FIELD(
+                error_generator_function_star_belongs_after_keyword_function,
+                star, offsets_matcher(&code, 0, u8"*")),
+            ERROR_TYPE_FIELD(
+                error_missing_name_in_function_statement, where,
+                offsets_matcher(&code, strlen(u8"*"), u8"function"))));
   }
 
-  // @@@ fix function expression
-  // {
-  //   padded_string code(u8"let x = *function() { yield x; }"_sv);
-  //   spy_visitor v;
-  //   parser p(&code, &v);
-  //   EXPECT_TRUE(p.parse_and_visit_statement(v));
-  //   @@@ report generator function star error
-  //   EXPECT_THAT(v.errors, IsEmpty());
-  // }
+  {
+    padded_string code(u8"*async function"_sv);
+    spy_visitor v;
+    parser p(&code, &v);
+    EXPECT_TRUE(p.parse_and_visit_statement(v));
+    EXPECT_THAT(v.visits, IsEmpty());
+    EXPECT_THAT(
+        v.errors,
+        ElementsAre(
+            ERROR_TYPE_FIELD(
+                error_generator_function_star_belongs_after_keyword_function,
+                star, offsets_matcher(&code, 0, u8"*")),
+            ERROR_TYPE_FIELD(
+                error_missing_name_in_function_statement, where,
+                offsets_matcher(&code, strlen(u8"*async "), u8"function"))));
+  }
+
+  {
+    padded_string code(u8"let x = *function(y) { yield y; }"_sv);
+    spy_visitor v;
+    parser p(&code, &v);
+    p.parse_and_visit_module(v);
+    EXPECT_THAT(v.visits, ElementsAre("visit_enter_function_scope",
+                                      "visit_variable_declaration",       // y
+                                      "visit_enter_function_scope_body",  //
+                                      "visit_variable_use",               // y
+                                      "visit_exit_function_scope",        //
+                                      "visit_variable_declaration",       // x
+                                      "visit_end_of_module"));
+    EXPECT_THAT(
+        v.errors,
+        ElementsAre(ERROR_TYPE_FIELD(
+            error_generator_function_star_belongs_after_keyword_function, star,
+            offsets_matcher(&code, strlen(u8"let x = "), u8"*"))));
+  }
+
+  {
+    padded_string code(u8"let x = *async function(y) { yield y; }"_sv);
+    spy_visitor v;
+    parser p(&code, &v);
+    p.parse_and_visit_module(v);
+    EXPECT_THAT(v.visits, ElementsAre("visit_enter_function_scope",
+                                      "visit_variable_declaration",       // y
+                                      "visit_enter_function_scope_body",  //
+                                      "visit_variable_use",               // y
+                                      "visit_exit_function_scope",        //
+                                      "visit_variable_declaration",       // x
+                                      "visit_end_of_module"));
+    EXPECT_THAT(
+        v.errors,
+        ElementsAre(ERROR_TYPE_FIELD(
+            error_generator_function_star_belongs_after_keyword_function, star,
+            offsets_matcher(&code, strlen(u8"let x = "), u8"*"))));
+  }
+}
+
+TEST(test_parse, star_before_async_or_function_is_not_generator_star) {
+  {
+    padded_string code(u8"*\nfunction f() {}"_sv);
+    spy_visitor v;
+    parser p(&code, &v);
+    p.parse_and_visit_module(v);
+    EXPECT_THAT(v.visits, ElementsAre("visit_enter_named_function_scope",  // f
+                                      "visit_enter_function_scope_body",   //
+                                      "visit_exit_function_scope",         //
+                                      "visit_end_of_module"));
+    EXPECT_THAT(v.errors, ElementsAre(ERROR_TYPE_FIELD(
+                              error_missing_operand_for_operator, where,
+                              offsets_matcher(&code, 0, u8"*"))));
+  }
+
+  {
+    padded_string code(u8"*\nasync function f() {}"_sv);
+    spy_visitor v;
+    parser p(&code, &v);
+    p.parse_and_visit_module(v);
+    EXPECT_THAT(v.visits, ElementsAre("visit_enter_named_function_scope",  // f
+                                      "visit_enter_function_scope_body",   //
+                                      "visit_exit_function_scope",         //
+                                      "visit_end_of_module"));
+    EXPECT_THAT(v.errors, ElementsAre(ERROR_TYPE_FIELD(
+                              error_missing_operand_for_operator, where,
+                              offsets_matcher(&code, 0, u8"*"))));
+  }
+
+  {
+    padded_string code(u8"*\nfunction f() {}"_sv);
+    spy_visitor v;
+    parser p(&code, &v);
+    p.parse_and_visit_module(v);
+    EXPECT_THAT(v.visits, ElementsAre("visit_enter_named_function_scope",  // f
+                                      "visit_enter_function_scope_body",   //
+                                      "visit_exit_function_scope",         //
+                                      "visit_end_of_module"));
+    EXPECT_THAT(v.errors, ElementsAre(ERROR_TYPE_FIELD(
+                              error_missing_operand_for_operator, where,
+                              offsets_matcher(&code, 0, u8"*"))));
+  }
+
+  {
+    padded_string code(u8"*\nasync function f() {}"_sv);
+    spy_visitor v;
+    parser p(&code, &v);
+    p.parse_and_visit_module(v);
+    EXPECT_THAT(v.visits, ElementsAre("visit_enter_named_function_scope",
+                                      "visit_enter_function_scope_body",
+                                      "visit_exit_function_scope",
+                                      "visit_end_of_module"));
+    EXPECT_THAT(v.errors, ElementsAre(ERROR_TYPE_FIELD(
+                              error_missing_operand_for_operator, where,
+                              offsets_matcher(&code, 0, u8"*"))));
+  }
+
+  {
+    padded_string code(u8"async *function f() {}"_sv);
+    spy_visitor v;
+    parser p(&code, &v);
+    p.parse_and_visit_module(v);
+    EXPECT_THAT(v.visits,
+                ElementsAre("visit_variable_use",                // async
+                            "visit_enter_named_function_scope",  // f
+                            "visit_enter_function_scope_body",   //
+                            "visit_exit_function_scope",         //
+                            "visit_end_of_module"));
+    EXPECT_THAT(v.errors, IsEmpty());
+  }
+
+  {
+    padded_string code(
+        u8"console.log('hi')\n*function f() {}\nconsole.log('hi')"_sv);
+    spy_visitor v;
+    parser p(&code, &v);
+    p.parse_and_visit_module(v);
+    EXPECT_THAT(v.visits,
+                ElementsAre("visit_variable_use",                // console
+                            "visit_enter_named_function_scope",  // f
+                            "visit_enter_function_scope_body",   //
+                            "visit_exit_function_scope",         //
+                            "visit_variable_use",                // console
+                            "visit_end_of_module"));
+    EXPECT_THAT(v.errors, IsEmpty());
+  }
 }
 
 TEST(test_parse, incomplete_function_body) {

--- a/test/test-parse-function.cpp
+++ b/test/test-parse-function.cpp
@@ -695,8 +695,8 @@ TEST(test_parse, generator_function_with_misplaced_star) {
         v.errors,
         ElementsAre(ERROR_TYPE_2_FIELDS(
             error_generator_function_star_belongs_before_name, function_name,
-            offsets_matcher(&code, strlen(u8"*async function "), u8"f"), star,
-            offsets_matcher(&code, 0, u8"*"))));
+            offsets_matcher(&code, strlen(u8"*async function "), u8"f"),  //
+            star, offsets_matcher(&code, 0, u8"*"))));
   }
 
   {
@@ -835,34 +835,6 @@ TEST(test_parse, star_before_async_or_function_is_not_generator_star) {
     EXPECT_THAT(v.visits, ElementsAre("visit_enter_named_function_scope",  // f
                                       "visit_enter_function_scope_body",   //
                                       "visit_exit_function_scope",         //
-                                      "visit_end_of_module"));
-    EXPECT_THAT(v.errors, ElementsAre(ERROR_TYPE_FIELD(
-                              error_missing_operand_for_operator, where,
-                              offsets_matcher(&code, 0, u8"*"))));
-  }
-
-  {
-    padded_string code(u8"*\nfunction f() {}"_sv);
-    spy_visitor v;
-    parser p(&code, &v);
-    p.parse_and_visit_module(v);
-    EXPECT_THAT(v.visits, ElementsAre("visit_enter_named_function_scope",  // f
-                                      "visit_enter_function_scope_body",   //
-                                      "visit_exit_function_scope",         //
-                                      "visit_end_of_module"));
-    EXPECT_THAT(v.errors, ElementsAre(ERROR_TYPE_FIELD(
-                              error_missing_operand_for_operator, where,
-                              offsets_matcher(&code, 0, u8"*"))));
-  }
-
-  {
-    padded_string code(u8"*\nasync function f() {}"_sv);
-    spy_visitor v;
-    parser p(&code, &v);
-    p.parse_and_visit_module(v);
-    EXPECT_THAT(v.visits, ElementsAre("visit_enter_named_function_scope",
-                                      "visit_enter_function_scope_body",
-                                      "visit_exit_function_scope",
                                       "visit_end_of_module"));
     EXPECT_THAT(v.errors, ElementsAre(ERROR_TYPE_FIELD(
                               error_missing_operand_for_operator, where,


### PR DESCRIPTION
The following code:

    *function f(x) { yield x; }

Should report error_generator_function_star_belongs_before_name

Fix: #267  