### PR TITLE
Report error on uninitialized declaration of const variable.

### DIFF
--- a/docs/errors/E205.md
+++ b/docs/errors/E205.md
@@ -1,0 +1,11 @@
+# E205: error missing initializer in const declaration
+
+The following code is missing is missing initialization for
+const variable declaration.
+
+    const x;
+
+To fix this error, initialize the variable x with some
+value.
+
+    const x = 10;

--- a/docs/errors/E205.md
+++ b/docs/errors/E205.md
@@ -9,3 +9,7 @@ To fix this error, initialize the variable x with some
 value.
 
     const x = 10;
+
+Another way to fix this error, change const to let.
+
+    let x;

--- a/docs/errors/E205.md
+++ b/docs/errors/E205.md
@@ -1,7 +1,7 @@
 # E205: error missing initializer in const declaration
 
-The following code is missing is missing initialization for
-const variable declaration.
+The following code is missing initialization for const
+variable declaration.
 
     const x;
 

--- a/plugin/vscode/test/other-tests.js
+++ b/plugin/vscode/test/other-tests.js
@@ -378,7 +378,7 @@ let tests = {
         );
 
         try {
-          let document = new MockDocument("hello.js", "const x;");
+          let document = new MockDocument("hello.js", "const x = 10;");
           let linter = linters.getLinter(document);
           let shouldOpenEditorBeforeChanges = rng.nextCoinFlip();
           if (shouldOpenEditorBeforeChanges) {
@@ -387,7 +387,7 @@ let tests = {
 
           qljs.maybeInjectFault = maybeInjectFaultWithExhaustiveRNG;
           let promises = [];
-          for (let charactersToType of ["const ", "x;"]) {
+          for (let charactersToType of ["const ", "x = 10;"]) {
             let changes = [
               {
                 range: new vscode.Range(
@@ -411,15 +411,15 @@ let tests = {
             diagnosticCollection.get(document.uri)
           );
           if (firstChangeFailed && lastChangeFailed) {
-            // No changes were applied. The linted document was "const x;".
+            // No changes were applied. The linted document was "const x = 10;".
             assert.deepStrictEqual(
               diags.map((diag) => diag.message),
               []
             );
           } else if (!firstChangeFailed && lastChangeFailed) {
             // Partial changes were applied. The linted document was either
-            // "const x;const " (if the first change finished before the second
-            // change started) or "const x; const x;" (if the second change failed
+            // "const x = 10;const " (if the first change finished before the second
+            // change started) or "const x = 10; const x = 10;" (if the second change failed
             // before the first change started).
             let messages = diags.map((diag) => diag.message);
             assert.strictEqual(messages.length, 1, messages);
@@ -432,7 +432,7 @@ let tests = {
             );
           } else {
             // Because the last call to textChangedAsync succeeded, all changes
-            // were applied. The linted document was "const x;const x;".
+            // were applied. The linted document was "const x = 10;const x = 10;".
             assert.deepStrictEqual(
               diags.map((diag) => diag.message),
               ["redeclaration of variable: x"]

--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -733,6 +733,12 @@
       .error(QLJS_TRANSLATABLE("missing for loop header"), where))             \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
+      error_missing_initializer_in_const_declaration, "E205",                  \
+      { source_code_span variable_name; },                                     \
+      .error(QLJS_TRANSLATABLE("missing initializer in const declaration"),    \
+             variable_name))                                                   \
+                                                                               \
+  QLJS_ERROR_TYPE(                                                             \
       error_missing_key_for_object_entry, "E154",                              \
       { source_code_span expression; },                                        \
       .error(QLJS_TRANSLATABLE(                                                \

--- a/src/quick-lint-js/parse.h
+++ b/src/quick-lint-js/parse.h
@@ -3176,6 +3176,11 @@ class parser {
         // let x;
         // let x, y;
         default:
+          if (declaration_kind == variable_kind::_const) {
+            this->error_reporter_->report(
+                error_missing_initializer_in_const_declaration{
+                    .variable_name = variable->span()});
+          }
           this->visit_binding_element(variable, v, declaration_kind);
           break;
         }

--- a/test/test-lint-parse.cpp
+++ b/test/test-lint-parse.cpp
@@ -77,7 +77,7 @@ TEST(test_lint, escape_sequences_are_allowed_for_arguments_variable) {
 
 TEST(test_lint,
      function_statement_inside_if_does_not_conflict_with_let_variable) {
-  padded_string input(u8"const f;\nif (true)\n  function f() {}"_sv);
+  padded_string input(u8"let f;\nif (true)\n  function f() {}"_sv);
 
   error_collector v;
   linter l(&v, &default_globals);
@@ -85,10 +85,7 @@ TEST(test_lint,
   p.parse_and_visit_module(l);
   l.visit_end_of_module();
 
-  EXPECT_THAT(v.errors,
-              ElementsAre(ERROR_TYPE_FIELD(
-                  error_missing_initializer_in_const_declaration, variable_name,
-                  offsets_matcher(&input, strlen(u8"const "), u8"f"))));
+  EXPECT_THAT(v.errors, IsEmpty());
 }
 
 TEST(test_lint, typeof_with_conditional_operator) {

--- a/test/test-lint-parse.cpp
+++ b/test/test-lint-parse.cpp
@@ -85,7 +85,10 @@ TEST(test_lint,
   p.parse_and_visit_module(l);
   l.visit_end_of_module();
 
-  EXPECT_THAT(v.errors, IsEmpty());
+  EXPECT_THAT(v.errors,
+              ElementsAre(ERROR_TYPE_FIELD(
+                  error_missing_initializer_in_const_declaration, variable_name,
+                  offsets_matcher(&input, strlen(u8"const "), u8"f"))));
 }
 
 TEST(test_lint, typeof_with_conditional_operator) {

--- a/test/test-parse-module.cpp
+++ b/test/test-parse-module.cpp
@@ -42,19 +42,11 @@ TEST(test_parse, export_variable) {
   }
 
   {
-    padded_string code(u8"export const x;"_sv);
-    spy_visitor v;
-    parser p(&code, &v);
-    EXPECT_TRUE(p.parse_and_visit_statement(v));
+    spy_visitor v = parse_and_visit_statement(u8"export const x = null;"_sv);
     EXPECT_THAT(v.visits, ElementsAre("visit_variable_declaration"));
     EXPECT_THAT(v.variable_declarations,
                 ElementsAre(spy_visitor::visited_variable_declaration{
                     u8"x", variable_kind::_const}));
-    EXPECT_THAT(
-        v.errors,
-        ElementsAre(ERROR_TYPE_FIELD(
-            error_missing_initializer_in_const_declaration, variable_name,
-            offsets_matcher(&code, strlen(u8"export const "), u8"x"))));
   }
 }
 

--- a/test/test-parse-module.cpp
+++ b/test/test-parse-module.cpp
@@ -42,11 +42,19 @@ TEST(test_parse, export_variable) {
   }
 
   {
-    spy_visitor v = parse_and_visit_statement(u8"export const x;"_sv);
+    padded_string code(u8"export const x;"_sv);
+    spy_visitor v;
+    parser p(&code, &v);
+    EXPECT_TRUE(p.parse_and_visit_statement(v));
     EXPECT_THAT(v.visits, ElementsAre("visit_variable_declaration"));
     EXPECT_THAT(v.variable_declarations,
                 ElementsAre(spy_visitor::visited_variable_declaration{
                     u8"x", variable_kind::_const}));
+    EXPECT_THAT(
+        v.errors,
+        ElementsAre(ERROR_TYPE_FIELD(
+            error_missing_initializer_in_const_declaration, variable_name,
+            offsets_matcher(&code, strlen(u8"export const "), u8"x"))));
   }
 }
 

--- a/test/test-parse-var.cpp
+++ b/test/test-parse-var.cpp
@@ -92,7 +92,10 @@ TEST(test_parse, parse_simple_const) {
   ASSERT_EQ(v.variable_declarations.size(), 1);
   EXPECT_EQ(v.variable_declarations[0].name, u8"x");
   EXPECT_EQ(v.variable_declarations[0].kind, variable_kind::_const);
-  EXPECT_THAT(v.errors, IsEmpty());
+  EXPECT_THAT(v.errors,
+              ElementsAre(ERROR_TYPE_FIELD(
+                  error_missing_initializer_in_const_declaration, variable_name,
+                  offsets_matcher(&code, strlen(u8"const "), u8"x"))));
 }
 
 TEST(test_parse, let_asi) {
@@ -861,10 +864,15 @@ TEST(test_parse, report_missing_semicolon_for_declarations) {
                     u8"x", variable_kind::_const}));
     cli_source_position::offset_type end_of_const_statement =
         strlen(u8"const x");
-    EXPECT_THAT(v.errors,
-                ElementsAre(ERROR_TYPE_FIELD(
-                    error_missing_semicolon_after_statement, where,
-                    offsets_matcher(&code, end_of_const_statement, u8""))));
+    EXPECT_THAT(
+        v.errors,
+        ElementsAre(
+            ERROR_TYPE_FIELD(error_missing_initializer_in_const_declaration,
+                             variable_name,
+                             offsets_matcher(&code, strlen(u8"const "), u8"x")),
+            ERROR_TYPE_FIELD(
+                error_missing_semicolon_after_statement, where,
+                offsets_matcher(&code, end_of_const_statement, u8""))));
   }
 }
 

--- a/test/test-parse-var.cpp
+++ b/test/test-parse-var.cpp
@@ -86,16 +86,13 @@ TEST(test_parse, parse_simple_var) {
 
 TEST(test_parse, parse_simple_const) {
   spy_visitor v;
-  padded_string code(u8"const x"_sv);
+  padded_string code(u8"const x = null"_sv);
   parser p(&code, &v);
   EXPECT_TRUE(p.parse_and_visit_statement(v));
   ASSERT_EQ(v.variable_declarations.size(), 1);
   EXPECT_EQ(v.variable_declarations[0].name, u8"x");
   EXPECT_EQ(v.variable_declarations[0].kind, variable_kind::_const);
-  EXPECT_THAT(v.errors,
-              ElementsAre(ERROR_TYPE_FIELD(
-                  error_missing_initializer_in_const_declaration, variable_name,
-                  offsets_matcher(&code, strlen(u8"const "), u8"x"))));
+  EXPECT_THAT(v.errors, IsEmpty());
 }
 
 TEST(test_parse, let_asi) {

--- a/test/test-parse-var.cpp
+++ b/test/test-parse-var.cpp
@@ -866,24 +866,18 @@ TEST(test_parse, report_missing_semicolon_for_declarations) {
   }
   {
     spy_visitor v;
-    padded_string code(u8"const x debugger"_sv);
+    padded_string code(u8"let x debugger"_sv);
     parser p(&code, &v);
     EXPECT_TRUE(p.parse_and_visit_statement(v));
     EXPECT_TRUE(p.parse_and_visit_statement(v));
     EXPECT_THAT(v.variable_declarations,
                 ElementsAre(spy_visitor::visited_variable_declaration{
-                    u8"x", variable_kind::_const}));
-    cli_source_position::offset_type end_of_const_statement =
-        strlen(u8"const x");
-    EXPECT_THAT(
-        v.errors,
-        ElementsAre(
-            ERROR_TYPE_FIELD(error_missing_initializer_in_const_declaration,
-                             variable_name,
-                             offsets_matcher(&code, strlen(u8"const "), u8"x")),
-            ERROR_TYPE_FIELD(
-                error_missing_semicolon_after_statement, where,
-                offsets_matcher(&code, end_of_const_statement, u8""))));
+                    u8"x", variable_kind::_let}));
+    cli_source_position::offset_type end_of_const_statement = strlen(u8"let x");
+    EXPECT_THAT(v.errors,
+                ElementsAre(ERROR_TYPE_FIELD(
+                    error_missing_semicolon_after_statement, where,
+                    offsets_matcher(&code, end_of_const_statement, u8""))));
   }
 }
 

--- a/test/test-parse-var.cpp
+++ b/test/test-parse-var.cpp
@@ -95,6 +95,20 @@ TEST(test_parse, parse_simple_const) {
   EXPECT_THAT(v.errors, IsEmpty());
 }
 
+TEST(test_parse, parse_const_with_no_initializers) {
+  spy_visitor v;
+  padded_string code(u8"const x;"_sv);
+  parser p(&code, &v);
+  EXPECT_TRUE(p.parse_and_visit_statement(v));
+  ASSERT_EQ(v.variable_declarations.size(), 1);
+  EXPECT_EQ(v.variable_declarations[0].name, u8"x");
+  EXPECT_EQ(v.variable_declarations[0].kind, variable_kind::_const);
+  EXPECT_THAT(v.errors,
+              ElementsAre(ERROR_TYPE_FIELD(
+                  error_missing_initializer_in_const_declaration, variable_name,
+                  offsets_matcher(&code, strlen(u8"const "), u8"x"))));
+}
+
 TEST(test_parse, let_asi) {
   {
     spy_visitor v = parse_and_visit_module(u8"let x\ny"_sv);

--- a/test/test-parse-var.cpp
+++ b/test/test-parse-var.cpp
@@ -873,11 +873,11 @@ TEST(test_parse, report_missing_semicolon_for_declarations) {
     EXPECT_THAT(v.variable_declarations,
                 ElementsAre(spy_visitor::visited_variable_declaration{
                     u8"x", variable_kind::_let}));
-    cli_source_position::offset_type end_of_const_statement = strlen(u8"let x");
+    cli_source_position::offset_type end_of_let_statement = strlen(u8"let x");
     EXPECT_THAT(v.errors,
                 ElementsAre(ERROR_TYPE_FIELD(
                     error_missing_semicolon_after_statement, where,
-                    offsets_matcher(&code, end_of_const_statement, u8""))));
+                    offsets_matcher(&code, end_of_let_statement, u8""))));
   }
 }
 


### PR DESCRIPTION
The following code:

    const x;

Should report error_missing_initializer_in_const_declaration

Fix: #252 