### PR TITLE
Disallow labels named 'await' in async functions

### DIFF
--- a/docs/errors/E206.md
+++ b/docs/errors/E206.md
@@ -1,0 +1,21 @@
+# E206: error label named await not allowed in async function
+
+The following code is using label named 'await' in an async
+function.
+
+    async function f() {
+      await:
+    }
+
+To fix this error, rename label await to something else.
+
+    async function f() {
+      label:
+    }
+
+Another way to fix this error, make 'f' a normal function
+rather than an async function.
+
+    function f() {
+      await:
+    }

--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -521,16 +521,6 @@
              await))                                                           \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
-      error_label_named_yield_not_allowed_in_generator_function, "E207",       \
-      {                                                                        \
-        source_code_span yield;                                                \
-        source_code_span colon;                                                \
-      },                                                                       \
-      .error(QLJS_TRANSLATABLE(                                                \
-                 "label named 'yield' not allowed in generator function"),     \
-             yield))                                                           \
-                                                                               \
-  QLJS_ERROR_TYPE(                                                             \
       error_legacy_octal_literal_may_not_be_big_int, "E032",                   \
       { source_code_span characters; },                                        \
       .error(QLJS_TRANSLATABLE("legacy octal literal may not be BigInt"),      \

--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -511,6 +511,26 @@
              escape_sequence))                                                 \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
+      error_label_named_await_not_allowed_in_async_function, "E206",           \
+      {                                                                        \
+        source_code_span await;                                                \
+        source_code_span colon;                                                \
+      },                                                                       \
+      .error(QLJS_TRANSLATABLE(                                                \
+                 "label named 'await' not allowed in async function"),         \
+             await))                                                           \
+                                                                               \
+  QLJS_ERROR_TYPE(                                                             \
+      error_label_named_yield_not_allowed_in_generator_function, "E207",       \
+      {                                                                        \
+        source_code_span yield;                                                \
+        source_code_span colon;                                                \
+      },                                                                       \
+      .error(QLJS_TRANSLATABLE(                                                \
+                 "label named 'yield' not allowed in generator function"),     \
+             yield))                                                           \
+                                                                               \
+  QLJS_ERROR_TYPE(                                                             \
       error_legacy_octal_literal_may_not_be_big_int, "E032",                   \
       { source_code_span characters; },                                        \
       .error(QLJS_TRANSLATABLE("legacy octal literal may not be BigInt"),      \

--- a/src/quick-lint-js/parse.h
+++ b/src/quick-lint-js/parse.h
@@ -372,6 +372,9 @@ class parser {
       this->skip();
       if (this->peek().type == token_type::colon) {
         // Labelled statement.
+        this->error_reporter_->report(
+            error_label_named_await_not_allowed_in_async_function{
+                .await = await_token.span(), .colon = this->peek().span()});
         this->skip();
         goto parse_statement;
       } else {
@@ -389,6 +392,15 @@ class parser {
     // yield: for(;;);
     case token_type::kw_yield:
       if (this->in_generator_function_) {
+        source_code_span yield_span = this->peek().span();
+        lexer_transaction transaction = this->lexer_.begin_transaction();
+        this->skip();
+        if (this->peek().type == token_type::colon) {
+          this->error_reporter_->report(
+              error_label_named_yield_not_allowed_in_generator_function{
+                  .yield = yield_span, .colon = this->peek().span()});
+        }
+        this->lexer_.roll_back_transaction(std::move(transaction));
         this->parse_and_visit_expression(v);
         parse_expression_end();
         break;

--- a/src/quick-lint-js/parse.h
+++ b/src/quick-lint-js/parse.h
@@ -392,15 +392,6 @@ class parser {
     // yield: for(;;);
     case token_type::kw_yield:
       if (this->in_generator_function_) {
-        source_code_span yield_span = this->peek().span();
-        lexer_transaction transaction = this->lexer_.begin_transaction();
-        this->skip();
-        if (this->peek().type == token_type::colon) {
-          this->error_reporter_->report(
-              error_label_named_yield_not_allowed_in_generator_function{
-                  .yield = yield_span, .colon = this->peek().span()});
-        }
-        this->lexer_.roll_back_transaction(std::move(transaction));
         this->parse_and_visit_expression(v);
         parse_expression_end();
         break;

--- a/src/quick-lint-js/parse.h
+++ b/src/quick-lint-js/parse.h
@@ -372,9 +372,11 @@ class parser {
       this->skip();
       if (this->peek().type == token_type::colon) {
         // Labelled statement.
-        this->error_reporter_->report(
-            error_label_named_await_not_allowed_in_async_function{
-                .await = await_token.span(), .colon = this->peek().span()});
+        if (this->in_async_function_) {
+          this->error_reporter_->report(
+              error_label_named_await_not_allowed_in_async_function{
+                  .await = await_token.span(), .colon = this->peek().span()});
+        }
         this->skip();
         goto parse_statement;
       } else {

--- a/test/test-parse-statement.cpp
+++ b/test/test-parse-statement.cpp
@@ -994,9 +994,9 @@ TEST(test_parse, disallow_label_named_await_in_async_function) {
   padded_string code(u8"async function f() {\nawait:\n}"_sv);
   parser p(&code, &v);
   EXPECT_TRUE(p.parse_and_visit_statement(v));
-  EXPECT_THAT(v.visits, ElementsAre("visit_variable_declaration",  // f
-                                    "visit_enter_function_scope",
-                                    "visit_enter_function_scope_body",
+  EXPECT_THAT(v.visits, ElementsAre("visit_variable_declaration",       // f
+                                    "visit_enter_function_scope",       //
+                                    "visit_enter_function_scope_body",  //
                                     "visit_exit_function_scope"));
   EXPECT_THAT(
       v.errors,

--- a/test/test-parse-statement.cpp
+++ b/test/test-parse-statement.cpp
@@ -1008,6 +1008,27 @@ TEST(test_parse, disallow_label_named_await_in_async_function) {
                           u8":"))));
 }
 
+TEST(test_parse, disallow_label_named_yield_in_generator_function) {
+  spy_visitor v;
+  padded_string code(u8"function *f() {yield:}"_sv);
+  parser p(&code, &v);
+  EXPECT_TRUE(p.parse_and_visit_statement(v));
+  EXPECT_THAT(v.visits, ElementsAre("visit_variable_declaration",       // f
+                                    "visit_enter_function_scope",       //
+                                    "visit_enter_function_scope_body",  //
+                                    "visit_exit_function_scope"));
+  EXPECT_THAT(
+      v.errors,
+      ElementsAre(
+          ERROR_TYPE_FIELD(
+              error_missing_semicolon_after_statement, where,
+              offsets_matcher(&code, strlen(u8"function *f() {yield"), u8"")),
+          ERROR_TYPE_FIELD(
+              error_unexpected_token, token,
+              offsets_matcher(&code, strlen(u8"function *f() {yield"),
+                              u8":"))));
+}
+
 TEST(test_parse, enum_statement_not_yet_implemented) {
   {
     spy_visitor v;

--- a/test/test-parse-statement.cpp
+++ b/test/test-parse-statement.cpp
@@ -991,7 +991,7 @@ TEST(test_parse, statement_label_can_be_a_contextual_keyword) {
 
 TEST(test_parse, disallow_label_named_await_in_async_function) {
   spy_visitor v;
-  padded_string code(u8"async function f() {\nawait:\n}"_sv);
+  padded_string code(u8"async function f() {await:}"_sv);
   parser p(&code, &v);
   EXPECT_TRUE(p.parse_and_visit_statement(v));
   EXPECT_THAT(v.visits, ElementsAre("visit_variable_declaration",       // f
@@ -1002,9 +1002,9 @@ TEST(test_parse, disallow_label_named_await_in_async_function) {
       v.errors,
       ElementsAre(ERROR_TYPE_2_FIELDS(
           error_label_named_await_not_allowed_in_async_function, await,
-          offsets_matcher(&code, strlen(u8"async function f() {\n"), u8"await"),
+          offsets_matcher(&code, strlen(u8"async function f() {"), u8"await"),
           colon,
-          offsets_matcher(&code, strlen(u8"async function f() {\nawait"),
+          offsets_matcher(&code, strlen(u8"async function f() {await"),
                           u8":"))));
 }
 

--- a/test/test-parse-statement.cpp
+++ b/test/test-parse-statement.cpp
@@ -1008,33 +1008,6 @@ TEST(test_parse, disallow_label_named_await_in_async_function) {
                           u8":"))));
 }
 
-TEST(test_parse, disallow_label_named_yield_in_generator_function) {
-  spy_visitor v;
-  padded_string code(u8"function *f() {\nyield:\n}"_sv);
-  parser p(&code, &v);
-  EXPECT_TRUE(p.parse_and_visit_statement(v));
-  EXPECT_THAT(v.visits, ElementsAre("visit_variable_declaration",  // f
-                                    "visit_enter_function_scope",
-                                    "visit_enter_function_scope_body",
-                                    "visit_exit_function_scope"));
-  EXPECT_THAT(
-      v.errors,
-      ElementsAre(
-          ERROR_TYPE_2_FIELDS(
-              error_label_named_yield_not_allowed_in_generator_function, yield,
-              offsets_matcher(&code, strlen(u8"function *f() {\n"), u8"yield"),
-              colon,
-              offsets_matcher(&code, strlen(u8"function *f() {\nyield"),
-                              u8":")),
-          ERROR_TYPE_FIELD(
-              error_missing_semicolon_after_statement, where,
-              offsets_matcher(&code, strlen(u8"function *f() {\nyield"), u8"")),
-          ERROR_TYPE_FIELD(
-              error_unexpected_token, token,
-              offsets_matcher(&code, strlen(u8"function *f() {\nyield"),
-                              u8":"))));
-}
-
 TEST(test_parse, enum_statement_not_yet_implemented) {
   {
     spy_visitor v;


### PR DESCRIPTION
The following code:

    async function f() {
      await:
    }

Should report error_label_named_await_not_allowed_in_async_function.

Fix: #214 