### PR TITLE
Improve error message for '#foo = bar;'

### DIFF
--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -863,6 +863,7 @@ next:
     case expression_kind::index:
     case expression_kind::object:
     case expression_kind::variable:
+    case expression_kind::private_variable:
       break;
     }
     expression* rhs = this->parse_expression(

--- a/test/test-parse-expression.cpp
+++ b/test/test-parse-expression.cpp
@@ -189,6 +189,19 @@ TEST_F(test_parse_expression, private_identifiers_are_not_valid_expressions) {
     EXPECT_EQ(p.range(ast).begin_offset(), 0);
     EXPECT_EQ(p.range(ast).end_offset(), strlen(u8"#myPrivateField"));
   }
+
+  {
+    test_parser p(u8"#myPrivateField = 10"_sv);
+    expression* ast = p.parse_expression();
+    EXPECT_EQ(ast->kind(), expression_kind::assignment);
+    EXPECT_THAT(p.errors(),
+                ElementsAre(ERROR_TYPE_FIELD(
+                    error_cannot_refer_to_private_variable_without_object,
+                    private_identifier,
+                    offsets_matcher(p.code(), 0, u8"#myPrivateField"))));
+    EXPECT_EQ(p.range(ast).begin_offset(), 0);
+    EXPECT_EQ(p.range(ast).end_offset(), strlen(u8"#myPrivateField = 10"));
+  }
 }
 
 TEST_F(test_parse_expression, parse_regular_expression) {


### PR DESCRIPTION
The following code:

    #myvar = 42;

Should only a produce single error, error_cannot_refer_to_private_variable_without_object