### PR TITLE
fix apt update notice

### DIFF
--- a/website/public/install/index.ejs.html
+++ b/website/public/install/index.ejs.html
@@ -1031,7 +1031,7 @@
         <p>Open a terminal, and run the following commands:</p>
         <blockquote>
           <pre><code><kbd>curl https://c.quick-lint-js.com/quick-lint-js-release.key | sudo apt-key add -</kbd>
-<span class="long-shell-command-line"><kbd>printf '\n# https://quick-lint-js.com/install/#debian\ndeb https://c.quick-lint-js.com/debian experimental main\n' | sudo tee -a /etc/apt/sources.list.d/quick-lint-js.list</kbd></span>
+<span class="long-shell-command-line"><kbd>printf '\n# https://quick-lint-js.com/install/#debian\ndeb [arch=amd64] https://c.quick-lint-js.com/debian experimental main\n' | sudo tee -a /etc/apt/sources.list.d/quick-lint-js.list</kbd></span>
 <kbd>sudo apt-get update</kbd>
 
 # <img class="install-logo" src="../gnome-terminal.svg" alt="" /> CLI and LSP server


### PR DESCRIPTION
It seems that the warning is due to apt trying to grab packages for
unsupported architecture. Fixed by making it default to amd64. #149 