### PR TITLE
7$: Error with nice message when trying to use TypeScript-style const fields

### DIFF
--- a/docs/errors/E165.md
+++ b/docs/errors/E165.md
@@ -1,0 +1,13 @@
+# E165: TypeScript style const field 
+
+`const` fields are only allowed in TypeScript, not JavaScript
+
+    class C {
+      const f = null;
+    } 
+
+To fix this error, remove the `const` declarator from the field 
+
+    class C {
+      f = null;
+    } 

--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -1197,11 +1197,9 @@
   QLJS_ERROR_TYPE(                                                             \
       error_typescript_style_const_field, "E165",                              \
       { source_code_span const_token; },                                       \
-      .error(QLJS_TRANSLATABLE(                                                \
-                 "const fields within classes are only "                       \
-                 "allowed in TypeScript, not Javascript"),                     \
+      .error(QLJS_TRANSLATABLE("const fields within classes are only "         \
+                               "allowed in TypeScript, not Javascript"),       \
              const_token))                                                     \
-                                                                               \
                                                                                \
   /* END */
 

--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -1194,6 +1194,15 @@
       .error(QLJS_TRANSLATABLE("continue can only be used inside of a loop"),  \
              continue_statement))                                              \
                                                                                \
+  QLJS_ERROR_TYPE(                                                             \
+      error_typescript_style_const_field, "E165",                              \
+      { source_code_span const_token; },                                       \
+      .error(QLJS_TRANSLATABLE(                                                \
+                 "const fields within classes are only "                       \
+                 "allowed in TypeScript, not Javascript"),                     \
+             const_token))                                                     \
+                                                                               \
+                                                                               \
   /* END */
 
 namespace quick_lint_js {

--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -1198,7 +1198,7 @@
       error_typescript_style_const_field, "E165",                              \
       { source_code_span const_token; },                                       \
       .error(QLJS_TRANSLATABLE("const fields within classes are only "         \
-                               "allowed in TypeScript, not Javascript"),       \
+                               "allowed in TypeScript, not JavaScript"),       \
              const_token))                                                     \
                                                                                \
   /* END */

--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -939,6 +939,13 @@
              enum_keyword))                                                    \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
+      error_typescript_style_const_field, "E165",                              \
+      { source_code_span const_token; },                                       \
+      .error(QLJS_TRANSLATABLE("const fields within classes are only "         \
+                               "allowed in TypeScript, not JavaScript"),       \
+             const_token))                                                     \
+                                                                               \
+  QLJS_ERROR_TYPE(                                                             \
       error_unclosed_block_comment, "E037",                                    \
       { source_code_span comment_open; },                                      \
       .error(QLJS_TRANSLATABLE("unclosed block comment"), comment_open))       \
@@ -1193,13 +1200,6 @@
       { source_code_span continue_statement; },                                \
       .error(QLJS_TRANSLATABLE("continue can only be used inside of a loop"),  \
              continue_statement))                                              \
-                                                                               \
-  QLJS_ERROR_TYPE(                                                             \
-      error_typescript_style_const_field, "E165",                              \
-      { source_code_span const_token; },                                       \
-      .error(QLJS_TRANSLATABLE("const fields within classes are only "         \
-                               "allowed in TypeScript, not JavaScript"),       \
-             const_token))                                                     \
                                                                                \
   /* END */
 

--- a/src/quick-lint-js/parse.h
+++ b/src/quick-lint-js/parse.h
@@ -1538,10 +1538,10 @@ class parser {
           // }
           v.visit_property_declaration(property_name);
         } else {
-            // class C {
-            //   const field
-            // }
-            if ("const" == to_string(property_name_span.string_view())) {
+          // class C {
+          //   const field
+          // }
+          if ("const" == to_string(property_name_span.string_view())) {
             this->error_reporter_->report(error_typescript_style_const_field{
                 .const_token = property_name_span,
             });

--- a/src/quick-lint-js/parse.h
+++ b/src/quick-lint-js/parse.h
@@ -1538,9 +1538,18 @@ class parser {
           // }
           v.visit_property_declaration(property_name);
         } else {
-          this->error_reporter_->report(error_unexpected_token{
-              .token = property_name_span,
-          });
+            // class C {
+            //   const field
+            // }
+            if ("const" == to_string(property_name_span.string_view())) {
+            this->error_reporter_->report(error_typescript_style_const_field{
+                .const_token = property_name_span,
+            });
+          } else {
+            this->error_reporter_->report(error_unexpected_token{
+                .token = property_name_span,
+            });
+          }
         }
         break;
 

--- a/src/quick-lint-js/parse.h
+++ b/src/quick-lint-js/parse.h
@@ -1541,7 +1541,7 @@ class parser {
           // class C {
           //   const field
           // }
-          if ("const" == to_string(property_name_span.string_view())) {
+          if (u8"const" == property_name_span.string_view()) {
             this->error_reporter_->report(error_typescript_style_const_field{
                 .const_token = property_name_span,
             });

--- a/test/test-parse-class.cpp
+++ b/test/test-parse-class.cpp
@@ -1182,6 +1182,21 @@ TEST(test_parse, async_method_prohibits_newline_after_async_keyword) {
     EXPECT_EQ(v.property_declarations[0].name, u8"async");
   }
 }
+TEST(test_parse, typescript_style_const_field) {
+  {
+    spy_visitor v;
+    padded_string code(u8"class C { const f = null }"_sv);
+    parser p(&code, &v);
+    EXPECT_TRUE(p.parse_and_visit_statement(v));
+    EXPECT_THAT(v.property_declarations,
+                ElementsAre(spy_visitor::visited_property_declaration{u8"f"}));
+    EXPECT_THAT(
+        v.errors,
+        ElementsAre(ERROR_TYPE_FIELD(
+            error_typescript_style_const_field, const_token,
+            offsets_matcher(&code, strlen(u8"class C { "), u8"const"))));
+  }
+}
 }
 }
 

--- a/test/test-parse-class.cpp
+++ b/test/test-parse-class.cpp
@@ -1196,6 +1196,19 @@ TEST(test_parse, typescript_style_const_field) {
             error_typescript_style_const_field, const_token,
             offsets_matcher(&code, strlen(u8"class C { "), u8"const"))));
   }
+  {
+    spy_visitor v;
+    padded_string code(u8"class C { const f }"_sv);
+    parser p(&code, &v);
+    EXPECT_TRUE(p.parse_and_visit_statement(v));
+    EXPECT_THAT(v.property_declarations,
+                ElementsAre(spy_visitor::visited_property_declaration{u8"f"}));
+    EXPECT_THAT(
+        v.errors,
+        ElementsAre(ERROR_TYPE_FIELD(
+            error_typescript_style_const_field, const_token,
+            offsets_matcher(&code, strlen(u8"class C { "), u8"const"))));
+  }
 }
 }
 }


### PR DESCRIPTION
- Reporting a `typescript_style_const_error` when a const field is used: 

```
class C {
  const f = null;
}
```

quick-lint-js reported:
```
hello.js:2:3: error: unexpected token [E054]
```

quick-lint-js now reports:
```
a.js:3:3: error: const fields within classes are only allowed in TypeScript, not Javascript [E165]
```


Fixes #235 