### PR TITLE
Report invalid unicode escapes

### DIFF
--- a/docs/errors/E207.md
+++ b/docs/errors/E207.md
@@ -1,11 +1,11 @@
-# E207: error escaped code point in unicode out of range
+# E207: error escaped code point in Unicode out of range
 
-The following code has escaped code point in unicode out of
+The following code has escaped code point in Unicode out of
 range.
 
     let x = "hello\u{abcdef}";
 
-To fix this error, make sure that the escaped code point in
-unicode is less than 10FFFF.
+To fix this error, make sure that the escaped code point is
+between U+0000 and U+10FFFF inclusive.
 
     let x = "hello\u{abcde}";

--- a/docs/errors/E207.md
+++ b/docs/errors/E207.md
@@ -1,4 +1,4 @@
-# E207: error escaped code point in Unicode out of range
+# E207: code point in Unicode escape sequence must not be greater than U+10FFFF
 
 The following code has escaped code point in Unicode out of
 range.

--- a/docs/errors/E207.md
+++ b/docs/errors/E207.md
@@ -1,0 +1,11 @@
+# E207: error escaped code point in unicode out of range
+
+The following code has escaped code point in unicode out of
+range.
+
+    let x = "hello\u{abcdef}";
+
+To fix this error, make sure that the escaped code point in
+unicode is less than 10FFFF.
+
+    let x = "hello\u{abcde}";

--- a/src/lex.cpp
+++ b/src/lex.cpp
@@ -1246,6 +1246,8 @@ const char8* lexer::parse_hex_digits_and_underscores(
       [](char8 character) -> bool { return is_hex_digit(character); }, input);
 }
 
+QLJS_WARNING_PUSH
+QLJS_WARNING_IGNORE_GCC("-Wuseless-cast")
 const char8* lexer::parse_unicode_escape(const char8* input) noexcept {
   const char8* escape_sequence_begin = input;
   auto get_escape_span = [escape_sequence_begin, &input]() {
@@ -1310,6 +1312,7 @@ const char8* lexer::parse_unicode_escape(const char8* input) noexcept {
   }
   return input;
 }
+QLJS_WARNING_POP
 
 lexer::parsed_identifier lexer::parse_identifier(const char8* input) {
   const char8* identifier_begin = input;

--- a/src/lex.cpp
+++ b/src/lex.cpp
@@ -1248,6 +1248,7 @@ const char8* lexer::parse_hex_digits_and_underscores(
 
 QLJS_WARNING_PUSH
 QLJS_WARNING_IGNORE_GCC("-Wuseless-cast")
+// TODO: factor duplication with parse_identifier_slow
 const char8* lexer::parse_unicode_escape(const char8* input) noexcept {
   const char8* escape_sequence_begin = input;
   auto get_escape_span = [escape_sequence_begin, &input]() {
@@ -1262,6 +1263,9 @@ const char8* lexer::parse_unicode_escape(const char8* input) noexcept {
     bool found_non_hex_digit = false;
     while (*input != u8'}') {
       if (*input == '\0' && this->is_eof(input)) {
+        // TODO: Add an enum to error_unclosed_identifier_escape_sequence to
+        // indicate whether the token is a template literal, a string literal
+        // or an identifier.
         this->error_reporter_->report(error_unclosed_identifier_escape_sequence{
             .escape_sequence = get_escape_span()});
         return input;
@@ -1283,6 +1287,9 @@ const char8* lexer::parse_unicode_escape(const char8* input) noexcept {
     code_point_hex_begin = input;
     for (int i = 0; i < 4; ++i) {
       if (*input == '\0' && this->is_eof(input)) {
+        // TODO: Add an enum to error_unclosed_identifier_escape_sequence to
+        // indicate whether the token is a template literal, a string literal
+        // or an identifier.
         this->error_reporter_->report(error_unclosed_identifier_escape_sequence{
             .escape_sequence = get_escape_span()});
         return input;

--- a/src/lex.cpp
+++ b/src/lex.cpp
@@ -721,6 +721,9 @@ const char8* lexer::parse_string_literal() noexcept {
           }
         }
         break;
+      case 'u':
+        c = this->parse_unicode_escape(escape_sequence_start);
+        break;
       default:
         ++c;
         break;
@@ -773,7 +776,8 @@ lexer::parsed_template_body lexer::parse_template_body(
       ++c;
       return parsed_template_body{token_type::complete_template, c};
 
-    case '\\':
+    case '\\': {
+      const char8* escape_sequence_start = c;
       ++c;
       switch (*c) {
       case '\0':
@@ -785,11 +789,15 @@ lexer::parsed_template_body lexer::parse_template_body(
           ++c;
           break;
         }
+      case 'u':
+        c = this->parse_unicode_escape(escape_sequence_start);
+        break;
       default:
         ++c;
         break;
       }
       break;
+    }
 
     case '$':
       if (c[1] == '{') {
@@ -1236,6 +1244,71 @@ const char8* lexer::parse_hex_digits_and_underscores(
     const char8* input) noexcept {
   return this->parse_digits_and_underscores(
       [](char8 character) -> bool { return is_hex_digit(character); }, input);
+}
+
+const char8* lexer::parse_unicode_escape(const char8* input) noexcept {
+  const char8* escape_sequence_begin = input;
+  auto get_escape_span = [escape_sequence_begin, &input]() {
+    return source_code_span(escape_sequence_begin, input);
+  };
+
+  const char8* code_point_hex_begin;
+  const char8* code_point_hex_end;
+  if (input[2] == u8'{') {
+    code_point_hex_begin = &input[3];
+    input += 3;  // Skip "\u{".
+    bool found_non_hex_digit = false;
+    while (*input != u8'}') {
+      if (*input == '\0' && this->is_eof(input)) {
+        this->error_reporter_->report(error_unclosed_identifier_escape_sequence{
+            .escape_sequence = get_escape_span()});
+        return input;
+      }
+      if (!this->is_hex_digit(*input)) {
+        found_non_hex_digit = true;
+      }
+      ++input;
+    }
+    code_point_hex_end = input;
+    ++input;  // Skip "}".
+    if (found_non_hex_digit || code_point_hex_begin == code_point_hex_end) {
+      this->error_reporter_->report(error_expected_hex_digits_in_unicode_escape{
+          .escape_sequence = get_escape_span()});
+      return input;
+    }
+  } else {
+    input += 2;  // Skip "\u".
+    code_point_hex_begin = input;
+    for (int i = 0; i < 4; ++i) {
+      if (*input == '\0' && this->is_eof(input)) {
+        this->error_reporter_->report(error_unclosed_identifier_escape_sequence{
+            .escape_sequence = get_escape_span()});
+        return input;
+      }
+      if (!this->is_hex_digit(*input)) {
+        this->error_reporter_->report(
+            error_expected_hex_digits_in_unicode_escape{
+                .escape_sequence =
+                    source_code_span(escape_sequence_begin, input + 1)});
+        return input;
+      }
+      ++input;
+    }
+    code_point_hex_end = input;
+  }
+  char32_t code_point;
+  from_chars_result parse_result = from_chars_hex(
+      reinterpret_cast<const char*>(code_point_hex_begin),
+      reinterpret_cast<const char*>(code_point_hex_end), code_point);
+  QLJS_ALWAYS_ASSERT(parse_result.ptr ==
+                     reinterpret_cast<const char*>(code_point_hex_end));
+  if (parse_result.ec == std::errc::result_out_of_range ||
+      code_point >= 0x110000) {
+    this->error_reporter_->report(
+        error_escaped_code_point_in_unicode_out_of_range{
+            .escape_sequence = get_escape_span()});
+  }
+  return input;
 }
 
 lexer::parsed_identifier lexer::parse_identifier(const char8* input) {

--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -238,6 +238,13 @@
       .error(QLJS_TRANSLATABLE("code point out of range"), escape_sequence))   \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
+      error_escaped_code_point_in_unicode_out_of_range, "E207",                \
+      { source_code_span escape_sequence; },                                   \
+      .error(QLJS_TRANSLATABLE("Code point in unicode escape sequence must "   \
+                               "not be greater than 10FFFF"),                  \
+             escape_sequence))                                                 \
+                                                                               \
+  QLJS_ERROR_TYPE(                                                             \
       error_extra_comma_not_allowed_between_arguments, "E068",                 \
       { source_code_span comma; },                                             \
       .error(QLJS_TRANSLATABLE(                                                \

--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -241,7 +241,7 @@
       error_escaped_code_point_in_unicode_out_of_range, "E207",                \
       { source_code_span escape_sequence; },                                   \
       .error(QLJS_TRANSLATABLE("code point in Unicode escape sequence must "   \
-                               "not be greater than U+10FFFF"),                  \
+                               "not be greater than U+10FFFF"),                \
              escape_sequence))                                                 \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \

--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -240,8 +240,8 @@
   QLJS_ERROR_TYPE(                                                             \
       error_escaped_code_point_in_unicode_out_of_range, "E207",                \
       { source_code_span escape_sequence; },                                   \
-      .error(QLJS_TRANSLATABLE("Code point in unicode escape sequence must "   \
-                               "not be greater than 10FFFF"),                  \
+      .error(QLJS_TRANSLATABLE("code point in Unicode escape sequence must "   \
+                               "not be greater than U+10FFFF"),                  \
              escape_sequence))                                                 \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \

--- a/src/quick-lint-js/lex.h
+++ b/src/quick-lint-js/lex.h
@@ -223,6 +223,7 @@ class lexer {
   const char8* parse_decimal_digits_and_underscores(
       const char8* input) noexcept;
   const char8* parse_hex_digits_and_underscores(const char8* input) noexcept;
+  const char8* parse_unicode_escape(const char8* input) noexcept;
 
   parsed_identifier parse_identifier(const char8*);
   parsed_identifier parse_identifier_slow(const char8* input,

--- a/test/test-lex.cpp
+++ b/test/test-lex.cpp
@@ -857,6 +857,8 @@ TEST_F(test_lex, lex_templates) {
 world`)",
       {token_type::complete_template});
   this->check_tokens(u8"`hello\\\nworld`"_sv, {token_type::complete_template});
+  this->check_tokens(u8R"(`\uabcd`)", {token_type::complete_template});
+  this->check_tokens(u8R"(`\u{abcd}`)", {token_type::complete_template});
 
   {
     padded_string code(u8"`hello${42}`"_sv);


### PR DESCRIPTION
The following code:

    let x = "hello\u{abcdefgh}";

Should report `error_escaped_code_point_in_unicode_out_of_range`

Fix: #187