### PR TITLE
collect-copyright: fix crash on Fedora

### DIFF
--- a/tools/collect-copyright
+++ b/tools/collect-copyright
@@ -583,10 +583,17 @@ class RedHat:
         return packages
 
     def get_copyright(self, package: InstalledPackage) -> str:
-        raw_text = (
-            pathlib.Path("/usr/share/licenses") / package.source / "LICENSES"
-        ).read_text()
-        return raw_text.replace("\x0C", "\n---\n")
+        error = None
+        for file_name in ("LICENSES", "LICENSE.TXT"):
+            try:
+                raw_text = (
+                    pathlib.Path("/usr/share/licenses") / package.source / file_name
+                ).read_text()
+                return raw_text.replace("\x0C", "\n---\n")
+            except FileNotFoundError as e:
+                error = e
+        assert error is not None
+        raise error
 
     @staticmethod
     def _rpm_package_for_installed_file(file_path: str) -> str:


### PR DESCRIPTION
When building quick-lint-js with Address Sanitizer, generating copyright
information fails:

    [57/57] Generating quick-lint-js-licenses.txt
    FAILED: src/quick-lint-js-licenses.txt
    cd /home/strager/quick-lint-js/build-fuzz/src && /usr/bin/python3 /home/strager/quick-lint-js/cmake/../tools/collect-copyright --linkmap /home/strager/quick-lint-js/build-fuzz/src/quick-lint-js.trace >"/home/strager/quick-lint-js/build-fuzz/src/quick-lint-js-licenses.txt"
    Traceback (most recent call last):
      File "/home/strager/quick-lint-js/cmake/../tools/collect-copyright", line 916, in <module>
        main()
      File "/home/strager/quick-lint-js/cmake/../tools/collect-copyright", line 87, in main
        dump_from_linkmap(
      File "/home/strager/quick-lint-js/cmake/../tools/collect-copyright", line 115, in dump_from_linkmap
        dump_from_system_archives(
      File "/home/strager/quick-lint-js/cmake/../tools/collect-copyright", line 245, in dump_from_system_archives
        copyright = system_package_manager.get_copyright(p)
      File "/home/strager/quick-lint-js/cmake/../tools/collect-copyright", line 586, in get_copyright
        raw_text = (
      File "/usr/lib64/python3.9/pathlib.py", line 1255, in read_text
        with self.open(mode='r', encoding=encoding, errors=errors) as f:
      File "/usr/lib64/python3.9/pathlib.py", line 1241, in open
        return io.open(self, mode, buffering, encoding, errors, newline,
      File "/usr/lib64/python3.9/pathlib.py", line 1109, in _opener
        return self._accessor.open(self, flags, mode)
    FileNotFoundError: [Errno 2] No such file or directory: '/usr/share/licenses/compiler-rt/LICENSES'
    ninja: build stopped: subcommand failed.

This is because the license file for Fedora's compiler-rt is called
LICENSE.TXT, not LICENSES.

Fix collect-copyrights to search for both possible file names (LICENSES
and LICENSE.TXT) to account for inconsistencies between Fedora packages.