### PR TITLE
Report error on use of this.#x outside of class

### DIFF
--- a/docs/errors/E208.md
+++ b/docs/errors/E208.md
@@ -7,16 +7,17 @@ the class.
         #x = 10;
     }
 
-    function f() {
-      this.#x = 20;
+    function f(c) {
+      c.#x = 20;
     }
 
-To fix this error, move function `f` as a member of class `C`.
+To fix this error, move function `f` as a static member of
+class `C` .
 
     class C {
         #x = 10;
-        f() {
-          this.#x = 20;
+        static f(c) {
+          c.#x = 20;
         }
     }
 
@@ -24,9 +25,9 @@ Another way to fix this error, remove `#` before variable
 `x`.
 
     class C {
-        #x = 10;
+        x = 10;
     }
 
-    function f() {
-      this.x = 20;
+    function f(c) {
+      c.x = 20;
     }

--- a/docs/errors/E208.md
+++ b/docs/errors/E208.md
@@ -1,0 +1,32 @@
+# E208: cannot access private identifier outside class
+
+The following code is accessing a private identifier outside
+the class.
+
+    class C {
+        #x = 10;
+    }
+
+    function f() {
+      this.#x = 20;
+    }
+
+To fix this error, move function `f` as a member of class `C`.
+
+    class C {
+        #x = 10;
+        f() {
+          this.#x = 20;
+        }
+    }
+
+Another way to fix this error, remove `#` before variable
+`x`.
+
+    class C {
+        #x = 10;
+    }
+
+    function f() {
+      this.x = 20;
+    }

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -374,6 +374,7 @@ expression* parser::parse_primary_expression(precedence prec) {
 
   // class {}
   case token_type::kw_class: {
+    class_guard g(this, std::exchange(this->in_class_, true));
     expression* class_expression = this->parse_class_expression();
     return class_expression;
   }

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -374,7 +374,6 @@ expression* parser::parse_primary_expression(precedence prec) {
 
   // class {}
   case token_type::kw_class: {
-    class_guard g(this, std::exchange(this->in_class_, true));
     expression* class_expression = this->parse_class_expression();
     return class_expression;
   }

--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -95,6 +95,13 @@
              expected_last_component))                                         \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
+      error_cannot_access_private_identifier_outside_class, "E208",            \
+      { identifier private_identifier; },                                      \
+      .error(                                                                  \
+          QLJS_TRANSLATABLE("cannot access private identifier outside class"), \
+          private_identifier))                                                 \
+                                                                               \
+  QLJS_ERROR_TYPE(                                                             \
       error_cannot_assign_to_variable_named_async_in_for_of_loop, "E082",      \
       { identifier async_identifier; },                                        \
       .error(                                                                  \

--- a/src/quick-lint-js/parse.h
+++ b/src/quick-lint-js/parse.h
@@ -438,11 +438,13 @@ class parser {
       goto parse_loop_label_or_expression_starting_with_identifier;
 
     // class C {}
-    case token_type::kw_class:
+    case token_type::kw_class: {
+      class_guard g(this, std::exchange(this->in_class_, true));
       this->parse_and_visit_class(
           v,
           /*require_name=*/name_requirement::required_for_statement);
       break;
+    }
 
     // switch (x) { default: ; }
     case token_type::kw_switch: {
@@ -3577,6 +3579,7 @@ class parser {
   bool in_generator_function_ = false;
   bool in_loop_statement_ = false;
   bool in_switch_statement_ = false;
+  bool in_class_ = false;
 
 #if QLJS_HAVE_SETJMP
   bool have_fatal_parse_error_jmp_buf_ = false;
@@ -3587,11 +3590,13 @@ class parser {
 
   using loop_guard = bool_guard<&parser::in_loop_statement_>;
   using switch_guard = bool_guard<&parser::in_switch_statement_>;
+  using class_guard = bool_guard<&parser::in_class_>;
 
  public:
   static constexpr const int stack_limit = 150;
   // For testing and internal use only.
   [[nodiscard]] loop_guard enter_loop();
+  [[nodiscard]] class_guard enter_class();
 };
 }
 

--- a/src/quick-lint-js/parse.h
+++ b/src/quick-lint-js/parse.h
@@ -439,7 +439,6 @@ class parser {
 
     // class C {}
     case token_type::kw_class: {
-      class_guard g(this, std::exchange(this->in_class_, true));
       this->parse_and_visit_class(
           v,
           /*require_name=*/name_requirement::required_for_statement);
@@ -1456,6 +1455,7 @@ class parser {
 
   template <QLJS_PARSE_VISITOR Visitor>
   void parse_and_visit_class_body(Visitor &v) {
+    class_guard g(this, std::exchange(this->in_class_, true));
     while (this->peek().type != token_type::right_curly) {
       this->parse_and_visit_class_member(v);
     }

--- a/test/test-parse-class.cpp
+++ b/test/test-parse-class.cpp
@@ -771,6 +771,20 @@ TEST(test_parse, class_expression) {
                                       "visit_variable_use",       // C
                                       "visit_exit_class_scope"));
   }
+
+  {
+    spy_visitor v =
+        parse_and_visit_statement(u8"(class C {#x = 10; m() {this.#x;}})"_sv);
+    EXPECT_THAT(v.visits, ElementsAre("visit_enter_class_scope",
+                                      "visit_variable_declaration",       // C
+                                      "visit_property_declaration",       // x
+                                      "visit_property_declaration",       // m
+                                      "visit_enter_function_scope",       //
+                                      "visit_enter_function_scope_body",  //
+                                      "visit_exit_function_scope",        //
+                                      "visit_exit_class_scope"));
+    EXPECT_THAT(v.errors, IsEmpty());
+  }
 }
 
 TEST(test_parse, class_statement_allows_stray_semicolons) {

--- a/test/test-parse-class.cpp
+++ b/test/test-parse-class.cpp
@@ -381,6 +381,17 @@ TEST(test_parse, class_statement_with_fields) {
   }
 
   {
+    spy_visitor v = parse_and_visit_statement(
+        u8"class C { #prop = init;\nf() {this.#prop;} }");
+    EXPECT_THAT(
+        v.property_declarations,
+        ElementsAre(spy_visitor::visited_property_declaration{u8"#prop"},
+                    spy_visitor::visited_property_declaration{u8"f"}));
+    EXPECT_THAT(v.variable_uses,
+                ElementsAre(spy_visitor::visited_variable_use{u8"init"}));
+  }
+
+  {
     // ASI after field name before private identifier.
     spy_visitor v = parse_and_visit_statement(u8"class C { #first\n#second }");
     EXPECT_THAT(

--- a/test/test-parse-expression-statement.cpp
+++ b/test/test-parse-expression-statement.cpp
@@ -795,6 +795,23 @@ TEST(test_parse, expression_statement) {
   }
 }
 
+TEST(test_parse, cannot_reference_private_identifier_outside_class) {
+  {
+    padded_string code(u8"this.#x = 10;"_sv);
+    spy_visitor v;
+    parser p(&code, &v);
+    EXPECT_TRUE(p.parse_and_visit_statement(v));
+    EXPECT_THAT(v.variable_uses, IsEmpty());
+    EXPECT_THAT(v.visits, IsEmpty());
+
+    EXPECT_THAT(v.errors,
+                ElementsAre(ERROR_TYPE_FIELD(
+                    error_cannot_access_private_identifier_outside_class,
+                    private_identifier,
+                    offsets_matcher(&code, strlen(u8"this."), u8"#x"))));
+  }
+}
+
 TEST(test_parse, asi_plusplus_minusminus) {
   {
     spy_visitor v;

--- a/test/test-parse-expression.cpp
+++ b/test/test-parse-expression.cpp
@@ -689,7 +689,11 @@ TEST_F(test_parse_expression, parse_dot_expressions) {
   }
 
   {
-    expression* ast = this->parse_expression(u8"x.#private"_sv);
+    spy_visitor v;
+    padded_string code(u8"x.#private"_sv);
+    parser p(&code, &v);
+    auto class_guard = p.enter_class();  // Allow to call private identifiers.
+    expression* ast = p.parse_expression();
     EXPECT_EQ(summarize(ast), "dot(var x, #private)");
   }
 }


### PR DESCRIPTION
The following code:

    this.#x;

Should report `error_cannot_access_private_identifier_outside_class`.

Fix: #219 