### PR TITLE
Fix print formatting for property declaration for --debug-parser-visits

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -237,7 +237,7 @@ class debug_visitor {
   void visit_property_declaration(std::optional<identifier> name) {
     std::cerr << "property declaration";
     if (name.has_value()) {
-      std::cerr << out_string8(name->normalized_name());
+      std::cerr << ": " << out_string8(name->normalized_name());
     }
     std::cerr << '\n';
   }


### PR DESCRIPTION
Previously there was no ": " in between "property declaration" and the name of the property, this PR fixes the formatting issue.