### PR TITLE
update emacs plugins error parsing

### DIFF
--- a/completions/_quick-lint-js
+++ b/completions/_quick-lint-js
@@ -21,14 +21,14 @@ function _quick-lint-js() {
         '(--lsp-server)--config-file=[Read configuration from a JSON file for later input files]:file:_files'
         '(--lsp-server)--stdin[Read standard input as a JavaScript file]'
         '(--lsp-server)--exit-fail-on=[Fail with a non-zero exit code if any of these errors are found (default\: "all")]'
-        '(--lsp-server)--output-format=[Format to print feedback where FORMAT is one of\: gnu-like (default if omitted), vim-qflist-json]:format:->format'
+        '(--lsp-server)--output-format=[Format to print feedback where FORMAT is one of\: gnu-like (default if omitted), vim-qflist-json, emacs-lisp]:format:->format'
         '--vim-file-bufnr=[Select a vim buffer for outputting feedback]')
 
         _arguments -C -S "${args[@]}" && ret=0
 
         case "$state" in
                 format)
-                        formats=( 'vim-qflist-json' 'gnu-like' )
+                        formats=( 'vim-qflist-json' 'gnu-like' 'emacs-lisp')
                         _describe 'format' formats && ret=0
                         ;;
         esac

--- a/completions/quick-lint-js.bash
+++ b/completions/quick-lint-js.bash
@@ -14,7 +14,7 @@ _quick-lint-js () {
                         return
                         ;;
                 --output-format=*)
-                        COMPREPLY=($(compgen -W 'gnu-like vim-qflist-json' -- "${cur#*=}"))
+                        COMPREPLY=($(compgen -W 'gnu-like vim-qflist-json emacs-lisp' -- "${cur#*=}"))
                         return
                         ;;
                 --exit-fail-on=*|--vim-file-bufnr=*)

--- a/completions/quick-lint-js.fish
+++ b/completions/quick-lint-js.fish
@@ -7,7 +7,7 @@ complete -c quick-lint-js -l lsp-server -d 'Run quick-lint-js in LSP server mode
 complete -c quick-lint-js -l config-file -d 'Read configuration from a JSON file for later input files' -r
 complete -c quick-lint-js -l stdin -d 'Read standard input as a JavaScript file' -r
 complete -c quick-lint-js -l exit-fail-on -d 'Fail with a non-zero exit code if any of these errors are found (default: "all")' -r
-complete -c quick-lint-js -l output-format -d 'Format to print feedback where FORMAT is one of: gnu-like (default if omitted), vim-qflist-json' -xa 'gnu-like vim-qflist-json'
+complete -c quick-lint-js -l output-format -d 'Format to print feedback where FORMAT is one of: gnu-like (default if omitted), vim-qflist-json, emacs-lisp' -xa 'gnu-like vim-qflist-json'
 complete -c quick-lint-js -l vim-file-bufnr -d 'Select a vim buffer for outputting feedback' -r
 
 # quick-lint-js finds bugs in JavaScript programs.

--- a/docs/cli.adoc
+++ b/docs/cli.adoc
@@ -42,6 +42,7 @@ This command has two modes:
 --
 - *gnu-like* (default): a human-readable format similar to GCC.
 - *vim-qflist-json*: machine-readable JSON which can be given to Vim's _setqflist_ function.
+- *emacs-lisp*: Emacs Lisp association list format.
 
 Incompatible with *--lsp-server*.
 --

--- a/plugin/emacs/test/quicklintjs-test.el
+++ b/plugin/emacs/test/quicklintjs-test.el
@@ -19,7 +19,7 @@
   (setq package-user-dir cache-dir-name
         package-check-signature nil)
   (add-to-list 'package-archives
-               '("MELPA" . "https://stable.melpa.org/packages/"))
+               '("MELPA" . "https://melpa.org/packages/"))
   (package-initialize)
 
   (unless package-archive-contents
@@ -92,7 +92,8 @@ foobar\")((16 . 22) 2 \"E057\" \"use of undeclared variable: foobar\")(\
   (ert-deftest quicklintjs-is-in-eglot-servers ()
     (skip-unless (>= emacs-major-version 26))
     (require 'eglot-quicklintjs)
-    (should (member '(js-mode "quick-lint-js" "--lsp-server")  eglot-server-programs))))
+    (should (member '(js-mode "quick-lint-js" "--lsp-server")
+                    eglot-server-programs))))
 
 (defun def-lsp-tests ()
   (ert-deftest quicklintjs-is-in-lsp-clients ()
@@ -109,26 +110,31 @@ foobar\")((16 . 22) 2 \"E057\" \"use of undeclared variable: foobar\")(\
     (should (member 'javascript-quicklintjs flycheck-checkers)))
 
   (flycheck-ert-def-checker-test
-   javascript-quicklintjs javascript error
+   javascript-quicklintjs javascript error-file-checks
    (let ((flycheck-checker 'javascript-quicklintjs)
-         (inhibit-message t))
+         (inhibit-message 't))
      (flycheck-ert-should-syntax-check
-      "test/error.js" '(js-mode)
+      "test/error.js" 'js-mode
       '(1 1 error "missing name in function statement"
-          :id "E061" :checker javascript-quicklintjs)
+          :id "E061" :checker javascript-quicklintjs
+          :end-line 1 :end-column 10)
       '(1 12 error "unclosed code block; expected '}' by end of file"
-          :id "E134" :checker javascript-quicklintjs)
-      '(2 7 error "unexpected token in variable declaration; expected variable name"
-          :id "E114" :checker javascript-quicklintjs))))
+          :id "E134" :checker javascript-quicklintjs
+          :end-line 1 :end-column 13)
+      '(2 7 error
+          "unexpected token in variable declaration; expected variable name"
+          :id "E114" :checker javascript-quicklintjs
+          :end-line 2 :end-column 10))))
 
   (flycheck-ert-def-checker-test
-   javascript-quicklintjs javascript warning
+   javascript-quicklintjs javascript warning-file-checks
    (let ((flycheck-checker 'javascript-quicklintjs)
-         (inhibit-message t))
+         (inhibit-message 't))
      (flycheck-ert-should-syntax-check
-      "test/warning.js" '(js-mode)
+      "test/warning.js" 'js-mode
       '(1 1 warning "assignment to undeclared variable"
-          :id "E059":checker javascript-quicklintjs)))))
+          :id "E059" :checker javascript-quicklintjs
+          :end-line 1 :end-column 2)))))
 
 ;; quick-lint-js finds bugs in JavaScript programs.
 ;; Copyright (C) 2020  Matthew "strager" Glazar

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,6 +46,8 @@ quick_lint_js_add_library(
   configuration.cpp
   crash.cpp
   document.cpp
+  emacs-lisp-error-reporter.cpp
+  emacs-location.cpp
   error-collector.cpp
   error-formatter.cpp
   error-list.cpp
@@ -89,6 +91,8 @@ quick_lint_js_add_library(
   quick-lint-js/cpp.h
   quick-lint-js/crash.h
   quick-lint-js/document.h
+  quick-lint-js/emacs-lisp-error-reporter.h
+  quick-lint-js/emacs-location.h
   quick-lint-js/error-collector.h
   quick-lint-js/error-formatter.h
   quick-lint-js/error-list.h

--- a/src/emacs-lisp-error-reporter.cpp
+++ b/src/emacs-lisp-error-reporter.cpp
@@ -1,0 +1,104 @@
+// Copyright (C) 2020  Matthew "strager" Glazar
+// See end of file for extended copyright information.
+
+#include <ostream>
+#include <quick-lint-js/char8.h>
+#include <quick-lint-js/emacs-lisp-error-reporter.h>
+#include <quick-lint-js/emacs-location.h>
+#include <quick-lint-js/location.h>
+#include <quick-lint-js/optional.h>
+#include <quick-lint-js/padded-string.h>
+#include <quick-lint-js/token.h>
+
+namespace quick_lint_js {
+emacs_lisp_error_reporter::emacs_lisp_error_reporter(std::ostream &output)
+    : output_(output) {
+  this->output_ << "(";
+}
+
+void emacs_lisp_error_reporter::finish() { this->output_ << ")"; }
+
+void emacs_lisp_error_reporter::set_source(padded_string_view input) {
+  this->locator_.emplace(input);
+}
+
+#define QLJS_ERROR_TYPE(name, code, struct_body, format_call) \
+  void emacs_lisp_error_reporter::report(name e) {            \
+    format_error(e, this->format(code));                      \
+  }
+QLJS_X_ERROR_TYPES
+#undef QLJS_ERROR_TYPE
+
+emacs_lisp_error_formatter emacs_lisp_error_reporter::format(const char *code) {
+  QLJS_ASSERT(this->locator_.has_value());
+  return emacs_lisp_error_formatter(/*output=*/this->output_,
+                                    /*locator=*/*this->locator_,
+                                    /*code=*/code);
+}
+
+emacs_lisp_error_formatter::emacs_lisp_error_formatter(std::ostream &output,
+                                                       emacs_locator &locator,
+                                                       const char *code)
+    : output_(output), locator_(locator), code_(code) {}
+
+void emacs_lisp_error_formatter::write_before_message(
+    severity sev, const source_code_span &origin) {
+  if (sev == severity::note) {
+    return;
+  }
+  emacs_source_range r = this->locator_.range(origin);
+  emacs_source_position::offset_type beg = r.begin().offset;
+  emacs_source_position::offset_type end = r.end().offset;
+  this->output_ << "((" << beg << " . " << end << ") " << static_cast<int>(sev)
+                << " "
+                << "\"" << this->code_ << "\" \"";
+}
+
+namespace {
+void write_elisp_stringp_escaped_message(std::ostream &output,
+                                         string8_view message) {
+  for (const auto &v : message) {
+    switch (v) {
+    case '\\':
+    case '"':
+      output << '\\';
+    }
+    output << static_cast<char>(v);
+  }
+}
+}
+
+void emacs_lisp_error_formatter::write_message_part(severity sev,
+                                                    string8_view message) {
+  if (sev == severity::note) {
+    return;
+  }
+  write_elisp_stringp_escaped_message(this->output_, message);
+}
+
+void emacs_lisp_error_formatter::write_after_message(severity sev,
+                                                     const source_code_span &) {
+  if (sev == severity::note) {
+    return;
+  }
+  this->output_ << "\")";
+}
+}
+
+// quick-lint-js finds bugs in JavaScript programs.
+// Copyright (C) 2020  Matthew "strager" Glazar
+//
+// This file is part of quick-lint-js.
+//
+// quick-lint-js is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// quick-lint-js is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with quick-lint-js.  If not, see <https://www.gnu.org/licenses/>.

--- a/src/emacs-location.cpp
+++ b/src/emacs-location.cpp
@@ -1,0 +1,74 @@
+// Copyright (C) 2020  Matthew "strager" Glazar
+// See end of file for extended copyright information.
+
+#include <algorithm>
+#include <cstddef>
+#include <ostream>
+#include <quick-lint-js/assert.h>
+#include <quick-lint-js/char8.h>
+#include <quick-lint-js/emacs-location.h>
+#include <quick-lint-js/location.h>
+#include <quick-lint-js/narrow-cast.h>
+#include <quick-lint-js/padded-string.h>
+#include <quick-lint-js/utf-8.h>
+
+namespace quick_lint_js {
+std::ostream &operator<<(std::ostream &out, const emacs_source_position &p) {
+  out << "emacs_source_position{" << p.offset << '}';
+  return out;
+}
+
+emacs_source_position emacs_source_range::begin() const noexcept {
+  return this->begin_;
+}
+
+emacs_source_position emacs_source_range::end() const noexcept {
+  return this->end_;
+}
+
+emacs_locator::emacs_locator(padded_string_view input) noexcept
+    : input_(input) {}
+
+emacs_source_range emacs_locator::range(source_code_span span) const {
+  emacs_source_position begin = this->position(span.begin());
+  emacs_source_position end = this->position(span.end());
+  return emacs_source_range(begin, end);
+}
+
+emacs_source_position emacs_locator::position(const char8 *source) const
+    noexcept {
+  emacs_source_position::offset_type offset = this->offset(source);
+  // Emacs point starts at 1
+  return this->position(offset + 1);
+}
+
+emacs_source_position::offset_type emacs_locator::offset(
+    const char8 *source) const noexcept {
+  std::size_t offset = narrow_cast<std::size_t>(source - this->input_.data());
+  return narrow_cast<emacs_source_position::offset_type>(
+      count_utf_8_characters(this->input_, offset));
+}
+
+emacs_source_position emacs_locator::position(
+    emacs_source_position::offset_type offset) const noexcept {
+  return emacs_source_position{offset};
+}
+}
+
+// quick-lint-js finds bugs in JavaScript programs.
+// Copyright (C) 2020  Matthew "strager" Glazar
+//
+// This file is part of quick-lint-js.
+//
+// quick-lint-js is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// quick-lint-js is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with quick-lint-js.  If not, see <https://www.gnu.org/licenses/>.

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -185,6 +185,8 @@ options parse_options(int argc, char** argv) {
         o.output_format = quick_lint_js::output_format::gnu_like;
       } else if (arg_value == "vim-qflist-json"sv) {
         o.output_format = quick_lint_js::output_format::vim_qflist_json;
+      } else if (arg_value == "emacs-lisp"sv) {
+        o.output_format = quick_lint_js::output_format::emacs_lisp;
       } else {
         o.error_unrecognized_options.emplace_back(arg_value);
       }

--- a/src/quick-lint-js/emacs-lisp-error-reporter.h
+++ b/src/quick-lint-js/emacs-lisp-error-reporter.h
@@ -1,0 +1,75 @@
+// Copyright (C) 2020  Matthew "strager" Glazar
+// See end of file for extended copyright information.
+
+#ifndef QUICK_LINT_JS_EMACS_ERROR_REPORTER_H
+#define QUICK_LINT_JS_EMACS_ERROR_REPORTER_H
+
+#include <iosfwd>
+#include <optional>
+#include <quick-lint-js/char8.h>
+#include <quick-lint-js/emacs-location.h>
+#include <quick-lint-js/error-formatter.h>
+#include <quick-lint-js/error.h>
+#include <quick-lint-js/language.h>
+#include <quick-lint-js/location.h>
+#include <quick-lint-js/padded-string.h>
+#include <quick-lint-js/token.h>
+
+namespace quick_lint_js {
+class emacs_lisp_error_formatter;
+
+class emacs_lisp_error_reporter final : public error_reporter {
+ public:
+  explicit emacs_lisp_error_reporter(std::ostream &output);
+
+  void set_source(padded_string_view input);
+  void finish();
+
+#define QLJS_ERROR_TYPE(name, code, struct_body, format) \
+  void report(name) override;
+  QLJS_X_ERROR_TYPES
+#undef QLJS_ERROR_TYPE
+
+ private:
+  emacs_lisp_error_formatter format(const char *code);
+
+  std::ostream &output_;
+  std::optional<emacs_locator> locator_;
+};
+
+class emacs_lisp_error_formatter
+    : public error_formatter<emacs_lisp_error_formatter> {
+ public:
+  explicit emacs_lisp_error_formatter(std::ostream &output,
+                                      emacs_locator &locator, const char *code);
+
+  void write_before_message(severity, const source_code_span &origin);
+  void write_message_part(severity, string8_view);
+  void write_after_message(severity, const source_code_span &origin);
+
+ private:
+  std::ostream &output_;
+  emacs_locator &locator_;
+  const char *code_;
+};
+}
+
+#endif
+
+// quick-lint-js finds bugs in JavaScript programs.
+// Copyright (C) 2020  Matthew "strager" Glazar
+//
+// This file is part of quick-lint-js.
+//
+// quick-lint-js is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// quick-lint-js is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with quick-lint-js.  If not, see <https://www.gnu.org/licenses/>.

--- a/src/quick-lint-js/emacs-location.h
+++ b/src/quick-lint-js/emacs-location.h
@@ -1,0 +1,83 @@
+// Copyright (C) 2020  Matthew "strager" Glazar
+// See end of file for extended copyright information.
+
+#ifndef QUICK_LINT_JS_EMACS_LOCATION_H
+#define QUICK_LINT_JS_EMACS_LOCATION_H
+
+#include <cstddef>
+#include <iosfwd>
+#include <quick-lint-js/char8.h>
+#include <quick-lint-js/location.h>
+#include <quick-lint-js/padded-string.h>
+#include <vector>
+
+namespace quick_lint_js {
+struct emacs_source_position {
+  using offset_type = std::size_t;
+
+  offset_type offset;
+
+  bool operator==(const emacs_source_position& other) const noexcept {
+    return this->offset == other.offset;
+  }
+
+  bool operator!=(const emacs_source_position& other) const noexcept {
+    return !(*this == other);
+  }
+};
+
+std::ostream& operator<<(std::ostream&, const emacs_source_position&);
+
+class emacs_source_range {
+ public:
+  using offset = emacs_source_position::offset_type;
+
+  explicit emacs_source_range(emacs_source_position begin,
+                              emacs_source_position end) noexcept
+      : begin_(begin), end_(end) {}
+
+  offset begin_offset() const noexcept { return this->begin_.offset; }
+  emacs_source_position begin() const noexcept;
+
+  offset end_offset() const noexcept { return this->end_.offset; }
+  emacs_source_position end() const noexcept;
+
+ private:
+  emacs_source_position begin_;
+  emacs_source_position end_;
+};
+
+class emacs_locator {
+ public:
+  explicit emacs_locator(padded_string_view input) noexcept;
+
+  emacs_source_range range(source_code_span) const;
+  emacs_source_position position(const char8*) const noexcept;
+
+ private:
+  emacs_source_position::offset_type offset(const char8*) const noexcept;
+  emacs_source_position position(
+      emacs_source_position::offset_type offset) const noexcept;
+  padded_string_view input_;
+};
+}
+
+#endif
+
+// quick-lint-js finds bugs in JavaScript programs.
+// Copyright (C) 2020  Matthew "strager" Glazar
+//
+// This file is part of quick-lint-js.
+//
+// quick-lint-js is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// quick-lint-js is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with quick-lint-js.  If not, see <https://www.gnu.org/licenses/>.

--- a/src/quick-lint-js/options.h
+++ b/src/quick-lint-js/options.h
@@ -14,6 +14,7 @@ enum class output_format {
   default_format,
   gnu_like,
   vim_qflist_json,
+  emacs_lisp,
 };
 
 struct file_to_lint {

--- a/src/quick-lint-js/utf-8.h
+++ b/src/quick-lint-js/utf-8.h
@@ -18,6 +18,7 @@ struct decode_utf_8_result {
 };
 
 decode_utf_8_result decode_utf_8(padded_string_view) noexcept;
+std::size_t count_utf_8_characters(padded_string_view, std::size_t) noexcept;
 
 const char8* advance_lsp_characters_in_utf_8(string8_view,
                                              int character_count) noexcept;

--- a/src/utf-8.cpp
+++ b/src/utf-8.cpp
@@ -203,6 +203,31 @@ std::ptrdiff_t count_lsp_characters_in_utf_8(padded_string_view utf_8,
   }
   return count;
 }
+
+std::size_t count_utf_8_characters(padded_string_view utf_8,
+                                   std::size_t offset) noexcept {
+  const char8* c = utf_8.data();
+  const char8* end = utf_8.null_terminator();
+  const char8* stop = c + offset;
+  std::size_t count = 0;
+
+  while (c < stop) {
+    auto result = decode_utf_8(padded_string_view(c, end));
+    if (!result.ok) {
+      c++;
+      count += 1;
+      continue;
+    }
+
+    if (c + result.size > stop) {
+      break;
+    }
+    c += result.size;
+    count += 1;
+  }
+
+  return count;
+}
 }
 
 // quick-lint-js finds bugs in JavaScript programs.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,8 @@ quick_lint_js_add_executable(
   test-constant-divider.cpp
   test-crash.cpp
   test-document.cpp
+  test-emacs-lisp-error-reporter.cpp
+  test-emacs-location.cpp
   test-error-formatter.cpp
   test-error-list.cpp
   test-error.cpp

--- a/test/test-emacs-lisp-error-reporter.cpp
+++ b/test/test-emacs-lisp-error-reporter.cpp
@@ -1,0 +1,184 @@
+// Copyright (C) 2020  Matthew "strager" Glazar
+// See end of file for extended copyright information.
+
+#include <cstring>
+#include <gtest/gtest.h>
+#include <quick-lint-js/char8.h>
+#include <quick-lint-js/emacs-lisp-error-reporter.h>
+#include <quick-lint-js/emacs-location.h>
+#include <quick-lint-js/location.h>
+#include <quick-lint-js/padded-string.h>
+#include <sstream>
+
+namespace quick_lint_js {
+namespace {
+class test_emacs_lisp_error_reporter : public ::testing::Test {
+ protected:
+  emacs_lisp_error_reporter make_reporter(padded_string_view input) {
+    emacs_lisp_error_reporter reporter(this->stream_);
+    reporter.set_source(input);
+    return reporter;
+  }
+
+  std::string get_output() { return this->stream_.str(); }
+
+ private:
+  std::ostringstream stream_;
+};
+
+TEST_F(test_emacs_lisp_error_reporter, assignment_before_variable_declaration) {
+  padded_string input(u8"x=0;let x;"_sv);
+  source_code_span assignment_span(&input[1 - 1], &input[1 + 1 - 1]);
+  ASSERT_EQ(assignment_span.string_view(), u8"x");
+  source_code_span declaration_span(&input[9 - 1], &input[9 + 1 - 1]);
+  ASSERT_EQ(declaration_span.string_view(), u8"x");
+
+  emacs_lisp_error_reporter reporter = this->make_reporter(&input);
+  reporter.report(error_assignment_before_variable_declaration{
+      .assignment = identifier(assignment_span),
+      .declaration = identifier(declaration_span)});
+  reporter.finish();
+  EXPECT_EQ(
+      this->get_output(),
+      R"--((((1 . 2) 0 "E001" "variable assigned before its declaration")))--");
+}
+
+TEST_F(test_emacs_lisp_error_reporter, assignment_to_const_global_variable) {
+  padded_string input(u8"to Infinity and beyond"_sv);
+  source_code_span infinity_span(&input[4 - 1], &input[11 + 1 - 1]);
+  ASSERT_EQ(infinity_span.string_view(), u8"Infinity");
+
+  emacs_lisp_error_reporter reporter = this->make_reporter(&input);
+
+  reporter.report(
+      error_assignment_to_const_global_variable{identifier(infinity_span)});
+  reporter.finish();
+  EXPECT_EQ(
+      this->get_output(),
+      R"--((((4 . 12) 0 "E002" "assignment to const global variable")))--");
+}
+
+TEST_F(test_emacs_lisp_error_reporter,
+       expected_parenthesis_around_if_condition) {
+  padded_string input(u8"if cond) {}"_sv);
+  source_code_span parenthesis_span(&input[4 - 1], &input[4 - 1]);
+  emacs_lisp_error_reporter reporter = this->make_reporter(&input);
+  reporter.report(error_expected_parenthesis_around_if_condition{
+      .where = parenthesis_span,
+      .token = '(',
+  });
+  reporter.finish();
+  EXPECT_EQ(
+      this->get_output(),
+      R"--((((4 . 4) 0 "E018" "if statement is missing '(' around condition")))--");
+}
+
+TEST_F(test_emacs_lisp_error_reporter, redeclaration_of_variable) {
+  padded_string input(u8"let myvar; let myvar;"_sv);
+  source_code_span original_declaration_span(&input[5 - 1], &input[9 + 1 - 1]);
+  ASSERT_EQ(original_declaration_span.string_view(), u8"myvar");
+  source_code_span redeclaration_span(&input[16 - 1], &input[20 + 1 - 1]);
+  ASSERT_EQ(redeclaration_span.string_view(), u8"myvar");
+
+  emacs_lisp_error_reporter reporter = this->make_reporter(&input);
+  reporter.report(error_redeclaration_of_variable{
+      identifier(redeclaration_span), identifier(original_declaration_span)});
+  reporter.finish();
+  EXPECT_EQ(this->get_output(),
+            R"--((((16 . 21) 0 "E034" "redeclaration of variable: myvar")))--");
+}
+
+TEST_F(test_emacs_lisp_error_reporter,
+       redeclaration_of_variable_after_multi_byte) {
+  padded_string input(u8"/*\u263b*/let myvar; let myvar;"_sv);
+  source_code_span original_declaration_span(&input[11], &input[16]);
+  ASSERT_EQ(original_declaration_span.string_view(), u8"myvar");
+  source_code_span redeclaration_span(&input[22], &input[27]);
+  ASSERT_EQ(redeclaration_span.string_view(), u8"myvar");
+
+  emacs_lisp_error_reporter reporter = this->make_reporter(&input);
+  reporter.report(error_redeclaration_of_variable{
+      identifier(redeclaration_span), identifier(original_declaration_span)});
+  reporter.finish();
+  EXPECT_EQ(this->get_output(),
+            R"--((((21 . 26) 0 "E034" "redeclaration of variable: myvar")))--");
+}
+
+TEST_F(test_emacs_lisp_error_reporter, unexpected_hash_character) {
+  padded_string input(u8"#"_sv);
+  source_code_span hash_span(&input[1 - 1], &input[1 + 1 - 1]);
+  ASSERT_EQ(hash_span.string_view(), u8"#");
+
+  emacs_lisp_error_reporter reporter = this->make_reporter(&input);
+  reporter.report(error_unexpected_hash_character{hash_span});
+  reporter.finish();
+  EXPECT_EQ(this->get_output(), R"--((((1 . 2) 0 "E052" "unexpected '#'")))--");
+}
+
+TEST_F(test_emacs_lisp_error_reporter, use_of_undeclared_variable) {
+  padded_string input(u8"myvar;"_sv);
+  source_code_span myvar_span(&input[1 - 1], &input[5 + 1 - 1]);
+  ASSERT_EQ(myvar_span.string_view(), u8"myvar");
+
+  emacs_lisp_error_reporter reporter = this->make_reporter(&input);
+  reporter.report(error_use_of_undeclared_variable{identifier(myvar_span)});
+  reporter.finish();
+  EXPECT_EQ(this->get_output(),
+            R"--((((1 . 6) 2 "E057" "use of undeclared variable: myvar")))--");
+}
+
+TEST_F(test_emacs_lisp_error_reporter,
+       use_of_undeclared_variable_after_multibyte) {
+  padded_string input(u8"/*\u2639*/myvar;"_sv);
+  source_code_span myvar_span(&input[7], &input[12]);
+  ASSERT_EQ(myvar_span.string_view(), u8"myvar");
+
+  emacs_lisp_error_reporter reporter = this->make_reporter(&input);
+  reporter.report(error_use_of_undeclared_variable{identifier(myvar_span)});
+  reporter.finish();
+  EXPECT_EQ(this->get_output(),
+            R"--((((6 . 11) 2 "E057" "use of undeclared variable: myvar")))--");
+}
+
+TEST_F(test_emacs_lisp_error_reporter, blackslash_is_escaped) {
+  padded_string input(u8"hello\backslash"_sv);
+  source_code_span span(&input[5], &input[6]);
+
+  emacs_lisp_error_reporter reporter = this->make_reporter(&input);
+  reporter.report(error_unexpected_backslash_in_identifier{span});
+  reporter.finish();
+  EXPECT_EQ(this->get_output(),
+            R"--((((6 . 7) 0 "E043" "unexpected '\\' in identifier")))--");
+}
+
+TEST_F(test_emacs_lisp_error_reporter, double_quote_is_escaped) {
+  padded_string input(u8"import { x } ;"_sv);
+  source_code_span span(&input[12], &input[12]);
+
+  emacs_lisp_error_reporter reporter = this->make_reporter(&input);
+  reporter.report(error_expected_from_and_module_specifier{span});
+  reporter.finish();
+  EXPECT_EQ(
+      this->get_output(),
+      R"--((((13 . 13) 0 "E129" "expected 'from \"name_of_module.mjs\"'")))--");
+}
+}
+}
+
+// quick-lint-js finds bugs in JavaScript programs.
+// Copyright (C) 2020  Matthew "strager" Glazar
+//
+// This file is part of quick-lint-js.
+//
+// quick-lint-js is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// quick-lint-js is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with quick-lint-js.  If not, see <https://www.gnu.org/licenses/>.

--- a/test/test-emacs-location.cpp
+++ b/test/test-emacs-location.cpp
@@ -1,0 +1,117 @@
+// Copyright (C) 2020  Matthew "strager" Glazar
+// See end of file for extended copyright information.
+
+#include <array>
+#include <cstring>
+#include <gtest/gtest.h>
+#include <quick-lint-js/char8.h>
+#include <quick-lint-js/characters.h>
+#include <quick-lint-js/emacs-location.h>
+#include <quick-lint-js/narrow-cast.h>
+#include <quick-lint-js/padded-string.h>
+#include <vector>
+
+namespace quick_lint_js {
+namespace {
+
+TEST(test_emacs_location, ascii_ranges) {
+  padded_string code(u8"let x = 2;"_sv);
+  emacs_locator l(&code);
+  emacs_source_range x_range = l.range(source_code_span(&code[4], &code[5]));
+
+  EXPECT_EQ(x_range.begin_offset(), 5);
+  EXPECT_EQ(x_range.end_offset(), 6);
+}
+
+TEST(test_emacs_location, multi_byte_ranges) {
+  padded_string code(u8"/* \u263a */ let x = 2;"_sv);
+  emacs_locator l(&code);
+  emacs_source_range x_range = l.range(source_code_span(&code[14], &code[15]));
+
+  EXPECT_EQ(x_range.begin_offset(), 13);
+  EXPECT_EQ(x_range.end_offset(), 14);
+}
+
+TEST(test_emacs_location, location_after_null_byte) {
+  padded_string code(string8(u8"hello\0beautiful\nworld"_sv));
+  const char8* r = &code[18];
+  ASSERT_EQ(*r, u8'r');
+
+  emacs_locator l(&code);
+  emacs_source_range r_range = l.range(source_code_span(r, r + 1));
+
+  // Emacs point starts at 1
+  EXPECT_EQ(r_range.begin_offset(), r - code.c_str() + 1);
+}
+
+TEST(test_emacs_location, location_after_null_multi_byte) {
+  padded_string code(string8(u8"hello\u263b\0beautiful\nworld"_sv));
+  const char8* r = &code[21];
+  ASSERT_EQ(*r, u8'r');
+
+  emacs_locator l(&code);
+  emacs_source_range r_range = l.range(source_code_span(r, r + 1));
+
+  EXPECT_EQ(r_range.begin_offset(), 20);
+}
+
+TEST(test_emacs_location, position_backwards) {
+  padded_string code(u8"ab\nc\n\nd\nefg\nh"_sv);
+
+  std::vector<emacs_source_position> expected_positions;
+  {
+    emacs_locator l(&code);
+    for (int i = 0; i < narrow_cast<int>(code.size()); ++i) {
+      expected_positions.push_back(l.position(&code[i]));
+    }
+  }
+
+  std::vector<emacs_source_position> actual_positions;
+  {
+    emacs_locator l(&code);
+    for (int i = narrow_cast<int>(code.size()) - 1; i >= 0; --i) {
+      actual_positions.push_back(l.position(&code[i]));
+    }
+  }
+  std::reverse(actual_positions.begin(), actual_positions.end());
+
+  EXPECT_EQ(actual_positions, expected_positions);
+}
+
+TEST(test_emacs_location, position_after_multi_byte_character) {
+  {
+    // U+2603 has three UTF-8 code units: e2 98 83
+    padded_string code(u8"\u2603 x"_sv);
+    const char8* x = strchr(code.c_str(), u8'x');
+    emacs_locator l(&code);
+    EXPECT_EQ(l.position(x).offset, 3);
+  }
+
+  {
+    // U+1f496 has four UTF-8 code units: f0 9f 92 96
+    padded_string code(u8"\U0001f496 x"_sv);
+    const char8* x = strchr(code.c_str(), u8'x');
+    emacs_locator l(&code);
+    EXPECT_EQ(l.position(x).offset, 3);
+  }
+}
+}
+}
+
+// quick-lint-js finds bugs in JavaScript programs.
+// Copyright (C) 2020  Matthew "strager" Glazar
+//
+// This file is part of quick-lint-js.
+//
+// quick-lint-js is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// quick-lint-js is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with quick-lint-js.  If not, see <https://www.gnu.org/licenses/>.

--- a/test/test-options.cpp
+++ b/test/test-options.cpp
@@ -101,6 +101,12 @@ TEST(test_options, output_format) {
     EXPECT_THAT(o.error_unrecognized_options, IsEmpty());
     EXPECT_EQ(o.output_format, output_format::vim_qflist_json);
   }
+
+  {
+    options o = parse_options({"--output-format=emacs-lisp"});
+    EXPECT_THAT(o.error_unrecognized_options, IsEmpty());
+    EXPECT_EQ(o.output_format, output_format::emacs_lisp);
+  }
 }
 
 TEST(test_options, invalid_output_format) {

--- a/test/test-utf-8.cpp
+++ b/test/test-utf-8.cpp
@@ -609,6 +609,63 @@ TEST(test_count_lsp_characters_in_utf_8,
   EXPECT_EQ(count_lsp_characters_in_utf_8("\xf0\x90"_padded, 1), 1);
   EXPECT_EQ(count_lsp_characters_in_utf_8("\xf0\x90??"_padded, 1), 1);
 }
+
+namespace {
+std::size_t count_utf_8_characters(padded_string_view utf_8) noexcept {
+  return quick_lint_js::count_utf_8_characters(
+      utf_8, static_cast<std::size_t>(utf_8.size()));
+}
+
+std::size_t count_utf_8_characters(const padded_string& utf_8) noexcept {
+  return count_utf_8_characters(&utf_8);
+}
+
+std::size_t count_utf_8_characters(const padded_string& utf_8,
+                                   std::size_t offset) noexcept {
+  return count_utf_8_characters(&utf_8, offset);
+}
+}
+
+TEST(test_count_utf_8_characters, empty_string) {
+  std::size_t n = count_utf_8_characters(u8""_padded);
+  EXPECT_EQ(n, 0);
+}
+
+TEST(test_count_utf_8_characters, ascii) {
+  std::size_t n = count_utf_8_characters(u8"foobar"_padded);
+  EXPECT_EQ(n, 6);
+}
+
+TEST(test_count_utf_8_characters, ascii_num) {
+  std::size_t n = count_utf_8_characters(u8"1,2,3,4"_padded);
+  EXPECT_EQ(n, 7);
+}
+
+TEST(test_count_utf_8_characters, multi_byte) {
+  std::size_t n = count_utf_8_characters(u8"\u263a\u263b\u2639"_padded);
+  EXPECT_EQ(n, 3);
+}
+
+TEST(test_count_utf_8_characters, multi_byte_offset) {
+  std::size_t n = count_utf_8_characters(u8"\u263a\u263b\u2639"_padded, 6);
+  EXPECT_EQ(n, 2);
+}
+
+TEST(test_count_utf_8_characters, invalid_counts_as_one) {
+  std::size_t n = count_utf_8_characters(u8"\xe2\x80"_padded);
+  EXPECT_EQ(n, 2);
+}
+
+TEST(test_count_utf_8_characters, invalid_conuts_as_one_with_null) {
+  std::size_t n = count_utf_8_characters(u8"\xe2\x00"_padded);
+  EXPECT_EQ(n, 2);
+}
+
+TEST(test_count_utf_8_characters, mixed_ascii_with_invalid) {
+  std::size_t n = count_utf_8_characters(u8"a\xe2\x80"_padded);
+  EXPECT_EQ(n, 3);
+}
+
 }
 
 // quick-lint-js finds bugs in JavaScript programs.


### PR DESCRIPTION
notes:

I didn't ran asciidoctor to generate manpages and html because my version (debian sid) is different than previously used to generate, and it makes a diff-mess in both man and html, so left that out of the patches

emacs-location and utf8 code point counting looks awkward, i feel it could handle the case where offset is in middle of a code point by going backward, altought im unsure if i should

the exit_fail_on is ignored in main when output_format is emacs_lisp because it's the easier path i saw, im unsure if there is a better place for that, it needs to return 0 for emacs so flymake (perhaps flycheck too) can disable quick-lint-js backend if some input is crashing quick-lint-js, it avoids inifnite loops spawning quick-lint-js
