### PR TITLE
fix #400: add semicol to generate an error in parse_expression_remainder

### DIFF
--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -942,6 +942,7 @@ next:
     case token_type::minus:
     case token_type::plus:
     case token_type::question:
+    case token_type::semicolon:
     case token_type::right_paren: {
       source_code_span empty_property_name(dot_span.end(), dot_span.end());
       children.back() = this->make_expression<expression::dot>(

--- a/test/test-parse-expression.cpp
+++ b/test/test-parse-expression.cpp
@@ -765,6 +765,28 @@ TEST_F(test_parse_expression, invalid_dot_expression) {
                 error_missing_property_name_for_dot_operator, dot,
                 offsets_matcher(p.code(), strlen(u8"x. ? y"), u8"."))));
   }
+
+  {
+    test_parser p(u8"x.;"_sv);
+    expression* ast = p.parse_expression();
+    EXPECT_EQ(summarize(ast), "dot(var x, )");
+    EXPECT_THAT(p.errors(),
+                ElementsAre(ERROR_TYPE_FIELD(
+                    error_missing_property_name_for_dot_operator, dot,
+                    offsets_matcher(p.code(), strlen(u8"x"), u8"."))));
+  }
+  {
+    test_parser p(u8".;"_sv);
+    expression* ast = p.parse_expression();
+    EXPECT_EQ(summarize(ast), "dot(?, )");
+    EXPECT_THAT(
+        p.errors(),
+        ElementsAre(
+            ERROR_TYPE_FIELD(error_missing_operand_for_operator, where,
+                             offsets_matcher(p.code(), 0, u8".")),
+            ERROR_TYPE_FIELD(error_missing_property_name_for_dot_operator, dot,
+                             offsets_matcher(p.code(), 0, u8"."))));
+  }
 }
 
 TEST_F(test_parse_expression, parse_optional_dot_expressions) {


### PR DESCRIPTION
first time touching the parser code, i hope i didn't screw up too much, i have a bad feeling about my second test case, i think errors should stop in `error_missing_operand_for_operator` and ignore `error_missing_property_name_for_dot_operator`. im spleepy atm so i couldn't find an easy path for doing that, so pardon me it should.