### PR TITLE
Handle unexpected keywords in expressions

### DIFF
--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -481,7 +481,21 @@ expression* parser::parse_primary_expression(precedence prec) {
   }
 
   case token_type::colon:
-  case token_type::kw_debugger: {
+  case token_type::kw_break:
+  case token_type::kw_case:
+  case token_type::kw_catch:
+  case token_type::kw_const:
+  case token_type::kw_continue:
+  case token_type::kw_debugger:
+  case token_type::kw_default:
+  case token_type::kw_do:
+  case token_type::kw_else:
+  case token_type::kw_export:
+  case token_type::kw_extends:
+  case token_type::kw_finally:
+  case token_type::kw_try:
+  case token_type::kw_var:
+  case token_type::kw_with: {
     source_code_span token_span = this->peek().span();
     this->error_reporter_->report(error_unexpected_token{token_span});
     this->skip();

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -481,35 +481,36 @@ expression* parser::parse_primary_expression(precedence prec) {
   }
 
   case token_type::colon:
-  case token_type::kw_break:
-  case token_type::kw_case:
-  case token_type::kw_catch:
-  case token_type::kw_const:
-  case token_type::kw_continue:
-  case token_type::kw_debugger:
-  case token_type::kw_default:
-  case token_type::kw_do:
-  case token_type::kw_else:
-  case token_type::kw_export:
-  case token_type::kw_extends:
-  case token_type::kw_finally:
-  case token_type::kw_try:
-  case token_type::kw_var:
-  case token_type::kw_with: {
+  case token_type::kw_debugger: {
     source_code_span token_span = this->peek().span();
-    this->error_reporter_->report(error_unexpected_token{token_span});
+    this->error_reporter_->report(
+        error_unexpected_token{token_span});
     this->skip();
     return this->make_expression<expression::_invalid>(token_span);
   }
 
   case token_type::end_of_file:
+  case token_type::kw_break:
+  case token_type::kw_case:
+  case token_type::kw_catch:
+  case token_type::kw_const:
+  case token_type::kw_continue:
+  case token_type::kw_default:
+  case token_type::kw_do:
+  case token_type::kw_else:
   case token_type::kw_enum:
+  case token_type::kw_export:
+  case token_type::kw_extends:
+  case token_type::kw_finally:
   case token_type::kw_for:
   case token_type::kw_if:
   case token_type::kw_return:
   case token_type::kw_switch:
   case token_type::kw_throw:
+  case token_type::kw_try:
+  case token_type::kw_var:
   case token_type::kw_while:
+  case token_type::kw_with:
   case token_type::right_curly:
   case token_type::right_paren:
   case token_type::right_square:

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -483,8 +483,7 @@ expression* parser::parse_primary_expression(precedence prec) {
   case token_type::colon:
   case token_type::kw_debugger: {
     source_code_span token_span = this->peek().span();
-    this->error_reporter_->report(
-        error_unexpected_token{token_span});
+    this->error_reporter_->report(error_unexpected_token{token_span});
     this->skip();
     return this->make_expression<expression::_invalid>(token_span);
   }

--- a/test/test-parse-expression-statement.cpp
+++ b/test/test-parse-expression-statement.cpp
@@ -1159,6 +1159,37 @@ TEST(test_parse, trailing_comma_in_comma_expression_is_disallowed) {
   }
 }
 
+TEST(test_parse, handle_unexpected_keyword_in_expression) {
+  //
+  // keywords temporarily omitted because they will crash downstream
+  // ---
+  // catch    parse_expression_remainder
+  // do       parse_and_visit_do_while
+  // else     parse_and_visit_statement
+  // extends  parse_expression_remainder: kw_extends
+  // finally  parse_expression_remainder: kw_finally
+  // function parse_and_visit_function_parameters_and_body_no_scope
+  // with     internal check failed in narrow_cast
+  //
+  for (string8_view statement : {
+           u8"break"_sv,
+           u8"case"_sv,
+           u8"const"_sv,
+           u8"continue"_sv,
+           u8"default"_sv,
+           u8"export"_sv,
+           u8"try"_sv,
+           u8"var"_sv,
+       }) {
+    padded_string code(string8(u8"*\n"_sv) + string8(statement));
+    SCOPED_TRACE(code);
+    spy_visitor v;
+    parser p(&code, &v);
+    p.parse_and_visit_module(v);
+    EXPECT_THAT(v.errors, Not(IsEmpty()));
+  }
+}
+
 TEST(test_parse, incomplete_unary_expression_with_following_statement_keyword) {
   for (string8_view statement : {
            u8"for(;x;);"_sv,


### PR DESCRIPTION
#407 

The new behavior is to end the expression for these keywords. It will not report an unexpected token error in an expression. 

Because the code continues parsing instead of crashing, there are known new issues with handling `catch`, `export`, `extends`, `finally` and `function` expressions. These issues occur when keywords are mentioned in unopened comment blocks.

For example:

```
*                  
* this function extends a string 
* /
```