### PR TITLE
Don't report an error on 'break await' in non-async functions and 'break yield' in non-generator functions

### DIFF
--- a/src/quick-lint-js/parse.h
+++ b/src/quick-lint-js/parse.h
@@ -578,6 +578,7 @@ class parser {
       QLJS_CASE_CONTEXTUAL_KEYWORD:
       case token_type::identifier:
       case token_type::kw_await:
+      case token_type::kw_yield:
         if (this->peek().has_leading_newline) {
           // ASI.
           this->lexer_.insert_semicolon();

--- a/src/quick-lint-js/parse.h
+++ b/src/quick-lint-js/parse.h
@@ -577,6 +577,7 @@ class parser {
       switch (this->peek().type) {
       QLJS_CASE_CONTEXTUAL_KEYWORD:
       case token_type::identifier:
+      case token_type::kw_await:
         if (this->peek().has_leading_newline) {
           // ASI.
           this->lexer_.insert_semicolon();

--- a/test/test-lint-parse.cpp
+++ b/test/test-lint-parse.cpp
@@ -154,6 +154,19 @@ TEST(test_lint, prefix_plusplus_plus_operand) {
                               offsets_matcher(&input, 6, 6 + 1))));
   }
 }
+
+
+TEST(test_lint, use_await_label_in_non_async_function) {
+  padded_string input(u8"function f() {await: for(;;){break await;}}"_sv);
+  error_collector v;
+  linter l(&v, &default_globals);
+  parser p(&input, &v);
+  p.parse_and_visit_module(l);
+  l.visit_end_of_module();
+
+  EXPECT_THAT(v.errors, IsEmpty());
+}
+
 }
 }
 

--- a/test/test-lint-parse.cpp
+++ b/test/test-lint-parse.cpp
@@ -155,7 +155,6 @@ TEST(test_lint, prefix_plusplus_plus_operand) {
   }
 }
 
-
 TEST(test_lint, use_await_label_in_non_async_function) {
   padded_string input(u8"function f() {await: for(;;){break await;}}"_sv);
   error_collector v;
@@ -166,7 +165,6 @@ TEST(test_lint, use_await_label_in_non_async_function) {
 
   EXPECT_THAT(v.errors, IsEmpty());
 }
-
 }
 }
 

--- a/test/test-lint-parse.cpp
+++ b/test/test-lint-parse.cpp
@@ -165,6 +165,17 @@ TEST(test_lint, use_await_label_in_non_async_function) {
 
   EXPECT_THAT(v.errors, IsEmpty());
 }
+
+TEST(test_lint, use_yield_label_in_non_generator_function) {
+  padded_string input(u8"function f() {yield: for(;;){break yield;}}"_sv);
+  error_collector v;
+  linter l(&v, &default_globals);
+  parser p(&input, &v);
+  p.parse_and_visit_module(l);
+  l.visit_end_of_module();
+
+  EXPECT_THAT(v.errors, IsEmpty());
+}
 }
 }
 


### PR DESCRIPTION
The following code:

    function f() {
      await: for(;;) {
        break await;
      }
    }

Should not report an error for `break await`.
Fix: #369 