### PR TITLE
Improve error when using => on object literal method

### DIFF
--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -638,9 +638,9 @@
               declaring_keyword, kind_of_statement))                           \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
-      error_methods_should_not_have_arrow_operator, "E174",                    \
+      error_functions_or_methods_should_not_have_arrow_operator, "E174",       \
       { source_code_span arrow_operator; },                                    \
-      ERROR(QLJS_TRANSLATABLE("methods should not have '=>'"),                 \
+      ERROR(QLJS_TRANSLATABLE("functions/methods should not have '=>'"),       \
             arrow_operator))                                                   \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \

--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -638,6 +638,12 @@
               declaring_keyword, kind_of_statement))                           \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
+      error_methods_should_not_have_arrow_operator, "E174",                    \
+      { source_code_span arrow_operator; },                                    \
+      ERROR(QLJS_TRANSLATABLE("methods should not have '=>'"),                 \
+            arrow_operator))                                                   \
+                                                                               \
+  QLJS_ERROR_TYPE(                                                             \
       error_methods_should_not_use_function_keyword, "E072",                   \
       { source_code_span function_token; },                                    \
       ERROR(                                                                   \

--- a/src/quick-lint-js/parse.h
+++ b/src/quick-lint-js/parse.h
@@ -1265,7 +1265,7 @@ class parser {
 
       if (this->peek().type == token_type::equal_greater) {
         this->error_reporter_->report(
-            error_methods_should_not_have_arrow_operator{
+            error_functions_or_methods_should_not_have_arrow_operator{
                 .arrow_operator = this->peek().span(),
             });
         this->skip();

--- a/src/quick-lint-js/parse.h
+++ b/src/quick-lint-js/parse.h
@@ -1263,6 +1263,14 @@ class parser {
       }
       this->skip();
 
+      if (this->peek().type == token_type::equal_greater) {
+        this->error_reporter_->report(
+            error_methods_should_not_have_arrow_operator{
+                .arrow_operator = this->peek().span(),
+            });
+        this->skip();
+      }
+
       if (this->peek().type != token_type::left_curly) {
         const char8 *expected_body = this->lexer_.end_of_previous_token();
         this->error_reporter_->report(error_missing_function_body{

--- a/test/test-parse-class.cpp
+++ b/test/test-parse-class.cpp
@@ -297,6 +297,29 @@ TEST(test_parse, class_statement_with_methods) {
   }
 }
 
+TEST(test_parse, class_statement_methods_with_arrow_operator) {
+  {
+    spy_visitor v;
+    padded_string code(u8"class C { method() => {} }"_sv);
+    parser p(&code, &v);
+    EXPECT_TRUE(p.parse_and_visit_statement(v));
+    EXPECT_THAT(v.visits,
+                ElementsAre("visit_variable_declaration",       // C
+                            "visit_enter_class_scope",          //
+                            "visit_property_declaration",       // method
+                            "visit_enter_function_scope",       //
+                            "visit_enter_function_scope_body",  //
+                            "visit_exit_function_scope",        //
+                            "visit_exit_class_scope"));
+    EXPECT_THAT(
+        v.errors,
+        ElementsAre(ERROR_TYPE_FIELD(
+            error_functions_or_methods_should_not_have_arrow_operator,
+            arrow_operator,
+            offsets_matcher(&code, strlen(u8"class C { method() "), u8"=>"))));
+  }
+}
+
 TEST(test_parse, class_statement_with_fields) {
   {
     spy_visitor v =

--- a/test/test-parse-expression-statement.cpp
+++ b/test/test-parse-expression-statement.cpp
@@ -648,7 +648,8 @@ TEST(test_parse, object_literal_method_with_arrow_operator) {
     EXPECT_THAT(
         v.errors,
         ElementsAre(ERROR_TYPE_FIELD(
-            error_methods_should_not_have_arrow_operator, arrow_operator,
+            error_functions_or_methods_should_not_have_arrow_operator,
+            arrow_operator,
             offsets_matcher(&code, strlen(u8"let o = {method() "), u8"=>"))));
   }
 }

--- a/test/test-parse-expression-statement.cpp
+++ b/test/test-parse-expression-statement.cpp
@@ -638,6 +638,21 @@ TEST(test_parse, object_literal) {
   }
 }
 
+TEST(test_parse, object_literal_method_with_arrow_operator) {
+  {
+    spy_visitor v;
+    padded_string code(u8"let o = {method() => {}}"_sv);
+    parser p(&code, &v);
+    EXPECT_TRUE(p.parse_and_visit_statement(v));
+
+    EXPECT_THAT(
+        v.errors,
+        ElementsAre(ERROR_TYPE_FIELD(
+            error_methods_should_not_have_arrow_operator, arrow_operator,
+            offsets_matcher(&code, strlen(u8"let o = {method() "), u8"=>"))));
+  }
+}
+
 TEST(test_parse, expression_statement) {
   {
     spy_visitor v = parse_and_visit_statement(u8"console.log('hello');"_sv);

--- a/test/test-parse-function.cpp
+++ b/test/test-parse-function.cpp
@@ -135,6 +135,22 @@ TEST(test_parse, parse_function_statement) {
   }
 }
 
+TEST(test_parse, function_with_arrow_operator) {
+  {
+    spy_visitor v;
+    padded_string code(u8"function f() => {}"_sv);
+    parser p(&code, &v);
+    EXPECT_TRUE(p.parse_and_visit_statement(v));
+
+    EXPECT_THAT(
+        v.errors,
+        ElementsAre(ERROR_TYPE_FIELD(
+            error_functions_or_methods_should_not_have_arrow_operator,
+            arrow_operator,
+            offsets_matcher(&code, strlen(u8"function f() "), u8"=>"))));
+  }
+}
+
 TEST(test_parse, function_statement_with_no_name) {
   {
     padded_string code(u8"function() {x;}"_sv);


### PR DESCRIPTION
The following code:
    let o = {
      method() => {
      },
    };

Should report error_methods_should_not_have_arrow_operator.
Fix: #292 