### PR TITLE
Improve error for missing arrow operator

### DIFF
--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -287,6 +287,15 @@ expression* parser::parse_primary_expression(precedence prec) {
             function_attributes::normal, left_paren_span.begin(),
             /*allow_in_operator=*/prec.in_operator);
         return ast;
+      } else if ((this->peek().type == token_type::left_curly) &&
+                 (!this->peek().has_leading_newline)) {
+        this->error_reporter_->report(
+            error_missing_arrow_operator_in_arrow_function{
+                .where = this->peek().span()});
+        expression* ast = this->parse_arrow_function_body(
+            function_attributes::normal, this->peek().span().begin(),
+            /*allow_in_operator=*/prec.in_operator);
+        return ast;
       } else {
         // ()  // Invalid.
         this->error_reporter_->report(

--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -667,6 +667,12 @@
           NOTE(QLJS_TRANSLATABLE("array started here"), left_square))          \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
+      error_missing_arrow_operator_in_arrow_function, "E176",                  \
+      { source_code_span where; },                                             \
+      ERROR(QLJS_TRANSLATABLE("missing arrow operator for arrow function"),    \
+            where))                                                            \
+                                                                               \
+  QLJS_ERROR_TYPE(                                                             \
       error_missing_arrow_function_parameter_list, "E105",                     \
       { source_code_span arrow; },                                             \
       ERROR(QLJS_TRANSLATABLE("missing parameters for arrow function"),        \

--- a/test/test-parse-function.cpp
+++ b/test/test-parse-function.cpp
@@ -975,6 +975,23 @@ TEST(test_parse, arrow_function_with_invalid_parameters) {
   }
 }
 
+TEST(test_parse, arrow_function_expression_without_arrow_operator) {
+  {
+    padded_string code(u8"(() {});"_sv);
+    spy_visitor v;
+    parser p(&code, &v);
+    p.parse_and_visit_module(v);
+    EXPECT_THAT(v.visits, ElementsAre("visit_enter_function_scope",       //
+                                      "visit_enter_function_scope_body",  //
+                                      "visit_exit_function_scope",        //
+                                      "visit_end_of_module"));
+    EXPECT_THAT(v.errors,
+                ElementsAre(ERROR_TYPE_FIELD(
+                    error_missing_arrow_operator_in_arrow_function, where,
+                    offsets_matcher(&code, strlen(u8"(() "), u8"{"))));
+  }
+}
+
 TEST(test_parse, generator_function_with_misplaced_star) {
   {
     padded_string code(u8"function f*(x) { yield x; }"_sv);

--- a/test/test-parse-function.cpp
+++ b/test/test-parse-function.cpp
@@ -990,6 +990,21 @@ TEST(test_parse, arrow_function_expression_without_arrow_operator) {
                     error_missing_arrow_operator_in_arrow_function, where,
                     offsets_matcher(&code, strlen(u8"(() "), u8"{"))));
   }
+
+  {
+    padded_string code(u8"(()\n{});"_sv);
+    spy_visitor v;
+    parser p(&code, &v);
+    p.parse_and_visit_module(v);
+    EXPECT_THAT(v.visits, ElementsAre("visit_enter_function_scope",       //
+                                      "visit_enter_function_scope_body",  //
+                                      "visit_exit_function_scope",        //
+                                      "visit_end_of_module"));
+    EXPECT_THAT(v.errors,
+                ElementsAre(ERROR_TYPE_FIELD(
+                    error_missing_arrow_operator_in_arrow_function, where,
+                    offsets_matcher(&code, strlen(u8"(()\n"), u8"{"))));
+  }
 }
 
 TEST(test_parse, generator_function_with_misplaced_star) {


### PR DESCRIPTION
The following code:

    let f = () {}

Should report error_missing_arrow_operator_in_arrow_function
Fix: #461 