### PR TITLE
Add suggestion to make Eglot run automatically

### DIFF
--- a/plugin/emacs/README.md
+++ b/plugin/emacs/README.md
@@ -51,7 +51,10 @@ Usage example in your [Emacs initialization] file.
 
   ;; Remove the time to wait after last change before automatically checking
   ;; buffer.  The default is 0.5 (500ms)
-  (setq-local eglot-send-changes-idle-time 0))
+  (setq-local eglot-send-changes-idle-time 0)
+
+  ;; Optional: Make Eglot run automatically when 'js-mode` is loaded
+  (eglot-ensure))
 (add-hook 'js-mode-hook #'my-eglot-quicklintjs-setup)
 ```
 

--- a/plugin/emacs/README.md
+++ b/plugin/emacs/README.md
@@ -53,7 +53,7 @@ Usage example in your [Emacs initialization] file.
   ;; buffer.  The default is 0.5 (500ms)
   (setq-local eglot-send-changes-idle-time 0)
 
-  ;; Optional: Make Eglot run automatically when 'js-mode` is loaded
+  ;; Optional: Make Eglot run automatically when `js-mode' is loaded
   (eglot-ensure))
 (add-hook 'js-mode-hook #'my-eglot-quicklintjs-setup)
 ```

--- a/plugin/emacs/eglot-quicklintjs.el
+++ b/plugin/emacs/eglot-quicklintjs.el
@@ -13,7 +13,10 @@
 ;;
 ;;   ;; Remove the time to wait after last change before automatically checking
 ;;   ;; buffer.  The default is 0.5 (500ms)
-;;   (setq-local eglot-send-changes-idle-time 0))
+;;   (setq-local eglot-send-changes-idle-time 0)
+;;
+;;   ;; Optional: Make Eglot run automatically when 'js-mode` is loaded
+;;   (eglot-ensure))
 ;; (add-hook 'js-mode-hook #'my-eglot-quicklintjs-setup)
 
 ;;; Code:

--- a/plugin/emacs/eglot-quicklintjs.el
+++ b/plugin/emacs/eglot-quicklintjs.el
@@ -15,7 +15,7 @@
 ;;   ;; buffer.  The default is 0.5 (500ms)
 ;;   (setq-local eglot-send-changes-idle-time 0)
 ;;
-;;   ;; Optional: Make Eglot run automatically when 'js-mode` is loaded
+;;   ;; Optional: Make Eglot run automatically when `js-mode' is loaded
 ;;   (eglot-ensure))
 ;; (add-hook 'js-mode-hook #'my-eglot-quicklintjs-setup)
 

--- a/website/public/install/emacs/configure/index.ejs.html
+++ b/website/public/install/emacs/configure/index.ejs.html
@@ -63,7 +63,7 @@
   ;; checking buffer. The default is 0.5 (500ms)
   (setq-local eglot-send-changes-idle-time 0)
 
-  ;; Optional: Make Eglot run automatically when 'js-mode` is loaded
+  ;; Optional: Make Eglot run automatically when `js-mode' is loaded
   (eglot-ensure))
 (add-hook 'js-mode-hook #'my-eglot-quicklintjs-setup)</code></pre>
 

--- a/website/public/install/emacs/configure/index.ejs.html
+++ b/website/public/install/emacs/configure/index.ejs.html
@@ -61,7 +61,10 @@
   "Configure eglot-quicklintjs for better experience."
   ;; Optional: Remove the time to wait after last change before automatically
   ;; checking buffer. The default is 0.5 (500ms)
-  (setq-local eglot-send-changes-idle-time 0))
+  (setq-local eglot-send-changes-idle-time 0)
+
+  ;; Optional: Make Eglot run automatically when 'js-mode` is loaded
+  (eglot-ensure))
 (add-hook 'js-mode-hook #'my-eglot-quicklintjs-setup)</code></pre>
 
       <h3 id="flycheck">Flycheck</h3>


### PR DESCRIPTION
At the current time, quick-lint-js's eglot setup requires that the user `M-x eglot` to start linting their code. This step can be avoided by including `(eglot-ensure)` in the `my-eglot-quicklintjs-setup` function. This is an improvement because it makes quick-lint-js integration with eglot plug and play, avoiding unnecessary steps.