### PR TITLE
Fix FreeBSD build failures

### DIFF
--- a/src/change-detecting-filesystem-kqueue.cpp
+++ b/src/change-detecting-filesystem-kqueue.cpp
@@ -278,10 +278,16 @@ std::string vnode_event_flags_to_string(std::uint32_t flags) {
     const char name[13];
   };
   static constexpr flag_entry known_flags[] = {
-      {NOTE_ATTRIB, "NOTE_ATTRIB"}, {NOTE_DELETE, "NOTE_DELETE"},
-      {NOTE_EXTEND, "NOTE_EXTEND"}, {NOTE_FUNLOCK, "NOTE_FUNLOCK"},
-      {NOTE_LINK, "NOTE_LINK"},     {NOTE_RENAME, "NOTE_RENAME"},
-      {NOTE_REVOKE, "NOTE_REVOKE"}, {NOTE_WRITE, "NOTE_WRITE"},
+    {NOTE_ATTRIB, "NOTE_ATTRIB"},
+    {NOTE_DELETE, "NOTE_DELETE"},
+    {NOTE_EXTEND, "NOTE_EXTEND"},
+    {NOTE_LINK, "NOTE_LINK"},
+    {NOTE_RENAME, "NOTE_RENAME"},
+    {NOTE_REVOKE, "NOTE_REVOKE"},
+    {NOTE_WRITE, "NOTE_WRITE"},
+#if defined(__APPLE__)
+    {NOTE_FUNLOCK, "NOTE_FUNLOCK"},
+#endif
   };
 
   if (flags == 0) {


### PR DESCRIPTION
As it seems, `NOTE_FUNLOCK` is an Apple Extension, which causes builds to fail on FreeBSD.
This fixes builds for the following targets, which I was able to test:
- FreeBSD 13.0-RELEASE-p4 GENERIC  arm64
- FreeBSD 13.0-RELEASE-p4 TRITON13 amd64
The test suites seem to be fine on both amd64 and arm64.
I got a curious little warning during the build on ARM tho:
```
[ 23%] Building CXX object src/CMakeFiles/quick-lint-js-lib.dir/file-handle.cpp.o
/home/nico/src/quick-lint-js/src/file-handle.cpp:262:2: warning: "Size returned by get_pipe_buffer_size might be inaccurate" [-W#warnings]
 ^
```
Don't know whether that would cause any issues on that platform.
