### PR TITLE
Report error on statement before first switch case

### DIFF
--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -1189,6 +1189,13 @@
           return_keyword))                                                     \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
+      error_statement_before_first_switch_case, "E0198",                       \
+      { source_code_span unexpected_statement; },                              \
+      ERROR(QLJS_TRANSLATABLE("unexpected statement before first switch "      \
+                              "case, expected 'case' or 'default'"),           \
+            unexpected_statement))                                             \
+                                                                               \
+  QLJS_ERROR_TYPE(                                                             \
       error_stray_comma_in_let_statement, "E0036",                             \
       { source_code_span where; },                                             \
       ERROR(QLJS_TRANSLATABLE("stray comma in let statement"), where))         \

--- a/test/test-parse-statement.cpp
+++ b/test/test-parse-statement.cpp
@@ -1112,6 +1112,26 @@ TEST(test_parse, with_statement) {
   }
 }
 
+TEST(test_parse, statement_before_first_switch_case) {
+  {
+    spy_visitor v;
+    padded_string code(
+        u8"switch (cond) { console.log('hi'); case ONE: break; }"_sv);
+    parser p(&code, &v);
+    EXPECT_TRUE(p.parse_and_visit_statement(v));
+    EXPECT_THAT(v.visits,
+                ElementsAre("visit_variable_use",       // cond
+                            "visit_enter_block_scope",  //
+                            "visit_variable_use",       // console
+                            "visit_variable_use",       // ONE
+                            "visit_exit_block_scope"));
+    EXPECT_THAT(v.errors, ElementsAre(ERROR_TYPE_OFFSETS(
+                              &code, error_statement_before_first_switch_case,
+                              unexpected_statement,
+                              strlen(u8"switch (cond) { "), u8"console")));
+  }
+}
+
 TEST(test_parse, with_statement_without_parens) {
   {
     spy_visitor v;


### PR DESCRIPTION
The following code:
```js
switch (true) {
  console.log("banana");
case true:
case false:
default:
}
```

Should report error_statement_before_first_switch_case.

Resolve: #632