### PR TITLE
Add new error type to address #662

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,10 @@ Semantic Versioning.
 
 ## Unreleased
 
+### Added
+
+* Missing parentheses around a self-invoked arrow function are now reported as [E0211][]
+
 ### Fixed
 
 * `<div> <> </> </div>` (a JSX fragment inside a JSX element) no longer reports
@@ -518,3 +522,4 @@ Beta release.
 [E0203]: https://quick-lint-js.com/errors/E0203/
 [E0205]: https://quick-lint-js.com/errors/E0205/
 [E0207]: https://quick-lint-js.com/errors/E0207/
+[E0211]: https://quick-lint-js.com/errors/E0211/

--- a/docs/errors/E0211.md
+++ b/docs/errors/E0211.md
@@ -1,0 +1,19 @@
+# E0211: missing parentheses around self-invoked function
+
+Invoking an arrow function immediately without parentheses is a syntax error.
+For example:
+
+```
+() => {
+  console.log('hi');
+}()
+```
+
+To fix this error, add parentheses around the entire function definition, before
+the invocation:
+
+```
+(() => {
+  console.log('hi');
+})()
+```

--- a/src/quick-lint-js/error.h
+++ b/src/quick-lint-js/error.h
@@ -1047,6 +1047,17 @@
                unary_operator))                                                \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
+      error_missing_parentheses_around_self_invoked_function, "E0211",         \
+      {                                                                        \
+        source_code_span invocation;                                           \
+        source_code_span func_start;                                           \
+      },                                                                       \
+      ERROR(QLJS_TRANSLATABLE(                                                 \
+                "missing parentheses around self-invoked function"),           \
+            invocation)                                                        \
+          NOTE(QLJS_TRANSLATABLE("function starts here"), func_start))         \
+                                                                               \
+  QLJS_ERROR_TYPE(                                                             \
       error_missing_parentheses_around_unary_lhs_of_exponent, "E0194",         \
       {                                                                        \
         source_code_span unary_expression;                                     \

--- a/src/quick-lint-js/parse-expression-inl.h
+++ b/src/quick-lint-js/parse-expression-inl.h
@@ -1149,6 +1149,17 @@ next:
 
   // f(x, y, z)  // Function call.
   case token_type::left_paren:
+    if (binary_builder.last_expression()->kind() ==
+        expression_kind::arrow_function) {
+      // () => {}() // Invalid.
+      auto func_span = binary_builder.last_expression()->span();
+      auto func_start_span =
+          source_code_span(func_span.begin(), func_span.begin());
+      this->error_reporter_->report(
+          error_missing_parentheses_around_self_invoked_function{
+              .invocation = this->peek().span(),
+              .func_start = func_start_span});
+    }
     binary_builder.replace_last(this->parse_call_expression_remainder(
         v, binary_builder.last_expression()));
     goto next;


### PR DESCRIPTION
This PR addresses #662 by introducing a new error type `E0211` (I'm not sure if there's a convention for these numbers, so I just went with +1)

I decided not to address the following scenario just yet:
```javascript
function() { }()
```

the reason being is that this behaves slightly differently than the arrow functions with where the surrounding parentheses are acceptable. I think this should probably be its own class of error, so the wording doesn't get confusing between the two

if you want, I can add that error type as part of this PR as well (or I can just roll it into `E0211` if you prefer that)

this was fun! thanks for coming by the stream and helping out, much appreciated