### PR TITLE
 5$: Website: remove empty <script> nodes #514 

### DIFF
--- a/website/public/benchmarks/index.ejs.html
+++ b/website/public/benchmarks/index.ejs.html
@@ -6,7 +6,7 @@
     <%- await include("../common-head.ejs.html", { title: `JS linter
     benchmarks`, description: `quick-lint-js is faster than any other JavaScript
     linter.` }) %>
-    <script>
+    <script id="thisTag">
       //<%
       let fs = await import("fs");
       let url = await import("url");
@@ -30,6 +30,8 @@
 
       let versions = JSON.parse(fs.readFileSync("full-change-wait-express-router-js.json", "utf-8")).metadata;
       //%>
+      var thisTag = document.getElementById('thisTag');
+      thisTag.remove();
     </script>
     <link href="../main.css" rel="stylesheet" />
     <link href="benchmark.css" rel="stylesheet" />

--- a/website/public/blog/syntax-errors-2021/index.ejs.html
+++ b/website/public/blog/syntax-errors-2021/index.ejs.html
@@ -6,7 +6,7 @@
     <%- await include("../../common-head.ejs.html", { title: `JavaScript syntax
     errors compared (2021)`, description: `Comparison of errors produced by
     different JavaScript parsers` }) %>
-    <script>
+    <script id="thisTag">
       //<%
       let url = await import("url");
       let { html } = await import(url.pathToFileURL("../../../src/html-tag.mjs"));
@@ -100,6 +100,8 @@
         return `${r}/5:`;
       }
       //%>
+      var thisTag = document.getElementById('thisTag');
+      thisTag.remove();
     </script>
     <link href="../../main.css" rel="stylesheet" />
     <style>

--- a/website/public/cli/index.ejs.html
+++ b/website/public/cli/index.ejs.html
@@ -5,7 +5,7 @@
   <head>
     <%- await include("../common-head.ejs.html", { title: `quick-lint-js CLI
     documentation` }) %>
-    <script>
+    <script id="thisTag">
       //<%
       let fs = await import("fs");
       let asciidoctor = (await import("asciidoctor")).default();
@@ -13,6 +13,8 @@
       let adoc = await fs.promises.readFile("../../../docs/cli.adoc", "utf-8");
       let cliDocumentation = asciidoctor.convert(adoc);
       //%>
+      var thisTag = document.getElementById('thisTag');
+      thisTag.remove();
     </script>
     <link href="../main.css" rel="stylesheet" />
   </head>

--- a/website/public/common-footer-nav.ejs.html
+++ b/website/public/common-footer-nav.ejs.html
@@ -3,7 +3,7 @@
 <!-- See end of file for extended copyright information. -->
 %>
 
-<script>
+<script id="thisTag">
   //<%
   let ejs = await import("ejs");
   let url = await import("url");
@@ -29,8 +29,9 @@
     </li>`;
   }
   //%>
+  var thisTag = document.getElementById('thisTag');
+  thisTag.remove();
 </script>
-
 <nav>
   <ul>
     <% for (let page of navigationPages) { %> <% if (page.uri !== currentURI) {

--- a/website/public/common-nav.ejs.html
+++ b/website/public/common-nav.ejs.html
@@ -2,8 +2,7 @@
 <!-- Copyright (C) 2020  Matthew "strager" Glazar -->
 <!-- See end of file for extended copyright information. -->
 %>
-
-<script>
+<script id="thisTag"> 
   //<%
   let assert = await import("assert");
   let ejs = await import("ejs");
@@ -250,8 +249,9 @@
     throw new Error("Malformed subpage: " + JSON.stringify(subpage));
   }
   //%>
-</script>
-
+  var thisTag = document.getElementById('thisTag');
+  thisTag.remove();
+</script> 
 <% if (currentURI === "/") { %>
 <h1>quick-lint-js</h1>
 <% } else { %>

--- a/website/public/config/index.ejs.html
+++ b/website/public/config/index.ejs.html
@@ -5,17 +5,18 @@
   <head>
     <%- await include("../common-head.ejs.html", { title: `Configuration files
     for quick-lint-js` }) %>
-    <script>
+    <script id="thisTag">
       //<%
       let fs = await import("fs");
       let asciidoctor = (await import("asciidoctor")).default();
-
       let adoc = await fs.promises.readFile(
         "../../../docs/config.adoc",
         "utf-8"
       );
       let configDocumentation = asciidoctor.convert(adoc);
       //%>
+      var thisTag = document.getElementById('thisTag');
+      thisTag.remove();
     </script>
     <link href="../main.css" rel="stylesheet" />
   </head>

--- a/website/public/errors/error.ejs.html
+++ b/website/public/errors/error.ejs.html
@@ -3,7 +3,7 @@
 <!-- See end of file for extended copyright information. -->
 <html lang="en">
   <head>
-    <script>
+    <script id="thisTag">
       //<%
       let path = await import("path");
       let url = await import("url");
@@ -16,6 +16,8 @@
       let errorCode = path.basename(currentURI);
       let errorDocument = await ErrorDocumentation.parseFileAsync(path.join(documentationDirectoryPath, `${errorCode}.md`));
       //%>
+      var thisTag = document.getElementById('thisTag');
+      thisTag.remove();
     </script>
     <%- await include("../common-head.ejs.html", { title: `${errorCode}
     documentation (quick-lint-js)`, description: `Docs for quick-lint-js error

--- a/website/public/errors/index.ejs.html
+++ b/website/public/errors/index.ejs.html
@@ -6,7 +6,7 @@
     <%- await include("../common-head.ejs.html", { title: `Errors and warnings
     for quick-lint-js`, description: `quick-lint-js provides helpful error
     messages.` }) %>
-    <script>
+    <script id="thisTag">
       //<%
       let url = await import("url");
 
@@ -19,6 +19,8 @@
         documentationDirectoryPath
       );
       //%>
+      var thisTag = document.getElementById('thisTag');
+      thisTag.remove();
     </script>
     <link href="../main.css" rel="stylesheet" />
     <style>

--- a/website/public/releases/index.ejs.html
+++ b/website/public/releases/index.ejs.html
@@ -5,7 +5,7 @@
   <head>
     <%- await include("../common-head.ejs.html", { title: `Release history for
     quick-lint-js`, description: `Older versions of quick-lint-js` }) %>
-    <script>
+    <script id="thisTag">
       //<%
       let fs = await import("fs");
       let url = await import("url");
@@ -14,6 +14,8 @@
         "../../src/release-documentation.mjs"
       );
       //%>
+      var thisTag = document.getElementById('thisTag');
+      thisTag.remove();
     </script>
     <link href="../main.css" rel="stylesheet" />
     <style>


### PR DESCRIPTION
the <script>//</script> lines exist in a lot of files mainly inside the tags <head>, <header> and <footer>.
this will prevent <script> nodes from appearing to clients.