### PR TITLE
Refactor parser::parse_arrow_function_body_impl issue #638

### DIFF
--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -508,8 +508,7 @@ void parser::consume_semicolon() {
 }
 
 bool parser::is_arrow_kind(expression* ast) noexcept {
-  return ast->kind() == expression_kind::arrow_function_with_statements ||
-         ast->kind() == expression_kind::arrow_function_with_expression;
+  return ast->kind() == expression_kind::arrow_function;
 }
 
 parser_transaction parser::begin_transaction() {

--- a/src/quick-lint-js/parse-expression-inl.h
+++ b/src/quick-lint-js/parse-expression-inl.h
@@ -436,7 +436,8 @@ expression* parser::parse_primary_expression(Visitor& v, precedence prec) {
         }
         expression* ast = this->parse_arrow_function_body(
             v, function_attributes::normal, left_paren_span.begin(),
-            /*allow_in_operator=*/prec.in_operator);
+            /*allow_in_operator=*/prec.in_operator,
+            expression_arena::array_ptr<expression*>());
         return ast;
       } else {
         // ()  // Invalid.
@@ -635,7 +636,8 @@ expression* parser::parse_primary_expression(Visitor& v, precedence prec) {
     expression* arrow_function = this->parse_arrow_function_body(
         v, function_attributes::normal,
         /*parameter_list_begin=*/arrow_span.begin(),
-        /*allow_in_operator=*/prec.in_operator);
+        /*allow_in_operator=*/prec.in_operator,
+        expression_arena::array_ptr<expression*>());
     return arrow_function;
   }
 
@@ -1779,16 +1781,6 @@ expression* parser::parse_index_expression_remainder(Visitor& v,
 
 template <QLJS_PARSE_VISITOR Visitor>
 expression* parser::parse_arrow_function_body(
-    Visitor& v, function_attributes attributes,
-    const char8* parameter_list_begin, bool allow_in_operator,
-    expression_arena::array_ptr<expression*>&& parameters) {
-  return this->parse_arrow_function_body_impl(
-      v, attributes, parameter_list_begin, allow_in_operator,
-      std::move(parameters));
-}
-
-template <class Visitor>
-expression* parser::parse_arrow_function_body_impl(
     Visitor& v, function_attributes attributes,
     const char8* parameter_list_begin, bool allow_in_operator,
     expression_arena::array_ptr<expression*>&& parameters) {

--- a/src/quick-lint-js/parse-expression-inl.h
+++ b/src/quick-lint-js/parse-expression-inl.h
@@ -42,8 +42,7 @@ void parser::visit_expression(expression* ast, Visitor& v,
   case expression_kind::_class:
   case expression_kind::_invalid:
   case expression_kind::_missing:
-  case expression_kind::arrow_function_with_expression:
-  case expression_kind::arrow_function_with_statements:
+  case expression_kind::arrow_function:
   case expression_kind::function:
   case expression_kind::import:
   case expression_kind::literal:
@@ -1582,8 +1581,7 @@ void parser::parse_arrow_function_expression_remainder(
   case expression_kind::_new:
   case expression_kind::_template:
   case expression_kind::_typeof:
-  case expression_kind::arrow_function_with_expression:
-  case expression_kind::arrow_function_with_statements:
+  case expression_kind::arrow_function:
   case expression_kind::await:
   case expression_kind::compound_assignment:
   case expression_kind::conditional:
@@ -1807,22 +1805,17 @@ expression* parser::parse_arrow_function_body_impl(
 
   if (this->peek().type == token_type::left_curly) {
     this->parse_and_visit_statement_block_no_scope(v);
-    v.visit_exit_function_scope();
-
-    const char8* span_end = this->lexer_.end_of_previous_token();
-    return this->make_expression<expression::arrow_function_with_statements>(
-        attributes, parameters, parameter_list_begin, span_end);
   } else {
     this->parse_and_visit_expression(v, precedence{
                                             .commas = false,
                                             .in_operator = allow_in_operator,
                                         });
-    v.visit_exit_function_scope();
-
-    const char8* span_end = this->lexer_.end_of_previous_token();
-    return this->make_expression<expression::arrow_function_with_expression>(
-        attributes, parameters, parameter_list_begin, span_end);
   }
+  v.visit_exit_function_scope();
+
+  const char8* span_end = this->lexer_.end_of_previous_token();
+  return this->make_expression<expression::arrow_function>(
+      attributes, parameters, parameter_list_begin, span_end);
 }
 
 template <QLJS_PARSE_VISITOR Visitor>

--- a/src/quick-lint-js/parse-expression-inl.h
+++ b/src/quick-lint-js/parse-expression-inl.h
@@ -1807,7 +1807,7 @@ expression* parser::parse_arrow_function_body(
 
   const char8* span_end = this->lexer_.end_of_previous_token();
   return this->make_expression<expression::arrow_function>(
-      attributes, parameters, parameter_list_begin, span_end);
+      attributes, std::move(parameters), parameter_list_begin, span_end);
 }
 
 template <QLJS_PARSE_VISITOR Visitor>

--- a/src/quick-lint-js/parse-statement-inl.h
+++ b/src/quick-lint-js/parse-statement-inl.h
@@ -3209,8 +3209,7 @@ void parser::visit_binding_element(
   case expression_kind::_new:
   case expression_kind::_template:
   case expression_kind::_typeof:
-  case expression_kind::arrow_function_with_expression:
-  case expression_kind::arrow_function_with_statements:
+  case expression_kind::arrow_function:
   case expression_kind::binary_operator:
   case expression_kind::conditional:
   case expression_kind::conditional_assignment:

--- a/src/quick-lint-js/parse.h
+++ b/src/quick-lint-js/parse.h
@@ -370,13 +370,6 @@ class parser {
   expression *parse_arrow_function_body(
       Visitor &, function_attributes, const char8 *parameter_list_begin,
       bool allow_in_operator,
-      expression_arena::array_ptr<expression *> &&parameters =
-          expression_arena::array_ptr<expression *>());
-
-  template <class Visitor>
-  expression *parse_arrow_function_body_impl(
-      Visitor &, function_attributes, const char8 *parameter_list_begin,
-      bool allow_in_operator,
       expression_arena::array_ptr<expression *> &&parameters);
   template <QLJS_PARSE_VISITOR Visitor>
   expression *parse_function_expression(Visitor &, function_attributes,

--- a/src/quick-lint-js/parse.h
+++ b/src/quick-lint-js/parse.h
@@ -367,22 +367,17 @@ class parser {
   template <QLJS_PARSE_VISITOR Visitor>
   expression *parse_index_expression_remainder(Visitor &, expression *lhs);
   template <QLJS_PARSE_VISITOR Visitor>
-  expression *parse_arrow_function_body(Visitor &, function_attributes,
-                                        const char8 *parameter_list_begin,
-                                        bool allow_in_operator);
-  template <QLJS_PARSE_VISITOR Visitor>
   expression *parse_arrow_function_body(
       Visitor &, function_attributes, const char8 *parameter_list_begin,
       bool allow_in_operator,
+      expression_arena::array_ptr<expression *> &&parameters =
+          expression_arena::array_ptr<expression *>());
+
+  template <class Visitor>
+  expression *parse_arrow_function_body_impl(
+      Visitor &, function_attributes, const char8 *parameter_list_begin,
+      bool allow_in_operator,
       expression_arena::array_ptr<expression *> &&parameters);
-  // Args is either of the following:
-  // * expression_arena::array_ptr<expression*> &&parameters
-  // * (none)
-  template <class Visitor, class... Args>
-  expression *parse_arrow_function_body_impl(Visitor &, function_attributes,
-                                             const char8 *parameter_list_begin,
-                                             bool allow_in_operator,
-                                             Args &&... args);
   template <QLJS_PARSE_VISITOR Visitor>
   expression *parse_function_expression(Visitor &, function_attributes,
                                         const char8 *span_begin);

--- a/test/parse-support.cpp
+++ b/test/parse-support.cpp
@@ -72,10 +72,8 @@ std::string summarize(const expression& expression) {
     return "typeof(" + summarize(expression.child_0()) + ")";
   case expression_kind::array:
     return "array(" + children() + ")";
-  case expression_kind::arrow_function_with_expression:
-    return function_attributes() + "arrowexpr(" + children() + ")";
-  case expression_kind::arrow_function_with_statements:
-    return function_attributes() + "arrowblock(" + children() + ")";
+  case expression_kind::arrow_function:
+    return function_attributes() + "arrowfunc(" + children() + ")";
   case expression_kind::assignment:
     return "assign(" + children() + ")";
   case expression_kind::await:


### PR DESCRIPTION
Refactored the parse_arrow_function_body_impl  member function by merging both expression::arrow_function_with_expression and expression::arrow_function_with_statement  classes into one, also removed the temporary expression from the function parse_arrow_function_body_impl to avoid double parsing of parameters.

I think the last item mentioned in issue #638 it's already done in this commit https://github.com/quick-lint/quick-lint-js/commit/35a362bce7e9b17252da3a0c1d11237ca9268595