### PR TITLE
Fixed #635 and added unit tests

### DIFF
--- a/src/quick-lint-js/parse-statement-inl.h
+++ b/src/quick-lint-js/parse-statement-inl.h
@@ -375,6 +375,7 @@ parse_statement:
         case token_type::slash_equal:  // Regular expression.
         case token_type::string:
         case token_type::tilde:
+        case token_type::less:
           if (statement_type == parse_statement_type::any_statement_in_block) {
             this->error_reporter_->report(
                 error_return_statement_returns_nothing{

--- a/src/quick-lint-js/parse-statement-inl.h
+++ b/src/quick-lint-js/parse-statement-inl.h
@@ -368,6 +368,7 @@ parse_statement:
         case token_type::left_curly:  // Object literal.
         case token_type::left_paren:
         case token_type::left_square:  // Array literal.
+        case token_type::less:
         case token_type::minus:
         case token_type::number:
         case token_type::plus:
@@ -375,7 +376,6 @@ parse_statement:
         case token_type::slash_equal:  // Regular expression.
         case token_type::string:
         case token_type::tilde:
-        case token_type::less:
           if (statement_type == parse_statement_type::any_statement_in_block) {
             this->error_reporter_->report(
                 error_return_statement_returns_nothing{

--- a/test/test-parse-statement.cpp
+++ b/test/test-parse-statement.cpp
@@ -155,17 +155,28 @@ TEST(test_parse, return_statement_disallows_newline) {
            u8"typeof banana",
            u8"{}",
            u8"~bits",
+           u8"<div>hi</div>",
+           u8"<a href=\"github.com/quick-lint/quick-lint-js\">link</a>",
+           u8"<p></p>",
+           u8"<div>this is <b>bold</b> and <i>italic</i> text</div>",
+           u8"<head><title>head and title</title></head>",
            // TODO(strager): Contextual keywords (let, from, yield, etc.).
            // TODO(strager): Function without name. (Must be an expression, not
            // a statement.)
-           // TODO(strager): JSX.
        }) {
     {
       padded_string code(u8"return\n"s + second_line);
       SCOPED_TRACE(code);
       spy_visitor v;
-      parser p(&code, &v);
-      p.parse_and_visit_module(v);
+      if (second_line[0] == '<') {
+        parser_options options;
+        options.jsx = true;
+        parser p(&code, &v, options);
+        p.parse_and_visit_module(v);
+      } else {
+        parser p(&code, &v);
+        p.parse_and_visit_module(v);
+      }
       EXPECT_THAT(v.errors,
                   ElementsAre(ERROR_TYPE_OFFSETS(
                       &code, error_return_statement_returns_nothing,  //
@@ -176,8 +187,15 @@ TEST(test_parse, return_statement_disallows_newline) {
       padded_string code(u8"{ return\n"s + second_line + u8"}");
       SCOPED_TRACE(code);
       spy_visitor v;
-      parser p(&code, &v);
-      p.parse_and_visit_module(v);
+      if (second_line[0] == '<') {
+        parser_options options;
+        options.jsx = true;
+        parser p(&code, &v, options);
+        p.parse_and_visit_module(v);
+      } else {
+        parser p(&code, &v);
+        p.parse_and_visit_module(v);
+      }
       EXPECT_THAT(v.errors,
                   ElementsAre(ERROR_TYPE_OFFSETS(
                       &code, error_return_statement_returns_nothing,  //
@@ -189,8 +207,15 @@ TEST(test_parse, return_statement_disallows_newline) {
                          u8"}");
       SCOPED_TRACE(code);
       spy_visitor v;
-      parser p(&code, &v);
-      p.parse_and_visit_module(v);
+      if (second_line[0] == '<') {
+        parser_options options;
+        options.jsx = true;
+        parser p(&code, &v, options);
+        p.parse_and_visit_module(v);
+      } else {
+        parser p(&code, &v);
+        p.parse_and_visit_module(v);
+      }
       EXPECT_THAT(
           v.errors,
           ElementsAre(ERROR_TYPE_OFFSETS(
@@ -206,8 +231,15 @@ TEST(test_parse, return_statement_disallows_newline) {
           second_line + u8"}");
       SCOPED_TRACE(code);
       spy_visitor v;
-      parser p(&code, &v);
-      p.parse_and_visit_module(v);
+      if (second_line[0] == '<') {
+        parser_options options;
+        options.jsx = true;
+        parser p(&code, &v, options);
+        p.parse_and_visit_module(v);
+      } else {
+        parser p(&code, &v);
+        p.parse_and_visit_module(v);
+      }
       EXPECT_THAT(v.errors,
                   ElementsAre(ERROR_TYPE_OFFSETS(
                       &code, error_return_statement_returns_nothing,  //

--- a/test/test-parse-statement.cpp
+++ b/test/test-parse-statement.cpp
@@ -169,9 +169,7 @@ TEST(test_parse, return_statement_disallows_newline) {
       SCOPED_TRACE(code);
       spy_visitor v;
       if (second_line[0] == '<') {
-        parser_options options;
-        options.jsx = true;
-        parser p(&code, &v, options);
+        parser p(&code, &v, jsx_options);
         p.parse_and_visit_module(v);
       } else {
         parser p(&code, &v);

--- a/test/test-parse-statement.cpp
+++ b/test/test-parse-statement.cpp
@@ -156,10 +156,7 @@ TEST(test_parse, return_statement_disallows_newline) {
            u8"{}",
            u8"~bits",
            u8"<div>hi</div>",
-           u8"<a href=\"github.com/quick-lint/quick-lint-js\">link</a>",
            u8"<p></p>",
-           u8"<div>this is <b>bold</b> and <i>italic</i> text</div>",
-           u8"<head><title>head and title</title></head>",
            // TODO(strager): Contextual keywords (let, from, yield, etc.).
            // TODO(strager): Function without name. (Must be an expression, not
            // a statement.)
@@ -168,13 +165,8 @@ TEST(test_parse, return_statement_disallows_newline) {
       padded_string code(u8"return\n"s + second_line);
       SCOPED_TRACE(code);
       spy_visitor v;
-      if (second_line[0] == '<') {
-        parser p(&code, &v, jsx_options);
-        p.parse_and_visit_module(v);
-      } else {
-        parser p(&code, &v);
-        p.parse_and_visit_module(v);
-      }
+      parser p(&code, &v, jsx_options);
+      p.parse_and_visit_module(v);
       EXPECT_THAT(v.errors,
                   ElementsAre(ERROR_TYPE_OFFSETS(
                       &code, error_return_statement_returns_nothing,  //
@@ -185,15 +177,8 @@ TEST(test_parse, return_statement_disallows_newline) {
       padded_string code(u8"{ return\n"s + second_line + u8"}");
       SCOPED_TRACE(code);
       spy_visitor v;
-      if (second_line[0] == '<') {
-        parser_options options;
-        options.jsx = true;
-        parser p(&code, &v, options);
-        p.parse_and_visit_module(v);
-      } else {
-        parser p(&code, &v);
-        p.parse_and_visit_module(v);
-      }
+      parser p(&code, &v, jsx_options);
+      p.parse_and_visit_module(v);
       EXPECT_THAT(v.errors,
                   ElementsAre(ERROR_TYPE_OFFSETS(
                       &code, error_return_statement_returns_nothing,  //
@@ -205,15 +190,8 @@ TEST(test_parse, return_statement_disallows_newline) {
                          u8"}");
       SCOPED_TRACE(code);
       spy_visitor v;
-      if (second_line[0] == '<') {
-        parser_options options;
-        options.jsx = true;
-        parser p(&code, &v, options);
-        p.parse_and_visit_module(v);
-      } else {
-        parser p(&code, &v);
-        p.parse_and_visit_module(v);
-      }
+      parser p(&code, &v, jsx_options);
+      p.parse_and_visit_module(v);
       EXPECT_THAT(
           v.errors,
           ElementsAre(ERROR_TYPE_OFFSETS(
@@ -229,15 +207,8 @@ TEST(test_parse, return_statement_disallows_newline) {
           second_line + u8"}");
       SCOPED_TRACE(code);
       spy_visitor v;
-      if (second_line[0] == '<') {
-        parser_options options;
-        options.jsx = true;
-        parser p(&code, &v, options);
-        p.parse_and_visit_module(v);
-      } else {
-        parser p(&code, &v);
-        p.parse_and_visit_module(v);
-      }
+      parser p(&code, &v, jsx_options);
+      p.parse_and_visit_module(v);
       EXPECT_THAT(v.errors,
                   ElementsAre(ERROR_TYPE_OFFSETS(
                       &code, error_return_statement_returns_nothing,  //


### PR DESCRIPTION
Previously, the code:
```
return
   <div>hi</div>
```
wouldn't report an error. It now correctly reports E0179 when returning an html tag on a new line. I also added unit tests.