### PR TITLE
Fix build against simdjson 2.2.0

### DIFF
--- a/src/quick-lint-js/padded-string.h
+++ b/src/quick-lint-js/padded-string.h
@@ -18,7 +18,7 @@ class padded_string {
  public:
   using size_type = int;
 
-  static constexpr size_type padding_size = 32;
+  static constexpr size_type padding_size = 64;
 
   explicit padded_string();
   explicit padded_string(string8 &&);


### PR DESCRIPTION
simdjson adjusted the value of `SIMDJSON_PADDING` from `32` to `64` in
simdjson/simdjson@3fde8a4eac96c88c352ff7819bbd116291611155. [1] This breaks
a `static_assert` in quick-lint-js. [2]

Let's fix that by following their lead.

[1] https://github.com/simdjson/simdjson/pull/1856
[2] https://github.com/quick-lint/quick-lint-js/blob/f5301aaf483d79514167ef518e7bb9526d5f2fa3/src/padded-string.cpp#L16-L17
