### PR TITLE
Fix #201 Report warnings for misuse of --vim-file-bufnr 

### DIFF
--- a/src/quick-lint-js/cli/options.h
+++ b/src/quick-lint-js/cli/options.h
@@ -42,7 +42,7 @@ struct options {
   compiled_diag_code_list exit_fail_on;
 
   std::vector<const char *> error_unrecognized_options;
-  std::vector<int> warning_vim_bufnr_without_file;
+  std::vector<const char *> warning_vim_bufnr_without_file;
   bool has_multiple_stdin = false;
   bool has_config_file = false;
   bool has_vim_file_bufnr = false;

--- a/src/quick-lint-js/cli/options.h
+++ b/src/quick-lint-js/cli/options.h
@@ -42,6 +42,7 @@ struct options {
   compiled_diag_code_list exit_fail_on;
 
   std::vector<const char *> error_unrecognized_options;
+  std::vector<int> warning_vim_bufnr_without_file;
   bool has_multiple_stdin = false;
   bool has_config_file = false;
 

--- a/src/quick-lint-js/cli/options.h
+++ b/src/quick-lint-js/cli/options.h
@@ -45,6 +45,7 @@ struct options {
   std::vector<int> warning_vim_bufnr_without_file;
   bool has_multiple_stdin = false;
   bool has_config_file = false;
+  bool has_vim_file_bufnr = false;
 
   bool dump_errors(output_stream &) const;
 };

--- a/test/test-options.cpp
+++ b/test/test-options.cpp
@@ -510,35 +510,35 @@ TEST(test_options, no_following_filename_vim_file_bufnr) {
 }
 
 TEST(test_options, using_vim_file_bufnr_without_format) {
-  for (const auto &format : {
-           output_format::default_format,
-           output_format::gnu_like,
-           output_format::vim_qflist_json,
-           output_format::emacs_lisp,
-       }) {
+  {
+    for (const auto &format : {
+             output_format::default_format,
+             output_format::gnu_like,
+             output_format::emacs_lisp,
+         }) {
+      options o = parse_options({"--vim-file-bufnr=1", "file.js"});
+      o.output_format = format;
+
+      memory_output_stream dumped_errors;
+      bool have_errors = o.dump_errors(dumped_errors);
+      EXPECT_FALSE(have_errors);
+      dumped_errors.flush();
+
+      EXPECT_EQ(dumped_errors.get_flushed_string8(),
+                u8"warning: --output-format selected which doesn't use "
+                u8"--vim-file-bufnr\n");
+    }
+  }
+  {
     options o = parse_options({"--vim-file-bufnr=1", "file.js"});
-    o.output_format = format;
+    o.output_format = output_format::vim_qflist_json;
 
     memory_output_stream dumped_errors;
     bool have_errors = o.dump_errors(dumped_errors);
     EXPECT_FALSE(have_errors);
     dumped_errors.flush();
 
-    string8 expected;
-    switch (format) {
-    case output_format::default_format:
-    case output_format::gnu_like:
-    case output_format::emacs_lisp:
-      expected =
-          u8"warning: --output-format selected which doesn't use "
-          u8"--vim-file-bufnr\n";
-      break;
-    case output_format::vim_qflist_json:
-      expected = u8"";
-      break;
-    }
-
-    EXPECT_EQ(dumped_errors.get_flushed_string8(), expected);
+    EXPECT_EQ(dumped_errors.get_flushed_string8(), u8"");
   }
 }
 

--- a/test/test-options.cpp
+++ b/test/test-options.cpp
@@ -507,6 +507,21 @@ TEST(test_options, no_following_filename_vim_file_bufnr) {
     dumped_errors.flush();
     EXPECT_EQ(dumped_errors.get_flushed_string8(), u8"");
   }
+  {
+    // test if the right argument gets inserted into the error message
+    options o =
+        parse_options({"--vim-file-bufnr=11", "--output-format=vim-qflist-json",
+                       "--vim-file-bufnr=22", "foo.js"});
+    o.output_format = output_format::vim_qflist_json;
+
+    memory_output_stream dumped_errors;
+    bool have_errors = o.dump_errors(dumped_errors);
+    EXPECT_FALSE(have_errors);
+    dumped_errors.flush();
+    EXPECT_EQ(dumped_errors.get_flushed_string8(),
+              u8"warning: flag: '--vim-file-bufnr=11' should be followed by an "
+              u8"input file name or --stdin\n");
+  }
 }
 
 TEST(test_options, using_vim_file_bufnr_without_format) {

--- a/test/test-options.cpp
+++ b/test/test-options.cpp
@@ -441,8 +441,6 @@ TEST(test_options, invalid_vim_file_bufnr) {
   }
 }
 
-// TODO(#201): Report warning for trailing (ununsed) --vim-file-bufnr.
-
 TEST(test_options, no_following_filename_vim_file_bufnr) {
   {
     options o = parse_options({"foo.js", "--vim-file-bufnr=1"});
@@ -511,8 +509,6 @@ TEST(test_options, no_following_filename_vim_file_bufnr) {
   }
 }
 
-// TODO(#201): Report warning for using --vim-file-bufnr without
-// --output-format.
 TEST(test_options, using_vim_file_bufnr_without_format) {
   for (const auto &format : {
            output_format::default_format,

--- a/test/test-options.cpp
+++ b/test/test-options.cpp
@@ -443,6 +443,70 @@ TEST(test_options, invalid_vim_file_bufnr) {
 
 // TODO(#201): Report warning for trailing (ununsed) --vim-file-bufnr.
 
+TEST(test_options, no_following_filename_vim_file_bufnr) {
+  {
+    options o = parse_options({"--vim-file-bufnr=1"});
+
+    memory_output_stream dumped_errors;
+    bool have_errors = o.dump_errors(dumped_errors);
+    EXPECT_TRUE(have_errors);
+    dumped_errors.flush();
+    EXPECT_EQ(dumped_errors.get_flushed_string8(),
+              u8"warning: flag: '--vim-file-bufnr=1' should be followed by an "
+              u8"input file name or --stdin\n");
+  }
+
+  {
+    options o =
+        parse_options({"--vim-file-bufnr=1", "--vim-file-bufnr=2", "a.js"});
+
+    memory_output_stream dumped_errors;
+    bool have_errors = o.dump_errors(dumped_errors);
+    EXPECT_TRUE(have_errors);
+    dumped_errors.flush();
+    EXPECT_EQ(dumped_errors.get_flushed_string8(),
+              u8"warning: flag: '--vim-file-bufnr=1' should be followed by an "
+              u8"input file name or --stdin\n");
+  }
+  {
+    options o =
+        parse_options({"--vim-file-bufnr=1", "a.js", "--vim-file-bufnr=2"});
+
+    memory_output_stream dumped_errors;
+    bool have_errors = o.dump_errors(dumped_errors);
+    EXPECT_TRUE(have_errors);
+    dumped_errors.flush();
+    EXPECT_EQ(dumped_errors.get_flushed_string8(),
+              u8"warning: flag: '--vim-file-bufnr=2' should be followed by an "
+              u8"input file name or --stdin\n");
+  }
+  {
+    options o = parse_options({"--vim-file-bufnr=1", "--vim-file-bufnr=2"});
+
+    memory_output_stream dumped_errors;
+    bool have_errors = o.dump_errors(dumped_errors);
+    EXPECT_TRUE(have_errors);
+    dumped_errors.flush();
+    EXPECT_EQ(dumped_errors.get_flushed_string8(),
+              u8"warning: flag: '--vim-file-bufnr=1' should be followed by an "
+              u8"input file name or --stdin\n"
+              u8"warning: flag: '--vim-file-bufnr=2' should be followed by an "
+              u8"input file name or --stdin\n");
+  }
+  {
+    options o = parse_options({"--vim-file-bufnr=1",
+                               "a.js"
+                               "--vim-file-bufnr=2",
+                               "--stdin"});
+
+    memory_output_stream dumped_errors;
+    bool have_errors = o.dump_errors(dumped_errors);
+    EXPECT_FALSE(have_errors);
+    dumped_errors.flush();
+    EXPECT_EQ(dumped_errors.get_flushed_string8(), u8"");
+  }
+}
+
 // TODO(#201): Report warning for using --vim-file-bufnr without
 // --output-format.
 


### PR DESCRIPTION
fixes #201

I also did notice that the output_stream wouldn't be displayed if it only contains warnings in lsp-mode. To fix this I added a `.flush()` at the  end of `options::dump_errors`.
