### PR TITLE
Fix #814: missing arrow operator error not reported

### DIFF
--- a/src/quick-lint-js/fe/parse-expression.cpp
+++ b/src/quick-lint-js/fe/parse-expression.cpp
@@ -1764,13 +1764,20 @@ next:
     bool looks_like_arrow_function_body =
         prec.trailing_curly_is_arrow_body &&
         !binary_builder.has_multiple_children() &&
-        ((!this->peek().has_leading_newline &&
-          // TODO(strager): Check for ',' operator explicitly, not any binary
-          // operator.
-          binary_builder.last_expression()->without_paren()->kind() ==
-              expression_kind::binary_operator) ||
-         (binary_builder.last_expression()->kind() ==
-          expression_kind::paren_empty));
+        ((  // multiple identifiers: (a, b)
+             !this->peek().has_leading_newline &&
+             // TODO(strager): Check for ',' operator explicitly, not any binary
+             // operator.
+             binary_builder.last_expression()->without_paren()->kind() ==
+                 expression_kind::binary_operator) ||
+         (  // one identifier: (a)
+             binary_builder.last_expression()->kind() ==
+                 expression_kind::paren &&
+             binary_builder.last_expression()->without_paren()->kind() ==
+                 expression_kind::variable) ||
+         (  // no identifier: ()
+             binary_builder.last_expression()->kind() ==
+             expression_kind::paren_empty));
     if (looks_like_arrow_function_body) {
       source_code_span arrow_span = this->peek().span();
       // (a, b) { return a + b; }  // Invalid.

--- a/test/test-parse-function.cpp
+++ b/test/test-parse-function.cpp
@@ -1050,6 +1050,34 @@ TEST_F(test_parse_function, arrow_function_expression_without_arrow_operator) {
   }
 
   {
+    test_parser p(u8"((a) {});"_sv, capture_diags);
+    p.parse_and_visit_module();
+    EXPECT_THAT(p.visits, ElementsAre("visit_enter_function_scope",       //
+                                      "visit_variable_declaration",       // a
+                                      "visit_enter_function_scope_body",  //
+                                      "visit_exit_function_scope",        //
+                                      "visit_end_of_module"));
+    EXPECT_THAT(p.errors,
+                ElementsAre(DIAG_TYPE_OFFSETS(
+                    p.code, diag_missing_arrow_operator_in_arrow_function,  //
+                    where, strlen(u8"((a) "), u8"{")));
+  }
+
+  {
+    test_parser p(u8"(async (a) {});"_sv, capture_diags);
+    p.parse_and_visit_module();
+    EXPECT_THAT(p.visits, ElementsAre("visit_enter_function_scope",       //
+                                      "visit_variable_declaration",       // a
+                                      "visit_enter_function_scope_body",  //
+                                      "visit_exit_function_scope",        //
+                                      "visit_end_of_module"));
+    EXPECT_THAT(p.errors,
+                ElementsAre(DIAG_TYPE_OFFSETS(
+                    p.code, diag_missing_arrow_operator_in_arrow_function,  //
+                    where, strlen(u8"(async (a) "), u8"{")));
+  }
+
+  {
     test_parser p(u8"((a, b) {});"_sv, capture_diags);
     p.parse_and_visit_module();
     EXPECT_THAT(p.visits, ElementsAre("visit_enter_function_scope",       //


### PR DESCRIPTION
fixes #814

Looks like it failed only if the arrow function had one argument.

Before:
```javascript
// test.js
let b1 = ()  {};
let b2 = (a)  {};
let b3 = (a, a)  {};
```
```
$ ./build/quick-lint-js test.js
test.js:1:14: error: missing arrow operator for arrow function [E0176]
test.js:2:13: error: missing ',' between variable declarations [E0132]
test.js:3:18: error: missing arrow operator for arrow function [E0176]
test.js:2:11: warning: use of undeclared variable: a [E0057]
```

After:
```javascript
// test.js
let b1 = ()  {};
let b2 = (a)  {};
let b3 = (a, a)  {};
```
```
$ ./build/quick-lint-js test.js
test.js:1:14: error: missing arrow operator for arrow function [E0176]
test.js:2:15: error: missing arrow operator for arrow function [E0176]
test.js:3:18: error: missing arrow operator for arrow function [E0176]
```