### PR TITLE
Fix #528: Optimize lexer::skip_line_comment_body with SIMD

### DIFF
--- a/src/quick-lint-js/fe/lex.cpp
+++ b/src/quick-lint-js/fe/lex.cpp
@@ -2042,22 +2042,21 @@ void lexer::skip_line_comment_body() {
 #endif
 
   auto found_comment_end = [&]() {
-    if (*this->input_ == '\n' || *this->input_ == '\r') {
+    int n = newline_character_size(this->input_);
+
+    if (n == 1) {
       this->input_ += 1;
       this->skip_whitespace();
       return true;
     }
-    if (*this->input_ == u8'\0' && this->is_eof(this->input_)) {
-      return true;
-    }
     // U+2028 Line Separator
     // U+2029 Paragraph Separator
-    if (static_cast<unsigned char>(this->input_[0]) == 0xe2 &&
-        static_cast<unsigned char>(this->input_[1]) == 0x80 &&
-        (static_cast<unsigned char>(this->input_[2]) == 0xa8 ||
-         static_cast<unsigned char>(this->input_[2]) == 0xa9)) {
+    if (n == 3) {
       this->input_ += 3;
       this->skip_whitespace();
+      return true;
+    }
+    if (*this->input_ == u8'\0' && this->is_eof(this->input_)) {
       return true;
     }
 

--- a/src/quick-lint-js/fe/lex.cpp
+++ b/src/quick-lint-js/fe/lex.cpp
@@ -2033,19 +2033,62 @@ found_end_of_file:
 }
 
 void lexer::skip_line_comment_body() {
-  for (const char8* c = this->input_;; ++c) {
-    int newline_size = this->newline_character_size(c);
-    if (newline_size > 0) {
-      this->input_ = c + newline_size;
+#if QLJS_HAVE_X86_SSE2
+  using bool_vector = bool_vector_16_sse2;
+  using char_vector = char_vector_16_sse2;
+#else
+  using bool_vector = bool_vector_1;
+  using char_vector = char_vector_1;
+#endif
+
+  auto found_comment_end = [&]() {
+    if (*this->input_ == '\n' || *this->input_ == '\r') {
+      this->input_ += 1;
       this->skip_whitespace();
-      break;
+      return true;
     }
-    // TODO(strager): Should we handle null bytes differently for #! comments?
-    if (*c == u8'\0' && this->is_eof(c)) {
-      this->input_ = c;
-      break;
+    if (*this->input_ == u8'\0' && this->is_eof(this->input_)) {
+      return true;
+    }
+    // U+2028 Line Separator
+    // U+2029 Paragraph Separator
+    if (static_cast<unsigned char>(this->input_[0]) == 0xe2 &&
+        static_cast<unsigned char>(this->input_[1]) == 0x80 &&
+        (static_cast<unsigned char>(this->input_[2]) == 0xa8 ||
+         static_cast<unsigned char>(this->input_[2]) == 0xa9)) {
+      this->input_ += 3;
+      this->skip_whitespace();
+      return true;
+    }
+
+    this->input_ += 1;
+    return false;
+  };
+
+  char_vector newLine = char_vector::repeated('\n');
+  char_vector carriageReturn = char_vector::repeated('\r');
+  char_vector unicodeFirstByte = char_vector::repeated(0xe2);  // U+2028 U+2029
+  char_vector zero = char_vector::repeated(0);
+
+  while (true) {
+    char_vector chars = char_vector::load(this->input_);
+
+    bool_vector matches = (chars == newLine) | (chars == carriageReturn) |
+                          (chars == unicodeFirstByte) | (chars == zero);
+
+    std::uint32_t mask = matches.mask();
+    if (mask == 0) {
+      // nothing found, go to the next chunk
+      this->input_ += char_vector::size;
+    } else {
+      // found an interesting char
+      this->input_ += countr_zero(mask);
+      if (found_comment_end()) {
+        break;
+      }
     }
   }
+
   this->last_token_.has_leading_newline = true;
 }
 

--- a/src/quick-lint-js/fe/lex.cpp
+++ b/src/quick-lint-js/fe/lex.cpp
@@ -2033,7 +2033,13 @@ found_end_of_file:
 }
 
 void lexer::skip_line_comment_body() {
-#if QLJS_HAVE_X86_SSE2
+#if QLJS_HAVE_ARM_NEON
+  using bool_vector = bool_vector_16_neon;
+  using char_vector = char_vector_16_neon;
+#elif QLJS_HAVE_WEB_ASSEMBLY_SIMD128
+  using bool_vector = bool_vector_16_wasm_simd128;
+  using char_vector = char_vector_16_wasm_simd128;
+#elif QLJS_HAVE_X86_SSE2
   using bool_vector = bool_vector_16_sse2;
   using char_vector = char_vector_16_sse2;
 #else

--- a/test/test-lex.cpp
+++ b/test/test-lex.cpp
@@ -235,6 +235,15 @@ TEST_F(test_lex, lex_line_comments) {
   EXPECT_THAT(this->lex_to_eof(u8"// hello\n// world"_sv), IsEmpty());
   this->check_tokens(u8"hello//*/\n \n \nworld"_sv,
                      {token_type::identifier, token_type::identifier});
+
+  /**
+   * Also test for a unicode sign that starts with 0xe280, because the
+   * skip_line_comment() will also look for U+2028 and U+2029
+   *  > U+2028 Line Separator      (0xe280a8)
+   *  > U+2029 Paragraph Separator (0xe280a9)
+   *  > U+2030 Per Mille Sign      (0xe280b0)
+   */
+  EXPECT_THAT(this->lex_to_eof(u8"// 123‰"_sv), IsEmpty());
 }
 
 TEST_F(test_lex, lex_line_comments_with_control_characters) {


### PR DESCRIPTION
fixes #528

## Summary
With SIMD, parsing only comments is 59% faster, but without SIMD the fallback is now 45% slower.
On [jquery-3.6.0.js](https://code.jquery.com/jquery-3.6.0.js) the effect is very marginal. about 1% faster with SIMD and about 1% slower without.

Can I make this even faster? Maybe without losing so much performance for the fallback?

## Test Setup

	$ mkdir build ; cd build ; cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DQUICK_LINT_JS_ENABLE_BENCHMARKS=YES .. ; cd "$OLDPWD"
	$ ninja -C build

	$ export QLJS_LINT_BENCHMARK_SOURCE_FILE=./jquery-3.6.0.js	# or test.js
	$ export QLJS_PARSE_BENCHMARK_SOURCE_FILE=./jquery-3.6.0.js	# or test.js

	$ ./build/benchmark/quick-lint-js-benchmark-lint \
		--benchmark_min_time=2 \
		--benchmark_repetitions=10 \
		--benchmark_counters_tabular=true \
		--benchmark_filter=benchmark_parse_and_lint \
		--benchmark_out_format=json \
		--benchmark_out=******-**.json

## Test Files
[jquery-3.6.0.js](https://code.jquery.com/jquery-3.6.0.js)
[test.js](https://github.com/quick-lint/quick-lint-js/files/9332245/test.js.txt)

## Results
The file names mean the following:
 - `before` for commit 2437f62faca2614b0d80c5c6af1bcb1366a82820
 - `after0` for commit aa0b4897791446d72b978713a269d534c1870982 without SIMD
 - `after1` for commit aa0b4897791446d72b978713a269d534c1870982 with SIMD
 - `-jq` for jquery
 - `-te` for test.js

#### test.js | before -> after with SIMD
```
Comparing before-te.json to after1-te.json
Benchmark                                         Time             CPU      Time Old      Time New       CPU Old       CPU New
------------------------------------------------------------------------------------------------------------------------------
benchmark_parse_and_lint                       -0.5930         -0.5930          2351           957          2350           956
benchmark_parse_and_lint                       -0.5959         -0.5959          2353           951          2351           950
benchmark_parse_and_lint                       -0.5979         -0.5978          2351           945          2349           945
benchmark_parse_and_lint                       -0.6024         -0.6024          2378           945          2376           945
benchmark_parse_and_lint                       -0.6008         -0.6008          2372           947          2371           946
benchmark_parse_and_lint                       -0.5966         -0.5966          2368           955          2366           955
benchmark_parse_and_lint                       -0.5924         -0.5924          2330           950          2329           949
benchmark_parse_and_lint                       -0.5912         -0.5912          2331           953          2329           952
benchmark_parse_and_lint                       -0.5961         -0.5961          2346           948          2345           947
benchmark_parse_and_lint                       -0.5923         -0.5923          2334           951          2333           951
benchmark_parse_and_lint_pvalue                 0.0002          0.0002      U Test, Repetitions: 10 vs 10
benchmark_parse_and_lint_mean                  -0.5959         -0.5959          2351           950          2350           950
benchmark_parse_and_lint_median                -0.5958         -0.5958          2351           950          2350           950
benchmark_parse_and_lint_stddev                -0.7695         -0.7693            17             4            17             4
benchmark_parse_and_lint_cv                    -0.4296         -0.4290             0             0             0             0
OVERALL_GEOMEAN                                -0.5961         -0.5960             0             0             0             0
```
#### test.js | before -> after without SIMD
```
Comparing before-te.json to after0-te.json
Benchmark                                         Time             CPU      Time Old      Time New       CPU Old       CPU New
------------------------------------------------------------------------------------------------------------------------------
benchmark_parse_and_lint                       +0.4633         +0.4631          2351          3440          2350          3438
benchmark_parse_and_lint                       +0.4607         +0.4604          2353          3436          2351          3434
benchmark_parse_and_lint                       +0.4637         +0.4638          2351          3441          2349          3439
benchmark_parse_and_lint                       +0.4443         +0.4440          2378          3434          2376          3432
benchmark_parse_and_lint                       +0.4473         +0.4471          2372          3433          2371          3431
benchmark_parse_and_lint                       +0.4527         +0.4525          2368          3439          2366          3437
benchmark_parse_and_lint                       +0.4722         +0.4718          2330          3431          2329          3428
benchmark_parse_and_lint                       +0.4702         +0.4700          2331          3426          2329          3424
benchmark_parse_and_lint                       +0.4529         +0.4526          2346          3409          2345          3406
benchmark_parse_and_lint                       +0.4683         +0.4682          2334          3427          2333          3425
benchmark_parse_and_lint_pvalue                 0.0002          0.0002      U Test, Repetitions: 10 vs 10
benchmark_parse_and_lint_mean                  +0.4595         +0.4593          2351          3432          2350          3429
benchmark_parse_and_lint_median                +0.4605         +0.4604          2351          3434          2350          3431
benchmark_parse_and_lint_stddev                -0.4400         -0.4349            17            10            17            10
benchmark_parse_and_lint_cv                    -0.6163         -0.6127             0             0             0             0
OVERALL_GEOMEAN                                +0.4597         +0.4593             0             0             0             0
```
#### jquery-3.6.0.js | before -> after with SIMD
```
Comparing before-jq.json to after1-jq.json
Benchmark                                         Time             CPU      Time Old      Time New       CPU Old       CPU New
------------------------------------------------------------------------------------------------------------------------------
benchmark_parse_and_lint                       -0.0095         -0.0095       2683920       2658407       2682541       2657034
benchmark_parse_and_lint                       -0.0118         -0.0118       2698131       2666344       2696717       2664904
benchmark_parse_and_lint                       -0.0135         -0.0135       2679004       2642768       2677561       2641407
benchmark_parse_and_lint                       -0.0104         -0.0104       2699775       2671665       2698359       2670224
benchmark_parse_and_lint                       -0.0164         -0.0164       2692817       2648654       2691413       2647259
benchmark_parse_and_lint                       -0.0072         -0.0072       2665869       2646720       2664413       2645359
benchmark_parse_and_lint                       -0.0128         -0.0128       2672521       2638298       2671131       2636897
benchmark_parse_and_lint                       -0.0100         -0.0100       2659630       2632928       2658208       2631542
benchmark_parse_and_lint                       -0.0099         -0.0099       2670021       2643622       2668611       2642223
benchmark_parse_and_lint                     
[test.js.txt](https://github.com/quick-lint/quick-lint-js/files/9332244/test.js.txt)
  -0.0037         -0.0037       2663185       2653257       2661761       2651874
benchmark_parse_and_lint_pvalue                 0.0013          0.0013      U Test, Repetitions: 10 vs 10
benchmark_parse_and_lint_mean                  -0.0105         -0.0105       2678487       2650266       2677072       2648872
benchmark_parse_and_lint_median                -0.0105         -0.0105       2675763       2647687       2674346       2646309
benchmark_parse_and_lint_stddev                -0.1634         -0.1650         14645         12252         14652         12235
benchmark_parse_and_lint_cv                    -0.1545         -0.1561             0             0             0             0
OVERALL_GEOMEAN                                -0.0105         -0.0105             0             0             0             0
```
#### jquery-3.6.0.js | before -> after without SIMD
```
Comparing before-jq.json to after0-jq.json
Benchmark                                         Time             CPU      Time Old      Time New       CPU Old       CPU New
------------------------------------------------------------------------------------------------------------------------------
benchmark_parse_and_lint                       +0.0069         +0.0069       2683920       2702383       2682541       2700952
benchmark_parse_and_lint                       +0.0053         +0.0053       2698131       2712546       2696717       2711138
benchmark_parse_and_lint                       +0.0099         +0.0100       2679004       2705591       2677561       2704211
benchmark_parse_and_lint                       -0.0039         -0.0039       2699775       2689300       2698359       2687897
benchmark_parse_and_lint                       +0.0069         +0.0069       2692817       2711318       2691413       2709894
benchmark_parse_and_lint                       +0.0155         +0.0155       2665869       2707113       2664413       2705722
benchmark_parse_and_lint                       +0.0092         +0.0092       2672521       2697007       2671131       2695609
benchmark_parse_and_lint                       +0.0129         +0.0129       2659630       2693963       2658208       2692562
benchmark_parse_and_lint                       +0.0127         +0.0127       2670021       2703946       2668611       2702539
benchmark_parse_and_lint                       +0.0132         +0.0133       2663185       2698450       2661761       2697077
benchmark_parse_and_lint_pvalue                 0.0017          0.0017      U Test, Repetitions: 10 vs 10
benchmark_parse_and_lint_mean                  +0.0088         +0.0088       2678487       2702162       2677072       2700760
benchmark_parse_and_lint_median                +0.0102         +0.0102       2675763       2703164       2674346       2701745
benchmark_parse_and_lint_stddev                -0.4889         -0.4895         14645          7485         14652          7481
benchmark_parse_and_lint_cv                    -0.4934         -0.4939             0             0             0             0
OVERALL_GEOMEAN                                +0.0088         +0.0089             0             0             0             0
```


