### PR TITLE
Fix 821: Warn on x === [], x === {}, etc

### DIFF
--- a/docs/errors/E0341.md
+++ b/docs/errors/E0341.md
@@ -1,0 +1,25 @@
+# E0341: using '===' or '!==' against an array literal does not compare items
+
+Using the strict equality or inequality operator against an array literal will not compare the items in them, e.g. 
+
+```javascript
+let x = [1, 2, 3];
+
+// the expression inside the if statement is always 'false'
+if (x === [1, 2, 3]) { 
+}
+
+// the expression inside the if statement is always 'true'
+if (x !== [1, 2, 3]) { 
+}
+```
+
+There are several ways to fix this warning, for example, we could compare all items manually, or, we could craft a JSON string and compare them
+
+```javascript
+let x = [1, 2, 3];
+
+if (JSON.stringify(x) === JSON.stringify([1, 2, 3])) {
+}
+```
+

--- a/docs/errors/E0342.md
+++ b/docs/errors/E0342.md
@@ -1,0 +1,59 @@
+# E0342: using equality or inequality operators against an arrow function will always produce the same result
+
+Using equality or inequality operators against an arrow function will always yield the same result (false or true), e.g. In the code below, the equality operator is used by mistake against an arrow function.
+
+```javascript
+class Car {
+  constructor(acceleration, speed) {
+    this.acceleration = acceleration;
+    this.speed = speed;
+  }
+
+  hitTheGas(acceleration) {
+    this.acceleration += acceleration;
+  }
+};
+
+let vehicle = new Car(0, 0);
+
+let acceleration = (force) => {
+  vehicle.hitTheGas(10 * force);
+};
+
+let sport_mode = true;
+
+if (sport_mode) {
+  acceleration == (force) => {
+    vehicle.hitTheGas(15 * force);
+  };
+}
+```
+
+To fix this warning, we need to replace the equality operator with the assigment operator.
+
+```javascript
+class Car {
+  constructor(acceleration, speed) {
+    this.acceleration = acceleration;
+    this.speed = speed;
+  }
+
+  hitTheGas(acceleration) {
+    this.acceleration += acceleration;
+  }
+};
+
+let vehicle = new Car(0, 0);
+
+let acceleration = (force) => {
+  vehicle.hitTheGas(10 * force);
+};
+
+let sport_mode = true;
+
+if (sport_mode) {
+  acceleration = (force) => {
+    vehicle.hitTheGas(15 * force);
+  };
+}
+```

--- a/docs/errors/E0344.md
+++ b/docs/errors/E0344.md
@@ -1,0 +1,26 @@
+# E0344: using '===' or '!==' against an empty array literal always produces the same result
+
+
+Using the strict equality operator against an empty array literal will always return 'false', and using the strict inequality operator will always return 'true'. e.g. the conditions below will always be 'false' and 'true' respectively, no matter what value 'x' holds.
+
+```javascript
+let x = [];
+
+// the expression inside the if statement is always 'false'
+if (x === []) { 
+}
+
+// the expression inside the if statement is always 'true'
+if (x !== []) { 
+}
+```
+
+To fix this particular example, we could compare the length of the array
+
+```javascript
+let x = [];
+
+if (x.length === 0) {
+}
+```
+

--- a/docs/errors/E0345.md
+++ b/docs/errors/E0345.md
@@ -1,0 +1,31 @@
+# E0345: using equality or inequality operators against an object literal always produces the same result
+
+
+Using equality or inequality operators against any object literal will always yield false or true respectively, e.g. 
+
+```javascript
+const cat = {
+  name: 'Morris',
+  sex: 'Male',
+};
+
+// the expression inside the if statement is always 'false'
+if (cat === { name: 'Morris', sex: 'Male' }) { 
+}
+
+// the expression inside the if statement is always 'true'
+if (cat !== { name: 'Morris', sex: 'Male' }) { 
+}
+```
+
+To fix this particular example, we could compare the properties manually
+
+```javascript
+const cat = {
+  name: 'Morris',
+  sex: 'Male',
+};
+
+if (cat.name === 'Morris' && cat.sex === 'Male') {
+}
+```

--- a/po/de.po
+++ b/po/de.po
@@ -1773,6 +1773,30 @@ msgstr "Kleinbuchstaben werden mit toUpperCase verglichen"
 msgid "upper case letters compared with toLowerCase"
 msgstr "Großbuchstaben werden mit toLowerCase verglichen"
 
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "using '{0}' against an array literal does not compare items"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "using '{0}' against an arrow function always returns '{1}'"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "using '{0}' against a class literal always returns '{1}'"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "'{0} []' is always '{1}'"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "using '{0}' against an object literal always returns '{1}'"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "using '{0}' against a regular expression literal always returns '{1}'"
+msgstr ""
+
 #: test/test-diagnostic-formatter.cpp
 #: test/test-vim-qflist-json-diag-reporter.cpp
 msgid "something happened"

--- a/po/en_US@snarky.po
+++ b/po/en_US@snarky.po
@@ -1653,6 +1653,30 @@ msgstr "You sure you're getting what toUpperCase does?"
 msgid "upper case letters compared with toLowerCase"
 msgstr "You sure you're getting what toLowerCase does?"
 
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "using '{0}' against an array literal does not compare items"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "using '{0}' against an arrow function always returns '{1}'"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "using '{0}' against a class literal always returns '{1}'"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "'{0} []' is always '{1}'"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "using '{0}' against an object literal always returns '{1}'"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "using '{0}' against a regular expression literal always returns '{1}'"
+msgstr ""
+
 #: test/test-diagnostic-formatter.cpp
 #: test/test-vim-qflist-json-diag-reporter.cpp
 msgid "something happened"

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -1789,6 +1789,30 @@ msgstr ""
 msgid "upper case letters compared with toLowerCase"
 msgstr ""
 
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "using '{0}' against an array literal does not compare items"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "using '{0}' against an arrow function always returns '{1}'"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "using '{0}' against a class literal always returns '{1}'"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "'{0} []' is always '{1}'"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "using '{0}' against an object literal always returns '{1}'"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "using '{0}' against a regular expression literal always returns '{1}'"
+msgstr ""
+
 #: test/test-diagnostic-formatter.cpp
 #: test/test-vim-qflist-json-diag-reporter.cpp
 msgid "something happened"

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -1543,6 +1543,30 @@ msgstr ""
 msgid "upper case letters compared with toLowerCase"
 msgstr ""
 
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "using '{0}' against an array literal does not compare items"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "using '{0}' against an arrow function always returns '{1}'"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "using '{0}' against a class literal always returns '{1}'"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "'{0} []' is always '{1}'"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "using '{0}' against an object literal always returns '{1}'"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "using '{0}' against a regular expression literal always returns '{1}'"
+msgstr ""
+
 #: test/test-diagnostic-formatter.cpp
 #: test/test-vim-qflist-json-diag-reporter.cpp
 msgid "something happened"

--- a/po/sv_SE.po
+++ b/po/sv_SE.po
@@ -1668,6 +1668,30 @@ msgstr ""
 msgid "upper case letters compared with toLowerCase"
 msgstr ""
 
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "using '{0}' against an array literal does not compare items"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "using '{0}' against an arrow function always returns '{1}'"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "using '{0}' against a class literal always returns '{1}'"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "'{0} []' is always '{1}'"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "using '{0}' against an object literal always returns '{1}'"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "using '{0}' against a regular expression literal always returns '{1}'"
+msgstr ""
+
 #: test/test-diagnostic-formatter.cpp
 #: test/test-vim-qflist-json-diag-reporter.cpp
 msgid "something happened"

--- a/src/quick-lint-js/fe/diagnostic-types.h
+++ b/src/quick-lint-js/fe/diagnostic-types.h
@@ -2530,6 +2530,67 @@
           QLJS_TRANSLATABLE("upper case letters compared with toLowerCase"),    \
           span_operator))                                                       \
                                                                                 \
+  QLJS_DIAG_TYPE(                                                               \
+      diag_pointless_strict_comp_against_array_literal, "E0341",                \
+      diagnostic_severity::warning, { source_code_span equals_operator; },      \
+      MESSAGE(                                                                  \
+          QLJS_TRANSLATABLE(                                                    \
+              "using '{0}' against an array literal does not compare items"),   \
+          equals_operator))                                                     \
+                                                                                \
+  QLJS_DIAG_TYPE(                                                               \
+      diag_pointless_comp_against_arrow_function, "E0342",                      \
+      diagnostic_severity::warning,                                             \
+      {                                                                         \
+        source_code_span equals_operator;                                       \
+        string8_view comparison_result;                                         \
+      },                                                                        \
+      MESSAGE(QLJS_TRANSLATABLE("using '{0}' against an arrow "                 \
+                                "function always returns '{1}'"),               \
+              equals_operator, comparison_result))                              \
+                                                                                \
+  QLJS_DIAG_TYPE(                                                               \
+      diag_pointless_comp_against_class_literal, "E0343",                       \
+      diagnostic_severity::warning,                                             \
+      {                                                                         \
+        source_code_span equals_operator;                                       \
+        string8_view comparison_result;                                         \
+      },                                                                        \
+      MESSAGE(QLJS_TRANSLATABLE("using '{0}' against a class "                  \
+                                "literal always returns '{1}'"),                \
+              equals_operator, comparison_result))                              \
+                                                                                \
+  QLJS_DIAG_TYPE(                                                               \
+      diag_pointless_strict_comp_against_empty_array_literal, "E0344",          \
+      diagnostic_severity::warning,                                             \
+      {                                                                         \
+        source_code_span equals_operator;                                       \
+        string8_view comparison_result;                                         \
+      },                                                                        \
+      MESSAGE(QLJS_TRANSLATABLE("'{0} []' is always '{1}'"), equals_operator,   \
+              comparison_result))                                               \
+                                                                                \
+  QLJS_DIAG_TYPE(                                                               \
+      diag_pointless_comp_against_object_literal, "E0345",                      \
+      diagnostic_severity::warning,                                             \
+      {                                                                         \
+        source_code_span equals_operator;                                       \
+        string8_view comparison_result;                                         \
+      },                                                                        \
+      MESSAGE(QLJS_TRANSLATABLE("using '{0}' against an object "                \
+                                "literal always returns '{1}'"),                \
+              equals_operator, comparison_result))                              \
+                                                                                \
+  QLJS_DIAG_TYPE(                                                               \
+      diag_pointless_comp_against_regular_expression_literal, "E0346",          \
+      diagnostic_severity::warning,                                             \
+      {                                                                         \
+        source_code_span equals_operator;                                       \
+        string8_view comparison_result;                                         \
+      },                                                                        \
+      MESSAGE(QLJS_TRANSLATABLE("using '{0}' against a regular "                \
+                                "expression literal always returns '{1}'"),     \
+              equals_operator, comparison_result))                              \
   /* END */
 
 // QLJS_X_RESERVED_DIAG_TYPES lists reserved error codes. These codes were used

--- a/src/quick-lint-js/fe/parse-expression.cpp
+++ b/src/quick-lint-js/fe/parse-expression.cpp
@@ -65,6 +65,8 @@ void parser::visit_expression(expression* ast, parse_visitor_base& v,
     break;
   case expression_kind::binary_operator:
     visit_children();
+    this->error_on_pointless_compare_against_literal(
+        static_cast<expression::binary_operator*>(ast));
     error_on_pointless_string_compare(
         static_cast<expression::binary_operator*>(ast));
     break;

--- a/src/quick-lint-js/fe/parse.h
+++ b/src/quick-lint-js/fe/parse.h
@@ -376,6 +376,10 @@ class parser {
 
   void error_on_sketchy_condition(expression *);
   void error_on_pointless_string_compare(expression::binary_operator *);
+  void error_on_pointless_compare_against_literal(
+      expression::binary_operator *);
+  void check_compare_against_literal(expression *, expression *,
+                                     source_code_span op_span);
   void error_on_invalid_as_const(expression *, source_code_span as_const_span);
 
   void error_on_class_statement(statement_kind statement_kind);

--- a/src/quick-lint-js/i18n/translation-table-generated.cpp
+++ b/src/quick-lint-js/i18n/translation-table-generated.cpp
@@ -49,7 +49,8 @@ const translation_table translation_data = {
         {0, 0, 0, 0, 38},             //
         {73, 31, 0, 0, 38},           //
         {15, 14, 0, 0, 13},           //
-        {15, 38, 0, 0, 17},           //
+        {0, 0, 0, 0, 17},             //
+        {15, 38, 0, 0, 25},           //
         {15, 17, 0, 0, 17},           //
         {0, 0, 0, 0, 50},             //
         {69, 48, 0, 0, 32},           //
@@ -379,7 +380,12 @@ const translation_table translation_data = {
         {50, 47, 31, 18, 53},         //
         {0, 33, 0, 0, 55},            //
         {64, 31, 79, 68, 28},         //
-        {57, 29, 48, 41, 32},         //
+        {0, 0, 0, 0, 32},             //
+        {0, 0, 0, 0, 57},             //
+        {0, 0, 0, 0, 70},             //
+        {0, 0, 0, 0, 60},             //
+        {0, 0, 0, 0, 59},             //
+        {57, 29, 48, 41, 59},         //
         {37, 26, 31, 35, 31},         //
         {38, 49, 41, 37, 41},         //
         {30, 29, 24, 27, 23},         //
@@ -1333,6 +1339,7 @@ const translation_table translation_data = {
         u8"'type' cannot be used twice in import\0"
         u8"'while' loop\0"
         u8"'with' statement\0"
+        u8"'{0} []' is always '{1}'\0"
         u8"'{0}' found here\0"
         u8"'{0}' is not allowed for strings; use {1} instead\0"
         u8"'{0}' is not allowed on methods\0"
@@ -1663,6 +1670,11 @@ const translation_table translation_data = {
         u8"use 'while' instead to loop until a condition is false\0"
         u8"use of undeclared type: {0}\0"
         u8"use of undeclared variable: {0}\0"
+        u8"using '{0}' against a class literal always returns '{1}'\0"
+        u8"using '{0}' against a regular expression literal always returns '{1}'\0"
+        u8"using '{0}' against an array literal does not compare items\0"
+        u8"using '{0}' against an arrow function always returns '{1}'\0"
+        u8"using '{0}' against an object literal always returns '{1}'\0"
         u8"variable already declared here\0"
         u8"variable assigned before its declaration\0"
         u8"variable declared here\0"

--- a/src/quick-lint-js/i18n/translation-table-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-generated.h
@@ -20,8 +20,8 @@ namespace quick_lint_js {
 using namespace std::literals::string_view_literals;
 
 constexpr std::uint32_t translation_table_locale_count = 4;
-constexpr std::uint16_t translation_table_mapping_table_size = 385;
-constexpr std::size_t translation_table_string_table_size = 55280;
+constexpr std::uint16_t translation_table_mapping_table_size = 391;
+constexpr std::size_t translation_table_string_table_size = 55610;
 constexpr std::size_t translation_table_locale_table_size = 29;
 
 QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
@@ -66,6 +66,7 @@ QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
           "'type' cannot be used twice in import"sv,
           "'while' loop"sv,
           "'with' statement"sv,
+          "'{0} []' is always '{1}'"sv,
           "'{0}' found here"sv,
           "'{0}' is not allowed for strings; use {1} instead"sv,
           "'{0}' is not allowed on methods"sv,
@@ -396,6 +397,11 @@ QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
           "use 'while' instead to loop until a condition is false"sv,
           "use of undeclared type: {0}"sv,
           "use of undeclared variable: {0}"sv,
+          "using '{0}' against a class literal always returns '{1}'"sv,
+          "using '{0}' against a regular expression literal always returns '{1}'"sv,
+          "using '{0}' against an array literal does not compare items"sv,
+          "using '{0}' against an arrow function always returns '{1}'"sv,
+          "using '{0}' against an object literal always returns '{1}'"sv,
           "variable already declared here"sv,
           "variable assigned before its declaration"sv,
           "variable declared here"sv,

--- a/test/quick-lint-js/test-translation-table-generated.h
+++ b/test/quick-lint-js/test-translation-table-generated.h
@@ -26,7 +26,7 @@ struct translated_string {
   const char8 *expected_per_locale[5];
 };
 
-extern const translated_string test_translation_table[384];
+extern const translated_string test_translation_table[390];
 }
 
 #endif

--- a/test/test-translation-table-generated.cpp
+++ b/test/test-translation-table-generated.cpp
@@ -391,6 +391,16 @@ const translated_string test_translation_table[] = {
         },
     },
     {
+        "'{0} []' is always '{1}'"_translatable,
+        {
+            u8"'{0} []' is always '{1}'",
+            u8"'{0} []' is always '{1}'",
+            u8"'{0} []' is always '{1}'",
+            u8"'{0} []' is always '{1}'",
+            u8"'{0} []' is always '{1}'",
+        },
+    },
+    {
         "'{0}' found here"_translatable,
         {
             u8"'{0}' found here",
@@ -3688,6 +3698,56 @@ const translated_string test_translation_table[] = {
             u8"did you fail spelling class?",
             u8"utilisation d'une variable non d\u00e9clar\u00e9e : {0}",
             u8"anv\u00e4ndning av odeklarerad variabel: {0}",
+        },
+    },
+    {
+        "using '{0}' against a class literal always returns '{1}'"_translatable,
+        {
+            u8"using '{0}' against a class literal always returns '{1}'",
+            u8"using '{0}' against a class literal always returns '{1}'",
+            u8"using '{0}' against a class literal always returns '{1}'",
+            u8"using '{0}' against a class literal always returns '{1}'",
+            u8"using '{0}' against a class literal always returns '{1}'",
+        },
+    },
+    {
+        "using '{0}' against a regular expression literal always returns '{1}'"_translatable,
+        {
+            u8"using '{0}' against a regular expression literal always returns '{1}'",
+            u8"using '{0}' against a regular expression literal always returns '{1}'",
+            u8"using '{0}' against a regular expression literal always returns '{1}'",
+            u8"using '{0}' against a regular expression literal always returns '{1}'",
+            u8"using '{0}' against a regular expression literal always returns '{1}'",
+        },
+    },
+    {
+        "using '{0}' against an array literal does not compare items"_translatable,
+        {
+            u8"using '{0}' against an array literal does not compare items",
+            u8"using '{0}' against an array literal does not compare items",
+            u8"using '{0}' against an array literal does not compare items",
+            u8"using '{0}' against an array literal does not compare items",
+            u8"using '{0}' against an array literal does not compare items",
+        },
+    },
+    {
+        "using '{0}' against an arrow function always returns '{1}'"_translatable,
+        {
+            u8"using '{0}' against an arrow function always returns '{1}'",
+            u8"using '{0}' against an arrow function always returns '{1}'",
+            u8"using '{0}' against an arrow function always returns '{1}'",
+            u8"using '{0}' against an arrow function always returns '{1}'",
+            u8"using '{0}' against an arrow function always returns '{1}'",
+        },
+    },
+    {
+        "using '{0}' against an object literal always returns '{1}'"_translatable,
+        {
+            u8"using '{0}' against an object literal always returns '{1}'",
+            u8"using '{0}' against an object literal always returns '{1}'",
+            u8"using '{0}' against an object literal always returns '{1}'",
+            u8"using '{0}' against an object literal always returns '{1}'",
+            u8"using '{0}' against an object literal always returns '{1}'",
         },
     },
     {


### PR DESCRIPTION
Fixes https://github.com/quick-lint/quick-lint-js/issues/821

Now quick-lint-js gives a warning when using strict equality or inequality operators for comparing against an array literal, object literal, class literal, arrow function, or regexp literal.


