### PR TITLE
Fix: Improve check for E0286 and E0287

### DIFF
--- a/src/quick-lint-js/fe/parse.cpp
+++ b/src/quick-lint-js/fe/parse.cpp
@@ -324,8 +324,8 @@ void parser::error_on_pointless_string_compare(
   };
 
   for (int i = 0; i < ast->child_count() - 1; i++) {
-    expression* lhs = ast->child(i);
-    expression* rhs = ast->child(i + 1);
+    expression* lhs = ast->child(i)->without_paren();
+    expression* rhs = ast->child(i + 1)->without_paren();
 
     if ((lhs->kind() == expression_kind::call &&
          rhs->kind() == expression_kind::literal) ||

--- a/test/test-parse-warning.cpp
+++ b/test/test-parse-warning.cpp
@@ -274,6 +274,23 @@ TEST_F(test_parse_warning,
                     span_operator, strlen(u8"if(s.toLowerCase() "), u8"===")));
   }
   {
+    test_parser p(u8"((s.toLowerCase())) === 'BANANA'"_sv, capture_diags);
+    p.parse_and_visit_expression();
+    EXPECT_THAT(p.errors,
+                ElementsAre(DIAG_TYPE_OFFSETS(
+                    p.code, diag_pointless_string_comp_contains_upper,
+                    span_operator, strlen(u8"((s.toLowerCase())) "), u8"===")));
+  }
+  {
+    test_parser p(u8"(((s.toLowerCase())) === ((('BANANA'))))"_sv,
+                  capture_diags);
+    p.parse_and_visit_expression();
+    EXPECT_THAT(p.errors, ElementsAre(DIAG_TYPE_OFFSETS(
+                              p.code, diag_pointless_string_comp_contains_upper,
+                              span_operator, strlen(u8"(((s.toLowerCase())) "),
+                              u8"===")));
+  }
+  {
     test_parser p(
         u8"s.toLowerCase() == 'BANANA' && s.toUpperCase() !== 'orange'"_sv,
         capture_diags);


### PR DESCRIPTION
Currently, quick-lint-js gives a warning when doing a pointless compare when using toUpperCase or toLowerCase against string literals, but it fails to do so if one of the expressions contains parenthesis e.g. 

`(s.toUpperCase()) === 'test'`

This PR intends to fix that issue and adds some tests to consider those scenarios.