### PR TITLE
Remove -a from tee to stop appending to source list each install

### DIFF
--- a/website/public/install/common-debian.ejs.html
+++ b/website/public/install/common-debian.ejs.html
@@ -6,7 +6,7 @@
 <p>Open a terminal, and run the following commands:</p>
 <blockquote>
   <pre><code class="shell-session"><kbd>curl https://c.quick-lint-js.com/quick-lint-js-release.key | sudo apt-key add -</kbd>
-<span class="long-shell-command-line"><kbd>printf '\n# From: https://quick-lint-js.com<%= currentURI %>\ndeb [arch=amd64] https://c.quick-lint-js.com/debian experimental main\n' | sudo tee -a /etc/apt/sources.list.d/quick-lint-js.list</kbd></span>
+<span class="long-shell-command-line"><kbd>printf '\n# From: https://quick-lint-js.com<%= currentURI %>\ndeb [arch=amd64] https://c.quick-lint-js.com/debian experimental main\n' | sudo tee /etc/apt/sources.list.d/quick-lint-js.list</kbd></span>
 <kbd>sudo apt-get update</kbd>
 <kbd>sudo apt-get install quick-lint-js<%= vim ? " quick-lint-js-vim" : "" %></kbd></code></pre>
 </blockquote>


### PR DESCRIPTION
Overwrite the source list (/etc/apt/soruces.list.d/quick-lint-js.list) on multiple installs (instead of appending).

That way don't end up with spam in the terminal:
![image](https://user-images.githubusercontent.com/49783296/210188217-4b8df280-de85-4382-b4dc-264424105568.png)
