### PR TITLE
feat(lint): ignore QuickJS scriptArgs pre defined global

### DIFF
--- a/src/quick-lint-js/fe/global-variables.cpp
+++ b/src/quick-lint-js/fe/global-variables.cpp
@@ -232,6 +232,11 @@ constexpr const char8 global_variables_node_js_es[] =
     u8"setTimeout\0"
     u8"unescape\0";
 
+constexpr const char8 global_variables_quickjs[] =
+    u8"scriptArgs\0"
+    u8"console\0"
+    u8"print\0";
+
 const global_group global_groups[] = {
     {
         .name = u8"browser",
@@ -302,6 +307,15 @@ const global_group global_groups[] = {
         .non_writable_globals = nullptr,
         .non_shadowable_globals = nullptr,
         .globals_count = 21,
+        .non_writable_globals_count = 0,
+        .non_shadowable_globals_count = 0,
+    },
+    {
+        .name = u8"quickjs",
+        .globals = global_variables_quickjs,
+        .non_writable_globals = nullptr,
+        .non_shadowable_globals = nullptr,
+        .globals_count = 3,
         .non_writable_globals_count = 0,
         .non_shadowable_globals_count = 0,
     },

--- a/src/quick-lint-js/fe/global-variables.h
+++ b/src/quick-lint-js/fe/global-variables.h
@@ -9,7 +9,7 @@
 #include <quick-lint-js/port/char8.h>
 
 namespace quick_lint_js {
-inline constexpr std::size_t global_group_count = 9;
+inline constexpr std::size_t global_group_count = 10;
 
 struct global_group {
   const char8 *name;


### PR DESCRIPTION
currently, this is the only global variable non standard defined by quickjs:
https://bellard.org/quickjs/quickjs.html#Global-objects