### PR TITLE
Fix crash in quick-lint-js-benchmark-parse

### DIFF
--- a/benchmark/benchmark-parse.cpp
+++ b/benchmark/benchmark-parse.cpp
@@ -67,7 +67,7 @@ function f() {
   ()=>{{{{{{{await/
   ()=>{{{{{{{await/
   ()=>{{{{{{{await/
-  ()=>{{{{{{{await/
+  ()=>{{{{{{ await/ 
 }
 )"_sv);
 BENCHMARK_CAPTURE(benchmark_parse, pathological_await_slash_top_level,


### PR DESCRIPTION
There was one extra scope going in which was causing the depth to exceed 130. Removing just one of the curly braces causes this limit to not be reached. 