### PR TITLE
Add warning diagnostic for comma operator usage in indexing operation

### DIFF
--- a/docs/errors/E0450.md
+++ b/docs/errors/E0450.md
@@ -1,0 +1,26 @@
+# E0450: misleading use of ',' operator in index
+
+Using comma operator within an indexing operation is misleading, as it
+can be confused with a new array definition, or with access to multiple elements
+of the container.
+
+For example:
+
+```javascript
+let matrix = [
+  [1, 2, 3],
+  [4, 5, 6],
+  [7, 8, 9],
+];
+let topLeft = matrix[0, 0];
+```
+Here, the value of `topLeft` will be equal to `matrix[0] = [1, 2, 3]`.
+If the intention is to find the value at the top-left corner of `matrix`, the correct syntax would be:
+```javascript
+let matrix = [
+  [1, 2, 3],
+  [4, 5, 6],
+  [7, 8, 9],
+];
+let topLeft = matrix[0][0]; // topLeft = 1
+```

--- a/po/de.po
+++ b/po/de.po
@@ -435,6 +435,15 @@ msgstr ""
 "Mehrere Kommata zwischen den Argumenten eines Funktionsaufruf sind ungültig"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
+msgid "misleading use of ',' operator in index"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+#, fuzzy
+msgid "index starts here"
+msgstr "Funktionsaufruf beginnt hier"
+
+#: src/quick-lint-js/fe/diagnostic-types.h
 msgid "expected 'as' between '{1}' and '{2}'"
 msgstr "'as' zwischen '{1}' und '{2}' erwartet"
 
@@ -1900,6 +1909,12 @@ msgstr "{1:singular} erwartet"
 #: test/test-vim-qflist-json-diag-reporter.cpp
 msgid "here"
 msgstr "hier"
+
+#, fuzzy
+#~ msgid "',' is not expected between the mems in '['']'"
+#~ msgstr ""
+#~ "Mehrere Kommata zwischen den Argumenten eines Funktionsaufruf sind "
+#~ "ungültig"
 
 #, fuzzy
 #~ msgid "already spread here"

--- a/po/en_US@snarky.po
+++ b/po/en_US@snarky.po
@@ -413,6 +413,15 @@ msgid "extra ',' is not allowed between enum members"
 msgstr "that's way too many commas 🚮"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
+msgid "misleading use of ',' operator in index"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+#, fuzzy
+msgid "index starts here"
+msgstr "IIFE started here"
+
+#: src/quick-lint-js/fe/diagnostic-types.h
 msgid "expected 'as' between '{1}' and '{2}'"
 msgstr "you forgot 'as' between '{1}' and '{2}'"
 
@@ -443,8 +452,7 @@ msgstr "be polite and say 'from'"
 #: src/quick-lint-js/fe/diagnostic-types.h
 msgid "expected hexadecimal digits in Unicode escape sequence"
 msgstr ""
-"what are you trying to do? This is a Unicode escape sequence, not a Wendy's "
-"🍔"
+"what are you trying to do? This is a Unicode escape sequence, not a Wendy's 🍔"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
 msgid "expected '{{'"
@@ -747,8 +755,7 @@ msgstr "how did the grammar Nazi die? colon cancer."
 
 #: src/quick-lint-js/fe/diagnostic-types.h
 msgid "'?' creates a conditional expression"
-msgstr ""
-"do you know what a conditional expression even is ? liar 🤥 : Kagi it 🔍"
+msgstr "do you know what a conditional expression even is ? liar 🤥 : Kagi it 🔍"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
 msgid "missing condition for if statement"
@@ -1783,6 +1790,10 @@ msgstr "expected {1:singular}"
 #: test/test-vim-qflist-json-diag-reporter.cpp
 msgid "here"
 msgstr "there 👈"
+
+#, fuzzy
+#~ msgid "',' is not expected between the mems in '['']'"
+#~ msgstr "that's way too many commas 🚮"
 
 #, fuzzy
 #~ msgid "already spread here"

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -445,6 +445,15 @@ msgstr ""
 "',' supplémentaire non autorisé entre les arguments d'appel d'une fonction"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
+msgid "misleading use of ',' operator in index"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+#, fuzzy
+msgid "index starts here"
+msgstr "appel de fonction débuté ici"
+
+#: src/quick-lint-js/fe/diagnostic-types.h
 msgid "expected 'as' between '{1}' and '{2}'"
 msgstr "'as' attendu entre '{1}' and '{2}'"
 
@@ -1917,6 +1926,11 @@ msgstr ""
 #: test/test-vim-qflist-json-diag-reporter.cpp
 msgid "here"
 msgstr ""
+
+#, fuzzy
+#~ msgid "',' is not expected between the mems in '['']'"
+#~ msgstr ""
+#~ "',' supplémentaire non autorisé entre les arguments d'appel d'une fonction"
 
 #, fuzzy
 #~ msgid "already spread here"

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -394,6 +394,14 @@ msgid "extra ',' is not allowed between enum members"
 msgstr ""
 
 #: src/quick-lint-js/fe/diagnostic-types.h
+msgid "misleading use of ',' operator in index"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "index starts here"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
 msgid "expected 'as' between '{1}' and '{2}'"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -397,6 +397,15 @@ msgid "extra ',' is not allowed between enum members"
 msgstr "',' extra não é permitido entre membros de um enum"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
+msgid "misleading use of ',' operator in index"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+#, fuzzy
+msgid "index starts here"
+msgstr "função inicia aqui"
+
+#: src/quick-lint-js/fe/diagnostic-types.h
 msgid "expected 'as' between '{1}' and '{2}'"
 msgstr "'as' esperado entre '{1}' e '{2}'"
 
@@ -1717,3 +1726,7 @@ msgstr "esperado {1:singular}"
 #: test/test-vim-qflist-json-diag-reporter.cpp
 msgid "here"
 msgstr "aqui"
+
+#, fuzzy
+#~ msgid "',' is not expected between the mems in '['']'"
+#~ msgstr "',' extra não é permitido entre membros de um enum"

--- a/po/sv_SE.po
+++ b/po/sv_SE.po
@@ -414,6 +414,15 @@ msgid "extra ',' is not allowed between enum members"
 msgstr "extra ',' är inte tillåtet mellan funktionkallelses argument"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
+msgid "misleading use of ',' operator in index"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+#, fuzzy
+msgid "index starts here"
+msgstr "funktionkallelse startar här"
+
+#: src/quick-lint-js/fe/diagnostic-types.h
 msgid "expected 'as' between '{1}' and '{2}'"
 msgstr "förväntade 'as' mellan '{1}' och '{2}'"
 
@@ -1789,6 +1798,10 @@ msgstr ""
 #: test/test-vim-qflist-json-diag-reporter.cpp
 msgid "here"
 msgstr ""
+
+#, fuzzy
+#~ msgid "',' is not expected between the mems in '['']'"
+#~ msgstr "extra ',' är inte tillåtet mellan funktionkallelses argument"
 
 #, fuzzy
 #~ msgid "already spread here"

--- a/src/quick-lint-js/fe/diagnostic-types.h
+++ b/src/quick-lint-js/fe/diagnostic-types.h
@@ -559,6 +559,17 @@
           comma))                                                               \
                                                                                 \
   QLJS_DIAG_TYPE(                                                               \
+      diag_misleading_comma_operator_in_index_operation, "E0450",               \
+      diagnostic_severity::warning,                                             \
+      {                                                                         \
+        source_code_span comma;                                                 \
+        source_code_span left_square;                                           \
+      },                                                                        \
+      MESSAGE(QLJS_TRANSLATABLE("misleading use of ',' operator in index"),     \
+              comma)                                                            \
+          MESSAGE(QLJS_TRANSLATABLE("index starts here"), left_square))         \
+                                                                                \
+  QLJS_DIAG_TYPE(                                                               \
       diag_expected_as_before_imported_namespace_alias, "E0126",                \
       diagnostic_severity::error,                                               \
       {                                                                         \

--- a/src/quick-lint-js/fe/expression.h
+++ b/src/quick-lint-js/fe/expression.h
@@ -657,12 +657,15 @@ class expression::index final : public expression {
   static constexpr expression_kind kind = expression_kind::index;
 
   explicit index(expression *container, expression *subscript,
+                 source_code_span left_square_span,
                  const char8 *subscript_end) noexcept
       : expression(kind),
         index_subscript_end_(subscript_end),
+        left_square_span(left_square_span),
         children_{container, subscript} {}
 
   const char8 *index_subscript_end_;
+  source_code_span left_square_span;
   std::array<expression *, 2> children_;
 };
 static_assert(expression_arena::is_allocatable<expression::index>);

--- a/src/quick-lint-js/fe/parse.h
+++ b/src/quick-lint-js/fe/parse.h
@@ -225,6 +225,8 @@ class parser {
                         variable_context context);
   void visit_assignment_expression(expression *lhs, expression *rhs,
                                    parse_visitor_base &v);
+  void warn_on_comma_operator_in_index(expression *ast,
+                                       source_code_span left_square_span);
   void visit_compound_or_conditional_assignment_expression(
       expression *lhs, expression *rhs, parse_visitor_base &v);
   void maybe_visit_assignment(expression *ast, parse_visitor_base &v);

--- a/src/quick-lint-js/i18n/translation-table-generated.cpp
+++ b/src/quick-lint-js/i18n/translation-table-generated.cpp
@@ -220,7 +220,8 @@ const translation_table translation_data = {
         {43, 18, 70, 35, 40, 32},            //
         {0, 0, 0, 147, 0, 147},              //
         {0, 0, 0, 54, 0, 46},                //
-        {175, 14, 144, 48, 175, 38},         //
+        {0, 0, 0, 0, 0, 38},                 //
+        {175, 14, 144, 48, 175, 18},         //
         {0, 0, 0, 30, 0, 32},                //
         {0, 30, 0, 26, 0, 24},               //
         {0, 0, 0, 68, 0, 59},                //
@@ -242,7 +243,8 @@ const translation_table translation_data = {
         {50, 22, 0, 63, 0, 51},              //
         {0, 0, 0, 46, 0, 45},                //
         {50, 47, 66, 33, 53, 27},            //
-        {68, 21, 0, 52, 0, 46},              //
+        {0, 0, 0, 0, 0, 46},                 //
+        {68, 21, 0, 52, 0, 40},              //
         {59, 43, 61, 49, 50, 39},            //
         {0, 0, 0, 44, 0, 42},                //
         {44, 2, 0, 64, 0, 57},               //
@@ -1905,6 +1907,7 @@ const translation_table translation_data = {
         u8"incomplete export; expected 'export default ...' or 'export {{name}' or 'export * from ...' or 'export class' or 'export function' or 'export let'\0"
         u8"index signature must be a field, not a method\0"
         u8"index signatures require a value type\0"
+        u8"index starts here\0"
         u8"indexing requires an expression\0"
         u8"initializer starts here\0"
         u8"integer cannot be represented and will be rounded to '{1}'\0"
@@ -1927,6 +1930,7 @@ const translation_table translation_data = {
         u8"lower case letters compared with toUpperCase\0"
         u8"methods cannot be readonly\0"
         u8"methods should not use the 'function' keyword\0"
+        u8"misleading use of ',' operator in index\0"
         u8"mismatched JSX tags; expected '</{1}>'\0"
         u8"missing ',' between variable declarations\0"
         u8"missing ',', ';', or newline between object type entries\0"

--- a/src/quick-lint-js/i18n/translation-table-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-generated.h
@@ -20,8 +20,8 @@ namespace quick_lint_js {
 using namespace std::literals::string_view_literals;
 
 constexpr std::uint32_t translation_table_locale_count = 5;
-constexpr std::uint16_t translation_table_mapping_table_size = 404;
-constexpr std::size_t translation_table_string_table_size = 74654;
+constexpr std::uint16_t translation_table_mapping_table_size = 406;
+constexpr std::size_t translation_table_string_table_size = 74712;
 constexpr std::size_t translation_table_locale_table_size = 35;
 
 QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
@@ -237,6 +237,7 @@ QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
           "incomplete export; expected 'export default ...' or 'export {{name}' or 'export * from ...' or 'export class' or 'export function' or 'export let'"sv,
           "index signature must be a field, not a method"sv,
           "index signatures require a value type"sv,
+          "index starts here"sv,
           "indexing requires an expression"sv,
           "initializer starts here"sv,
           "integer cannot be represented and will be rounded to '{1}'"sv,
@@ -259,6 +260,7 @@ QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
           "lower case letters compared with toUpperCase"sv,
           "methods cannot be readonly"sv,
           "methods should not use the 'function' keyword"sv,
+          "misleading use of ',' operator in index"sv,
           "mismatched JSX tags; expected '</{1}>'"sv,
           "missing ',' between variable declarations"sv,
           "missing ',', ';', or newline between object type entries"sv,

--- a/test/quick-lint-js/test-translation-table-generated.h
+++ b/test/quick-lint-js/test-translation-table-generated.h
@@ -27,7 +27,7 @@ struct translated_string {
   const char8 *expected_per_locale[6];
 };
 
-extern const translated_string test_translation_table[403];
+extern const translated_string test_translation_table[405];
 }
 
 #endif

--- a/test/test-translation-table-generated.cpp
+++ b/test/test-translation-table-generated.cpp
@@ -2310,6 +2310,17 @@ const translated_string test_translation_table[] = {
         },
     },
     {
+        "index starts here"_translatable,
+        {
+            u8"index starts here",
+            u8"index starts here",
+            u8"index starts here",
+            u8"index starts here",
+            u8"index starts here",
+            u8"index starts here",
+        },
+    },
+    {
         "indexing requires an expression"_translatable,
         {
             u8"indexing requires an expression",
@@ -2549,6 +2560,17 @@ const translated_string test_translation_table[] = {
             u8"les m\u00e9thodes ne doivent pas utiliser le mot-cl\u00e9 'function'",
             u8"m\u00e9todos n\u00e3o podem usar a palavra-chave 'function'",
             u8"metoder b\u00f6r inte anv\u00e4nda nyckelordet 'function'",
+        },
+    },
+    {
+        "misleading use of ',' operator in index"_translatable,
+        {
+            u8"misleading use of ',' operator in index",
+            u8"misleading use of ',' operator in index",
+            u8"misleading use of ',' operator in index",
+            u8"misleading use of ',' operator in index",
+            u8"misleading use of ',' operator in index",
+            u8"misleading use of ',' operator in index",
         },
     },
     {


### PR DESCRIPTION
This commit adds a new diagnostic to point out misleading use of comma operators in indexing operation (e.g., let b = a[i, j]).
Closes #939 