### PR TITLE
Warn on comma operator in conditional statements

### DIFF
--- a/docs/errors/E0451.md
+++ b/docs/errors/E0451.md
@@ -1,0 +1,23 @@
+# E0451: misleading use of ',' operator in conditional statement
+
+Using comma operator within a conditional statement of a control block (if, for, while, switch) is misleading, because only the last expression will be used to evaluate the condition.
+
+For example:
+
+```javascript
+let N = 10;
+for (let i = 0, j = N - 1; i < j, j >= 0; ++i, --j) {
+  console.log(i, j);
+}
+```
+
+Here, the statement `i < j, j >= 0` will be evaluated as `j >= 0`, disregarding
+the first part of the statement `i < j`. In order to have both parts evaluated,
+a conditional operator should be used instead of the comma operator.
+
+```javascript
+let N = 10;
+for (let i = 0, j = N - 1; i < j && j >= 0; ++i, --j) {
+  console.log(i, j);
+}
+```

--- a/docs/errors/E0451.md
+++ b/docs/errors/E0451.md
@@ -1,6 +1,6 @@
 # E0451: misleading use of ',' operator in conditional statement
 
-Using comma operator within a conditional statement of a control block (if, for, while, switch) is misleading, because only the last expression will be used to evaluate the condition.
+Using comma operator within a conditional statement of a control block (`if`, `for`, `while`, `switch`) is misleading, because only the last expression will be used to evaluate the condition.
 
 For example:
 
@@ -12,8 +12,8 @@ for (let i = 0, j = N - 1; i < j, j >= 0; ++i, --j) {
 ```
 
 Here, the statement `i < j, j >= 0` will be evaluated as `j >= 0`, disregarding
-the first part of the statement `i < j`. In order to have both parts evaluated,
-a conditional operator should be used instead of the comma operator.
+the first part (`i < j`) of the statement. In order to have both parts evaluated,
+a logical operator should be used instead of the comma operator.
 
 ```javascript
 let N = 10;

--- a/po/de.po
+++ b/po/de.po
@@ -538,6 +538,11 @@ msgid "index starts here"
 msgstr "Funktionsaufruf beginnt hier"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
+#, fuzzy
+msgid "misleading use of ',' operator in conditional statement"
+msgstr "Semikolon fehlt nach Anweisung"
+
+#: src/quick-lint-js/fe/diagnostic-types.h
 msgid "expected 'as' between '{1}' and '{2}'"
 msgstr "'as' zwischen '{1}' und '{2}' erwartet"
 

--- a/po/en_US@snarky.po
+++ b/po/en_US@snarky.po
@@ -492,6 +492,11 @@ msgid "index starts here"
 msgstr "IIFE started here"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
+#, fuzzy
+msgid "misleading use of ',' operator in conditional statement"
+msgstr "I know you hate semicolons, but you need one here"
+
+#: src/quick-lint-js/fe/diagnostic-types.h
 msgid "expected 'as' between '{1}' and '{2}'"
 msgstr "you forgot 'as' between '{1}' and '{2}'"
 

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -548,6 +548,11 @@ msgid "index starts here"
 msgstr "appel de fonction débuté ici"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
+#, fuzzy
+msgid "misleading use of ',' operator in conditional statement"
+msgstr "point-virgule manquant après l'instruction"
+
+#: src/quick-lint-js/fe/diagnostic-types.h
 msgid "expected 'as' between '{1}' and '{2}'"
 msgstr "'as' attendu entre '{1}' and '{2}'"
 

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -458,6 +458,10 @@ msgid "index starts here"
 msgstr ""
 
 #: src/quick-lint-js/fe/diagnostic-types.h
+msgid "misleading use of ',' operator in conditional statement"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
 msgid "expected 'as' between '{1}' and '{2}'"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -476,6 +476,11 @@ msgid "index starts here"
 msgstr "função inicia aqui"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
+#, fuzzy
+msgid "misleading use of ',' operator in conditional statement"
+msgstr "falta o ponto e vírgula após a instrução"
+
+#: src/quick-lint-js/fe/diagnostic-types.h
 msgid "expected 'as' between '{1}' and '{2}'"
 msgstr "'as' esperado entre '{1}' e '{2}'"
 

--- a/po/sv_SE.po
+++ b/po/sv_SE.po
@@ -493,6 +493,11 @@ msgid "index starts here"
 msgstr "funktionkallelse startar här"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
+#, fuzzy
+msgid "misleading use of ',' operator in conditional statement"
+msgstr "saknar semikolon efter påstående"
+
+#: src/quick-lint-js/fe/diagnostic-types.h
 msgid "expected 'as' between '{1}' and '{2}'"
 msgstr "förväntade 'as' mellan '{1}' och '{2}'"
 

--- a/src/quick-lint-js/fe/diagnostic-types.h
+++ b/src/quick-lint-js/fe/diagnostic-types.h
@@ -669,6 +669,13 @@
           MESSAGE(QLJS_TRANSLATABLE("index starts here"), left_square))         \
                                                                                 \
   QLJS_DIAG_TYPE(                                                               \
+      diag_misleading_comma_operator_in_conditional_statement, "E0451",         \
+      diagnostic_severity::warning, { source_code_span comma; },                \
+      MESSAGE(QLJS_TRANSLATABLE(                                                \
+                  "misleading use of ',' operator in conditional statement"),   \
+              comma))                                                           \
+                                                                                \
+  QLJS_DIAG_TYPE(                                                               \
       diag_expected_as_before_imported_namespace_alias, "E0126",                \
       diagnostic_severity::error,                                               \
       {                                                                         \

--- a/src/quick-lint-js/fe/parse-expression.cpp
+++ b/src/quick-lint-js/fe/parse-expression.cpp
@@ -128,20 +128,12 @@ void parser::visit_expression(expression* ast, parse_visitor_base& v,
   case expression_kind::dot:
     this->visit_expression(ast->child_0(), v, variable_context::rhs);
     break;
-  case expression_kind::index: {
+  case expression_kind::index:
     this->visit_expression(ast->child_0(), v, variable_context::rhs);
     this->visit_expression(ast->child_1(), v, variable_context::rhs);
-    std::optional<source_code_span> comma =
-        this->find_comma_operator(ast->child_1());
-    if (comma.has_value()) {
-      this->diag_reporter_->report(
-          diag_misleading_comma_operator_in_index_operation{
-              .comma = comma.value(),
-              .left_square =
-                  static_cast<expression::index*>(ast)->left_square_span});
-    }
+    this->warn_on_comma_operator_in_index(
+        ast->child_1(), static_cast<expression::index*>(ast)->left_square_span);
     break;
-  }
 
   case expression_kind::jsx_element: {
     auto* element = static_cast<expression::jsx_element*>(ast);

--- a/src/quick-lint-js/fe/parse-statement.cpp
+++ b/src/quick-lint-js/fe/parse-statement.cpp
@@ -2626,7 +2626,13 @@ void parser::parse_and_visit_for(parse_visitor_base &v) {
           expression *ast = this->parse_expression(v);
           this->visit_expression(ast, v, variable_context::rhs);
           this->error_on_sketchy_condition(ast);
-          this->warn_on_comma_operator_in_conditional_statement(ast);
+          std::optional<source_code_span> comma =
+              this->find_comma_operator(ast);
+          if (comma.has_value()) {
+            this->diag_reporter_->report(
+                diag_misleading_comma_operator_in_conditional_statement{
+                    .comma = comma.value()});
+          }
         }
 
         switch (this->peek().type) {

--- a/src/quick-lint-js/fe/parse-statement.cpp
+++ b/src/quick-lint-js/fe/parse-statement.cpp
@@ -2626,13 +2626,7 @@ void parser::parse_and_visit_for(parse_visitor_base &v) {
           expression *ast = this->parse_expression(v);
           this->visit_expression(ast, v, variable_context::rhs);
           this->error_on_sketchy_condition(ast);
-          std::optional<source_code_span> comma =
-              this->find_comma_operator(ast);
-          if (comma.has_value()) {
-            this->diag_reporter_->report(
-                diag_misleading_comma_operator_in_conditional_statement{
-                    .comma = comma.value()});
-          }
+          this->warn_on_comma_operator_in_conditional_statement(ast);
         }
 
         switch (this->peek().type) {

--- a/src/quick-lint-js/fe/parse-statement.cpp
+++ b/src/quick-lint-js/fe/parse-statement.cpp
@@ -1922,7 +1922,8 @@ void parser::parse_and_visit_switch(parse_visitor_base &v) {
     this->parse_and_visit_parenthesized_expression<
         diag_expected_parentheses_around_switch_condition,
         diag_expected_parenthesis_around_switch_condition,
-        /*CheckForSketchyConditions=*/false>(v);
+        /*CheckForSketchyConditions=*/false,
+        /*CheckForCommaOperator=*/true>(v);
   }
 
   switch (this->peek().type) {
@@ -2590,7 +2591,8 @@ void parser::parse_and_visit_do_while(parse_visitor_base &v) {
   this->parse_and_visit_parenthesized_expression<
       diag_expected_parentheses_around_do_while_condition,
       diag_expected_parenthesis_around_do_while_condition,
-      /*CheckForSketchyConditions=*/true>(v);
+      /*CheckForSketchyConditions=*/true,
+      /*CheckForCommaOperator=*/true>(v);
 
   if (this->peek().type == token_type::semicolon) {
     this->skip();
@@ -2624,6 +2626,7 @@ void parser::parse_and_visit_for(parse_visitor_base &v) {
           expression *ast = this->parse_expression(v);
           this->visit_expression(ast, v, variable_context::rhs);
           this->error_on_sketchy_condition(ast);
+          this->warn_on_comma_operator_in_conditional_statement(ast);
         }
 
         switch (this->peek().type) {
@@ -3003,7 +3006,8 @@ void parser::parse_and_visit_while(parse_visitor_base &v) {
     this->parse_and_visit_parenthesized_expression<
         diag_expected_parentheses_around_while_condition,
         diag_expected_parenthesis_around_while_condition,
-        /*CheckForSketchyConditions=*/true>(v);
+        /*CheckForSketchyConditions=*/true,
+        /*CheckForCommaOperator=*/true>(v);
   }
 
   this->error_on_class_statement(statement_kind::while_loop);
@@ -3026,7 +3030,8 @@ void parser::parse_and_visit_with(parse_visitor_base &v) {
   this->parse_and_visit_parenthesized_expression<
       diag_expected_parentheses_around_with_expression,
       diag_expected_parenthesis_around_with_expression,
-      /*CheckForSketchyConditions=*/false>(v);
+      /*CheckForSketchyConditions=*/false,
+      /*CheckForCommaOperator=*/false>(v);
 
   this->error_on_class_statement(statement_kind::with_statement);
   this->error_on_function_statement(statement_kind::with_statement);
@@ -3055,7 +3060,8 @@ void parser::parse_and_visit_if(parse_visitor_base &v) {
     this->parse_and_visit_parenthesized_expression<
         diag_expected_parentheses_around_if_condition,
         diag_expected_parenthesis_around_if_condition,
-        /*CheckForSketchyConditions=*/true>(v);
+        /*CheckForSketchyConditions=*/true,
+        /*CheckForCommaOperator=*/true>(v);
   }
 
   auto parse_and_visit_body = [this, &v]() -> void {

--- a/src/quick-lint-js/fe/parse.cpp
+++ b/src/quick-lint-js/fe/parse.cpp
@@ -328,6 +328,23 @@ void parser::error_on_sketchy_condition(expression* ast) {
   }
 }
 
+void parser::warn_on_comma_operator_in_conditional_statement(expression* ast) {
+  if (ast->kind() != expression_kind::binary_operator) return;
+
+  auto is_comma = [](string8_view s) -> bool { return s == u8","_sv; };
+
+  auto* binary_operator = static_cast<expression::binary_operator*>(ast);
+  for (span_size i = binary_operator->child_count() - 2; i >= 0; i--) {
+    source_code_span op_span = binary_operator->operator_spans_[i];
+    if (is_comma(op_span.string_view())) {
+      this->diag_reporter_->report(
+          diag_misleading_comma_operator_in_conditional_statement{.comma =
+                                                                      op_span});
+      return;
+    }
+  }
+}
+
 void parser::error_on_pointless_string_compare(
     expression::binary_operator* ast) {
   auto is_comparison_operator = [](string8_view s) {

--- a/src/quick-lint-js/fe/parse.h
+++ b/src/quick-lint-js/fe/parse.h
@@ -401,7 +401,8 @@ class parser {
   void parse_and_visit_parenthesized_expression(parse_visitor_base &v);
 
   void error_on_sketchy_condition(expression *);
-  std::optional<source_code_span> find_comma_operator(expression *ast);
+  void warn_on_comma_operator_in_conditional_statement(expression *);
+  void warn_on_comma_operator_in_index(expression *, source_code_span);
   void error_on_pointless_string_compare(expression::binary_operator *);
   void error_on_pointless_compare_against_literal(
       expression::binary_operator *);
@@ -929,12 +930,7 @@ void parser::parse_and_visit_parenthesized_expression(parse_visitor_base &v) {
   }
 
   if constexpr (CheckForCommaOperator) {
-    std::optional<source_code_span> comma = this->find_comma_operator(ast);
-    if (comma.has_value()) {
-      this->diag_reporter_->report(
-          diag_misleading_comma_operator_in_conditional_statement{
-              .comma = comma.value()});
-    }
+    this->warn_on_comma_operator_in_conditional_statement(ast);
   }
 
   const char8 *expression_end = this->lexer_.end_of_previous_token();

--- a/src/quick-lint-js/i18n/translation-table-generated.cpp
+++ b/src/quick-lint-js/i18n/translation-table-generated.cpp
@@ -260,6 +260,7 @@ const translation_table translation_data = {
         {0, 0, 0, 46, 0, 45},                //
         {50, 47, 66, 33, 53, 27},            //
         {0, 0, 0, 0, 0, 46},                 //
+        {0, 0, 0, 0, 0, 56},                 //
         {68, 21, 0, 52, 0, 40},              //
         {59, 43, 61, 49, 50, 39},            //
         {0, 0, 0, 44, 0, 42},                //
@@ -1963,6 +1964,7 @@ const translation_table translation_data = {
         u8"lower case letters compared with toUpperCase\0"
         u8"methods cannot be readonly\0"
         u8"methods should not use the 'function' keyword\0"
+        u8"misleading use of ',' operator in conditional statement\0"
         u8"misleading use of ',' operator in index\0"
         u8"mismatched JSX tags; expected '</{1}>'\0"
         u8"missing ',' between variable declarations\0"

--- a/src/quick-lint-js/i18n/translation-table-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-generated.h
@@ -20,8 +20,8 @@ namespace quick_lint_js {
 using namespace std::literals::string_view_literals;
 
 constexpr std::uint32_t translation_table_locale_count = 5;
-constexpr std::uint16_t translation_table_mapping_table_size = 423;
-constexpr std::size_t translation_table_string_table_size = 75516;
+constexpr std::uint16_t translation_table_mapping_table_size = 424;
+constexpr std::size_t translation_table_string_table_size = 75572;
 constexpr std::size_t translation_table_locale_table_size = 35;
 
 QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
@@ -276,6 +276,7 @@ QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
           "lower case letters compared with toUpperCase"sv,
           "methods cannot be readonly"sv,
           "methods should not use the 'function' keyword"sv,
+          "misleading use of ',' operator in conditional statement"sv,
           "misleading use of ',' operator in index"sv,
           "mismatched JSX tags; expected '</{1}>'"sv,
           "missing ',' between variable declarations"sv,

--- a/test/quick-lint-js/test-translation-table-generated.h
+++ b/test/quick-lint-js/test-translation-table-generated.h
@@ -27,7 +27,7 @@ struct translated_string {
   const char8 *expected_per_locale[6];
 };
 
-extern const translated_string test_translation_table[422];
+extern const translated_string test_translation_table[423];
 }
 
 #endif

--- a/test/test-parse-warning.cpp
+++ b/test/test-parse-warning.cpp
@@ -404,14 +404,14 @@ TEST_F(test_parse_warning, warn_on_comma_operator_in_conditional_statement) {
   }
 
   {
-    test_parser p(u8"do{i++}while((i < 0), true)"_sv, capture_diags);
+    test_parser p(u8"do{i++}while(i < 0, true)"_sv, capture_diags);
     p.parse_and_visit_statement();
     EXPECT_THAT(
         p.errors,
         ElementsAreArray({
             DIAG_TYPE_OFFSETS(
                 p.code, diag_misleading_comma_operator_in_conditional_statement,
-                comma, strlen(u8"do{i++}while((i < 0)"), u8","_sv),
+                comma, strlen(u8"do{i++}while(i < 0"), u8","_sv),
         }));
   }
 
@@ -435,6 +435,18 @@ TEST_F(test_parse_warning, warn_on_comma_operator_in_conditional_statement) {
 
   {
     test_parser p(u8"for(let i = 0, j = 0;;){}"_sv, capture_diags);
+    p.parse_and_visit_statement();
+    EXPECT_THAT(p.errors, IsEmpty());
+  }
+
+  {
+    test_parser p(u8"for(i = 0, j = 0;;){}"_sv, capture_diags);
+    p.parse_and_visit_statement();
+    EXPECT_THAT(p.errors, IsEmpty());
+  }
+
+  {
+    test_parser p(u8"for(;; ++i, ++j){}"_sv, capture_diags);
     p.parse_and_visit_statement();
     EXPECT_THAT(p.errors, IsEmpty());
   }

--- a/test/test-translation-table-generated.cpp
+++ b/test/test-translation-table-generated.cpp
@@ -2739,6 +2739,17 @@ const translated_string test_translation_table[] = {
         },
     },
     {
+        "misleading use of ',' operator in conditional statement"_translatable,
+        {
+            u8"misleading use of ',' operator in conditional statement",
+            u8"misleading use of ',' operator in conditional statement",
+            u8"misleading use of ',' operator in conditional statement",
+            u8"misleading use of ',' operator in conditional statement",
+            u8"misleading use of ',' operator in conditional statement",
+            u8"misleading use of ',' operator in conditional statement",
+        },
+    },
+    {
         "misleading use of ',' operator in index"_translatable,
         {
             u8"misleading use of ',' operator in index",


### PR DESCRIPTION
This commit adds a warning diagnostic to catch misleading comma operator usage in conditional statements of the if, while, for, and switch control blocks.

Closes #585 