### PR TITLE
Add diagnostic for empty parenthesis

### DIFF
--- a/docs/errors/E0452.md
+++ b/docs/errors/E0452.md
@@ -1,0 +1,19 @@
+# E0452: empty parenthesis after control statement
+
+Leaving parenthesis empty after control statements (`if`, `while`, `switch`,
+`with`) is a syntax error.
+
+```javascript
+while () {
+  console.log("Oops!..")
+}
+```
+
+If the intention here was to create an infinite loop, the implementation would
+be this:
+
+```javascript
+while (true) {
+  console.log("Now, that's an infinite loop");
+}
+```

--- a/po/de.po
+++ b/po/de.po
@@ -544,12 +544,12 @@ msgstr "Semikolon fehlt nach Anweisung"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
 #, fuzzy
-msgid "missing condition in '{1}' statement"
-msgstr "Bedingung der if-Anweisung fehlt"
+msgid "expected expression after '('"
+msgstr "Ausdruck nach 'case' erwartet"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
 #, fuzzy
-msgid "'{1}' statement ends here"
+msgid "'{1}' statement starts here"
 msgstr "try-Statement beginnt hier"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
@@ -2037,6 +2037,14 @@ msgstr "{1:singular} erwartet"
 #: test/test-vim-qflist-json-diag-reporter.cpp
 msgid "here"
 msgstr "hier"
+
+#, fuzzy
+#~ msgid "missing condition in '{1}' statement"
+#~ msgstr "Bedingung der if-Anweisung fehlt"
+
+#, fuzzy
+#~ msgid "'{1}' statement ends here"
+#~ msgstr "try-Statement beginnt hier"
 
 #, fuzzy
 #~ msgid "empty condition statement in if"

--- a/po/de.po
+++ b/po/de.po
@@ -543,6 +543,16 @@ msgid "misleading use of ',' operator in conditional statement"
 msgstr "Semikolon fehlt nach Anweisung"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
+#, fuzzy
+msgid "missing condition in '{1}' statement"
+msgstr "Bedingung der if-Anweisung fehlt"
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+#, fuzzy
+msgid "'{1}' statement ends here"
+msgstr "try-Statement beginnt hier"
+
+#: src/quick-lint-js/fe/diagnostic-types.h
 msgid "expected 'as' between '{1}' and '{2}'"
 msgstr "'as' zwischen '{1}' und '{2}' erwartet"
 
@@ -2027,6 +2037,14 @@ msgstr "{1:singular} erwartet"
 #: test/test-vim-qflist-json-diag-reporter.cpp
 msgid "here"
 msgstr "hier"
+
+#, fuzzy
+#~ msgid "empty condition statement in if"
+#~ msgstr "Bedingung der if-Anweisung fehlt"
+
+#, fuzzy
+#~ msgid "if ends here"
+#~ msgstr "Children enden hier"
 
 #, fuzzy
 #~ msgid "',' is not expected between the mems in '['']'"

--- a/po/en_US@snarky.po
+++ b/po/en_US@snarky.po
@@ -497,6 +497,16 @@ msgid "misleading use of ',' operator in conditional statement"
 msgstr "I know you hate semicolons, but you need one here"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
+#, fuzzy
+msgid "missing condition in '{1}' statement"
+msgstr "if WHAT?!"
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+#, fuzzy
+msgid "'{1}' statement ends here"
+msgstr "at least you tried"
+
+#: src/quick-lint-js/fe/diagnostic-types.h
 msgid "expected 'as' between '{1}' and '{2}'"
 msgstr "you forgot 'as' between '{1}' and '{2}'"
 
@@ -527,8 +537,7 @@ msgstr "be polite and say 'from'"
 #: src/quick-lint-js/fe/diagnostic-types.h
 msgid "expected hexadecimal digits in Unicode escape sequence"
 msgstr ""
-"what are you trying to do? This is a Unicode escape sequence, not a Wendy's "
-"🍔"
+"what are you trying to do? This is a Unicode escape sequence, not a Wendy's 🍔"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
 msgid "expected '{{'"
@@ -831,8 +840,7 @@ msgstr "how did the grammar Nazi die? colon cancer."
 
 #: src/quick-lint-js/fe/diagnostic-types.h
 msgid "'?' creates a conditional expression"
-msgstr ""
-"do you know what a conditional expression even is ? liar 🤥 : Kagi it 🔍"
+msgstr "do you know what a conditional expression even is ? liar 🤥 : Kagi it 🔍"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
 msgid "missing condition for if statement"
@@ -1882,6 +1890,14 @@ msgstr "expected {1:singular}"
 #: test/test-vim-qflist-json-diag-reporter.cpp
 msgid "here"
 msgstr "there 👈"
+
+#, fuzzy
+#~ msgid "empty condition statement in if"
+#~ msgstr "if WHAT?!"
+
+#, fuzzy
+#~ msgid "if ends here"
+#~ msgstr "🚸🚫⛔"
 
 #, fuzzy
 #~ msgid "',' is not expected between the mems in '['']'"

--- a/po/en_US@snarky.po
+++ b/po/en_US@snarky.po
@@ -498,12 +498,12 @@ msgstr "I know you hate semicolons, but you need one here"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
 #, fuzzy
-msgid "missing condition in '{1}' statement"
-msgstr "if WHAT?!"
+msgid "expected expression after '('"
+msgstr "this 'case' is awful lonely"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
 #, fuzzy
-msgid "'{1}' statement ends here"
+msgid "'{1}' statement starts here"
 msgstr "at least you tried"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
@@ -1890,6 +1890,14 @@ msgstr "expected {1:singular}"
 #: test/test-vim-qflist-json-diag-reporter.cpp
 msgid "here"
 msgstr "there 👈"
+
+#, fuzzy
+#~ msgid "missing condition in '{1}' statement"
+#~ msgstr "if WHAT?!"
+
+#, fuzzy
+#~ msgid "'{1}' statement ends here"
+#~ msgstr "at least you tried"
 
 #, fuzzy
 #~ msgid "empty condition statement in if"

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -554,12 +554,12 @@ msgstr "point-virgule manquant après l'instruction"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
 #, fuzzy
-msgid "missing condition in '{1}' statement"
-msgstr "condition manquante pour l'instruction if"
+msgid "expected expression after '('"
+msgstr "instruction attendue après 'case'"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
 #, fuzzy
-msgid "'{1}' statement ends here"
+msgid "'{1}' statement starts here"
 msgstr "l'instruction try débute ici"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
@@ -2054,6 +2054,14 @@ msgstr ""
 #: test/test-vim-qflist-json-diag-reporter.cpp
 msgid "here"
 msgstr ""
+
+#, fuzzy
+#~ msgid "missing condition in '{1}' statement"
+#~ msgstr "condition manquante pour l'instruction if"
+
+#, fuzzy
+#~ msgid "'{1}' statement ends here"
+#~ msgstr "l'instruction try débute ici"
 
 #, fuzzy
 #~ msgid "empty condition statement in if"

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -553,6 +553,16 @@ msgid "misleading use of ',' operator in conditional statement"
 msgstr "point-virgule manquant après l'instruction"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
+#, fuzzy
+msgid "missing condition in '{1}' statement"
+msgstr "condition manquante pour l'instruction if"
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+#, fuzzy
+msgid "'{1}' statement ends here"
+msgstr "l'instruction try débute ici"
+
+#: src/quick-lint-js/fe/diagnostic-types.h
 msgid "expected 'as' between '{1}' and '{2}'"
 msgstr "'as' attendu entre '{1}' and '{2}'"
 
@@ -2044,6 +2054,14 @@ msgstr ""
 #: test/test-vim-qflist-json-diag-reporter.cpp
 msgid "here"
 msgstr ""
+
+#, fuzzy
+#~ msgid "empty condition statement in if"
+#~ msgstr "condition manquante pour l'instruction if"
+
+#, fuzzy
+#~ msgid "if ends here"
+#~ msgstr "appel de fonction débuté ici"
 
 #, fuzzy
 #~ msgid "',' is not expected between the mems in '['']'"

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -462,6 +462,14 @@ msgid "misleading use of ',' operator in conditional statement"
 msgstr ""
 
 #: src/quick-lint-js/fe/diagnostic-types.h
+msgid "missing condition in '{1}' statement"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+msgid "'{1}' statement ends here"
+msgstr ""
+
+#: src/quick-lint-js/fe/diagnostic-types.h
 msgid "expected 'as' between '{1}' and '{2}'"
 msgstr ""
 

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -462,11 +462,11 @@ msgid "misleading use of ',' operator in conditional statement"
 msgstr ""
 
 #: src/quick-lint-js/fe/diagnostic-types.h
-msgid "missing condition in '{1}' statement"
+msgid "expected expression after '('"
 msgstr ""
 
 #: src/quick-lint-js/fe/diagnostic-types.h
-msgid "'{1}' statement ends here"
+msgid "'{1}' statement starts here"
 msgstr ""
 
 #: src/quick-lint-js/fe/diagnostic-types.h

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -481,6 +481,16 @@ msgid "misleading use of ',' operator in conditional statement"
 msgstr "falta o ponto e vírgula após a instrução"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
+#, fuzzy
+msgid "missing condition in '{1}' statement"
+msgstr "falta a condição da instrução if"
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+#, fuzzy
+msgid "'{1}' statement ends here"
+msgstr "instrução try iniciou aqui"
+
+#: src/quick-lint-js/fe/diagnostic-types.h
 msgid "expected 'as' between '{1}' and '{2}'"
 msgstr "'as' esperado entre '{1}' e '{2}'"
 
@@ -1816,6 +1826,14 @@ msgstr "esperado {1:singular}"
 #: test/test-vim-qflist-json-diag-reporter.cpp
 msgid "here"
 msgstr "aqui"
+
+#, fuzzy
+#~ msgid "empty condition statement in if"
+#~ msgstr "falta a condição da instrução if"
+
+#, fuzzy
+#~ msgid "if ends here"
+#~ msgstr "os nós acabam aqui"
 
 #, fuzzy
 #~ msgid "',' is not expected between the mems in '['']'"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -482,12 +482,12 @@ msgstr "falta o ponto e vírgula após a instrução"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
 #, fuzzy
-msgid "missing condition in '{1}' statement"
-msgstr "falta a condição da instrução if"
+msgid "expected expression after '('"
+msgstr "esperada uma expressão após 'case'"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
 #, fuzzy
-msgid "'{1}' statement ends here"
+msgid "'{1}' statement starts here"
 msgstr "instrução try iniciou aqui"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
@@ -1826,6 +1826,14 @@ msgstr "esperado {1:singular}"
 #: test/test-vim-qflist-json-diag-reporter.cpp
 msgid "here"
 msgstr "aqui"
+
+#, fuzzy
+#~ msgid "missing condition in '{1}' statement"
+#~ msgstr "falta a condição da instrução if"
+
+#, fuzzy
+#~ msgid "'{1}' statement ends here"
+#~ msgstr "instrução try iniciou aqui"
 
 #, fuzzy
 #~ msgid "empty condition statement in if"

--- a/po/sv_SE.po
+++ b/po/sv_SE.po
@@ -498,6 +498,16 @@ msgid "misleading use of ',' operator in conditional statement"
 msgstr "saknar semikolon efter påstående"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
+#, fuzzy
+msgid "missing condition in '{1}' statement"
+msgstr "saknar vilkor i if påstående"
+
+#: src/quick-lint-js/fe/diagnostic-types.h
+#, fuzzy
+msgid "'{1}' statement ends here"
+msgstr "try sats startar här"
+
+#: src/quick-lint-js/fe/diagnostic-types.h
 msgid "expected 'as' between '{1}' and '{2}'"
 msgstr "förväntade 'as' mellan '{1}' och '{2}'"
 
@@ -1888,6 +1898,14 @@ msgstr ""
 #: test/test-vim-qflist-json-diag-reporter.cpp
 msgid "here"
 msgstr ""
+
+#, fuzzy
+#~ msgid "empty condition statement in if"
+#~ msgstr "saknar vilkor i if påstående"
+
+#, fuzzy
+#~ msgid "if ends here"
+#~ msgstr "funktionkallelse startar här"
 
 #, fuzzy
 #~ msgid "',' is not expected between the mems in '['']'"

--- a/po/sv_SE.po
+++ b/po/sv_SE.po
@@ -499,12 +499,12 @@ msgstr "saknar semikolon efter påstående"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
 #, fuzzy
-msgid "missing condition in '{1}' statement"
-msgstr "saknar vilkor i if påstående"
+msgid "expected expression after '('"
+msgstr "förväntade ett uttryck efter 'case'"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
 #, fuzzy
-msgid "'{1}' statement ends here"
+msgid "'{1}' statement starts here"
 msgstr "try sats startar här"
 
 #: src/quick-lint-js/fe/diagnostic-types.h
@@ -1898,6 +1898,14 @@ msgstr ""
 #: test/test-vim-qflist-json-diag-reporter.cpp
 msgid "here"
 msgstr ""
+
+#, fuzzy
+#~ msgid "missing condition in '{1}' statement"
+#~ msgstr "saknar vilkor i if påstående"
+
+#, fuzzy
+#~ msgid "'{1}' statement ends here"
+#~ msgstr "try sats startar här"
 
 #, fuzzy
 #~ msgid "empty condition statement in if"

--- a/src/quick-lint-js/fe/diagnostic-types.h
+++ b/src/quick-lint-js/fe/diagnostic-types.h
@@ -676,6 +676,19 @@
               comma))                                                           \
                                                                                 \
   QLJS_DIAG_TYPE(                                                               \
+      diag_empty_paren_after_control_statement, "E0452",                        \
+      diagnostic_severity::error,                                               \
+      {                                                                         \
+        source_code_span token;                                                 \
+        source_code_span left_paren;                                            \
+        source_code_span right_paren;                                           \
+      },                                                                        \
+      MESSAGE(QLJS_TRANSLATABLE("missing condition in '{1}' statement"),        \
+              left_paren, token)                                                \
+          MESSAGE(QLJS_TRANSLATABLE("'{1}' statement ends here"), right_paren,  \
+                  token))                                                       \
+                                                                                \
+  QLJS_DIAG_TYPE(                                                               \
       diag_expected_as_before_imported_namespace_alias, "E0126",                \
       diagnostic_severity::error,                                               \
       {                                                                         \

--- a/src/quick-lint-js/fe/diagnostic-types.h
+++ b/src/quick-lint-js/fe/diagnostic-types.h
@@ -680,12 +680,11 @@
       diagnostic_severity::error,                                               \
       {                                                                         \
         source_code_span token;                                                 \
-        source_code_span left_paren;                                            \
-        source_code_span right_paren;                                           \
+        source_code_span expected_expression;                                   \
       },                                                                        \
-      MESSAGE(QLJS_TRANSLATABLE("missing condition in '{1}' statement"),        \
-              left_paren, token)                                                \
-          MESSAGE(QLJS_TRANSLATABLE("'{1}' statement ends here"), right_paren,  \
+      MESSAGE(QLJS_TRANSLATABLE("expected expression after '('"),               \
+              expected_expression)                                              \
+          MESSAGE(QLJS_TRANSLATABLE("'{1}' statement starts here"), token,      \
                   token))                                                       \
                                                                                 \
   QLJS_DIAG_TYPE(                                                               \

--- a/src/quick-lint-js/fe/parse-statement.cpp
+++ b/src/quick-lint-js/fe/parse-statement.cpp
@@ -1923,7 +1923,7 @@ void parser::parse_and_visit_switch(parse_visitor_base &v) {
         diag_expected_parentheses_around_switch_condition,
         diag_expected_parenthesis_around_switch_condition,
         /*CheckForSketchyConditions=*/false,
-        /*CheckForCommaOperator=*/true>(v);
+        /*CheckForCommaOperator=*/true>(switch_token_span, v);
   }
 
   switch (this->peek().type) {
@@ -2592,7 +2592,7 @@ void parser::parse_and_visit_do_while(parse_visitor_base &v) {
       diag_expected_parentheses_around_do_while_condition,
       diag_expected_parenthesis_around_do_while_condition,
       /*CheckForSketchyConditions=*/true,
-      /*CheckForCommaOperator=*/true>(v);
+      /*CheckForCommaOperator=*/true>(do_token_span, v);
 
   if (this->peek().type == token_type::semicolon) {
     this->skip();
@@ -3007,7 +3007,7 @@ void parser::parse_and_visit_while(parse_visitor_base &v) {
         diag_expected_parentheses_around_while_condition,
         diag_expected_parenthesis_around_while_condition,
         /*CheckForSketchyConditions=*/true,
-        /*CheckForCommaOperator=*/true>(v);
+        /*CheckForCommaOperator=*/true>(while_token_span, v);
   }
 
   this->error_on_class_statement(statement_kind::while_loop);
@@ -3025,13 +3025,14 @@ void parser::parse_and_visit_while(parse_visitor_base &v) {
 
 void parser::parse_and_visit_with(parse_visitor_base &v) {
   QLJS_ASSERT(this->peek().type == token_type::kw_with);
+  source_code_span with_token_span = this->peek().span();
   this->skip();
 
   this->parse_and_visit_parenthesized_expression<
       diag_expected_parentheses_around_with_expression,
       diag_expected_parenthesis_around_with_expression,
       /*CheckForSketchyConditions=*/false,
-      /*CheckForCommaOperator=*/false>(v);
+      /*CheckForCommaOperator=*/false>(with_token_span, v);
 
   this->error_on_class_statement(statement_kind::with_statement);
   this->error_on_function_statement(statement_kind::with_statement);
@@ -3061,7 +3062,7 @@ void parser::parse_and_visit_if(parse_visitor_base &v) {
         diag_expected_parentheses_around_if_condition,
         diag_expected_parenthesis_around_if_condition,
         /*CheckForSketchyConditions=*/true,
-        /*CheckForCommaOperator=*/true>(v);
+        /*CheckForCommaOperator=*/true>(if_token_span, v);
   }
 
   auto parse_and_visit_body = [this, &v]() -> void {

--- a/src/quick-lint-js/fe/parse-statement.cpp
+++ b/src/quick-lint-js/fe/parse-statement.cpp
@@ -1923,7 +1923,7 @@ void parser::parse_and_visit_switch(parse_visitor_base &v) {
         diag_expected_parentheses_around_switch_condition,
         diag_expected_parenthesis_around_switch_condition,
         /*CheckForSketchyConditions=*/false,
-        /*CheckForCommaOperator=*/true>(switch_token_span, v);
+        /*CheckForCommaOperator=*/true>(v, switch_token_span);
   }
 
   switch (this->peek().type) {
@@ -2592,7 +2592,7 @@ void parser::parse_and_visit_do_while(parse_visitor_base &v) {
       diag_expected_parentheses_around_do_while_condition,
       diag_expected_parenthesis_around_do_while_condition,
       /*CheckForSketchyConditions=*/true,
-      /*CheckForCommaOperator=*/true>(do_token_span, v);
+      /*CheckForCommaOperator=*/true>(v, do_token_span);
 
   if (this->peek().type == token_type::semicolon) {
     this->skip();
@@ -3007,7 +3007,7 @@ void parser::parse_and_visit_while(parse_visitor_base &v) {
         diag_expected_parentheses_around_while_condition,
         diag_expected_parenthesis_around_while_condition,
         /*CheckForSketchyConditions=*/true,
-        /*CheckForCommaOperator=*/true>(while_token_span, v);
+        /*CheckForCommaOperator=*/true>(v, while_token_span);
   }
 
   this->error_on_class_statement(statement_kind::while_loop);
@@ -3032,7 +3032,7 @@ void parser::parse_and_visit_with(parse_visitor_base &v) {
       diag_expected_parentheses_around_with_expression,
       diag_expected_parenthesis_around_with_expression,
       /*CheckForSketchyConditions=*/false,
-      /*CheckForCommaOperator=*/false>(with_token_span, v);
+      /*CheckForCommaOperator=*/false>(v, with_token_span);
 
   this->error_on_class_statement(statement_kind::with_statement);
   this->error_on_function_statement(statement_kind::with_statement);
@@ -3062,7 +3062,7 @@ void parser::parse_and_visit_if(parse_visitor_base &v) {
         diag_expected_parentheses_around_if_condition,
         diag_expected_parenthesis_around_if_condition,
         /*CheckForSketchyConditions=*/true,
-        /*CheckForCommaOperator=*/true>(if_token_span, v);
+        /*CheckForCommaOperator=*/true>(v, if_token_span);
   }
 
   auto parse_and_visit_body = [this, &v]() -> void {

--- a/src/quick-lint-js/fe/parse.h
+++ b/src/quick-lint-js/fe/parse.h
@@ -398,8 +398,8 @@ class parser {
 
   template <class ExpectedParenthesesError, class ExpectedParenthesisError,
             bool CheckForSketchyConditions, bool CheckForCommaOperator>
-  void parse_and_visit_parenthesized_expression(source_code_span token,
-                                                parse_visitor_base &v);
+  void parse_and_visit_parenthesized_expression(parse_visitor_base &v,
+                                                source_code_span token);
 
   void error_on_sketchy_condition(expression *);
   void warn_on_comma_operator_in_conditional_statement(expression *);
@@ -917,20 +917,20 @@ class parser {
 template <class ExpectedParenthesesError, class ExpectedParenthesisError,
           bool CheckForSketchyConditions, bool CheckForCommaOperator>
 void parser::parse_and_visit_parenthesized_expression(
-    source_code_span token_span, parse_visitor_base &v) {
+    parse_visitor_base &v, source_code_span token_span) {
   bool have_expression_left_paren = this->peek().type == token_type::left_paren;
-  source_code_span left_paren_span = this->peek().span();
   if (have_expression_left_paren) {
+    source_code_span left_paren_span = this->peek().span();
     this->skip();
+
+    if (this->peek().type == token_type::right_paren) {
+      this->diag_reporter_->report(diag_empty_paren_after_control_statement{
+          .token = token_span,
+          .expected_expression =
+              source_code_span::unit(left_paren_span.end())});
+    }
   }
 
-  if (this->peek().type == token_type::right_paren) {
-    source_code_span right_paren_span = this->peek().span();
-    this->diag_reporter_->report(diag_empty_paren_after_control_statement{
-        .token = token_span,
-        .left_paren = left_paren_span,
-        .right_paren = right_paren_span});
-  }
   const char8 *expression_begin = this->peek().begin;
 
   expression *ast = this->parse_expression(v);

--- a/src/quick-lint-js/i18n/translation-table-generated.cpp
+++ b/src/quick-lint-js/i18n/translation-table-generated.cpp
@@ -75,7 +75,7 @@ const translation_table translation_data = {
         {0, 0, 0, 46, 0, 50},                //
         {69, 48, 0, 36, 0, 32},              //
         {0, 0, 0, 0, 0, 62},                 //
-        {68, 25, 0, 65, 0, 26},              //
+        {68, 25, 0, 65, 0, 28},              //
         {83, 55, 66, 62, 49, 62},            //
         {32, 32, 57, 34, 45, 38},            //
         {30, 33, 40, 30, 44, 33},            //
@@ -195,7 +195,8 @@ const translation_table translation_data = {
         {37, 29, 36, 37, 41, 37},            //
         {39, 25, 49, 41, 44, 40},            //
         {0, 0, 0, 14, 0, 14},                //
-        {14, 24, 13, 67, 18, 58},            //
+        {0, 0, 0, 0, 0, 58},                 //
+        {14, 24, 13, 67, 18, 30},            //
         {30, 28, 35, 37, 38, 33},            //
         {36, 18, 44, 49, 37, 35},            //
         {32, 39, 44, 50, 41, 37},            //
@@ -293,8 +294,7 @@ const translation_table translation_data = {
         {76, 28, 56, 73, 48, 69},            //
         {33, 10, 42, 37, 31, 35},            //
         {38, 14, 46, 41, 38, 39},            //
-        {0, 0, 0, 0, 0, 38},                 //
-        {35, 13, 45, 40, 37, 37},            //
+        {35, 13, 45, 40, 37, 38},            //
         {36, 34, 39, 35, 40, 35},            //
         {33, 7, 40, 40, 33, 39},             //
         {24, 11, 33, 22, 23, 24},            //
@@ -1781,7 +1781,7 @@ const translation_table translation_data = {
         u8"'{0}' is not allowed for strings; use {1} instead\0"
         u8"'{0}' is not allowed on methods\0"
         u8"'{0}' operator cannot be used before '**' without parentheses\0"
-        u8"'{1}' statement ends here\0"
+        u8"'{1}' statement starts here\0"
         u8"'}' is not allowed directly in JSX text; write {{'}'} instead\0"
         u8"BigInt literal contains decimal point\0"
         u8"BigInt literal contains exponent\0"
@@ -1902,6 +1902,7 @@ const translation_table translation_data = {
         u8"expected 'from' before module specifier\0"
         u8"expected '{{'\0"
         u8"expected at least one parameter in generic parameter list\0"
+        u8"expected expression after '('\0"
         u8"expected expression after 'case'\0"
         u8"expected expression before newline\0"
         u8"expected expression before semicolon\0"
@@ -2000,7 +2001,6 @@ const translation_table translation_data = {
         u8"missing condition for if statement\0"
         u8"missing condition for switch statement\0"
         u8"missing condition for while statement\0"
-        u8"missing condition in '{1}' statement\0"
         u8"missing end of array; expected ']'\0"
         u8"missing expression between parentheses\0"
         u8"missing for loop header\0"

--- a/src/quick-lint-js/i18n/translation-table-generated.cpp
+++ b/src/quick-lint-js/i18n/translation-table-generated.cpp
@@ -74,7 +74,8 @@ const translation_table translation_data = {
         {15, 17, 0, 22, 0, 17},              //
         {0, 0, 0, 46, 0, 50},                //
         {69, 48, 0, 36, 0, 32},              //
-        {68, 25, 0, 65, 0, 62},              //
+        {0, 0, 0, 0, 0, 62},                 //
+        {68, 25, 0, 65, 0, 26},              //
         {83, 55, 66, 62, 49, 62},            //
         {32, 32, 57, 34, 45, 38},            //
         {30, 33, 40, 30, 44, 33},            //
@@ -292,7 +293,8 @@ const translation_table translation_data = {
         {76, 28, 56, 73, 48, 69},            //
         {33, 10, 42, 37, 31, 35},            //
         {38, 14, 46, 41, 38, 39},            //
-        {35, 13, 45, 40, 37, 38},            //
+        {0, 0, 0, 0, 0, 38},                 //
+        {35, 13, 45, 40, 37, 37},            //
         {36, 34, 39, 35, 40, 35},            //
         {33, 7, 40, 40, 33, 39},             //
         {24, 11, 33, 22, 23, 24},            //
@@ -1779,6 +1781,7 @@ const translation_table translation_data = {
         u8"'{0}' is not allowed for strings; use {1} instead\0"
         u8"'{0}' is not allowed on methods\0"
         u8"'{0}' operator cannot be used before '**' without parentheses\0"
+        u8"'{1}' statement ends here\0"
         u8"'}' is not allowed directly in JSX text; write {{'}'} instead\0"
         u8"BigInt literal contains decimal point\0"
         u8"BigInt literal contains exponent\0"
@@ -1997,6 +2000,7 @@ const translation_table translation_data = {
         u8"missing condition for if statement\0"
         u8"missing condition for switch statement\0"
         u8"missing condition for while statement\0"
+        u8"missing condition in '{1}' statement\0"
         u8"missing end of array; expected ']'\0"
         u8"missing expression between parentheses\0"
         u8"missing for loop header\0"

--- a/src/quick-lint-js/i18n/translation-table-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-generated.h
@@ -21,7 +21,7 @@ using namespace std::literals::string_view_literals;
 
 constexpr std::uint32_t translation_table_locale_count = 5;
 constexpr std::uint16_t translation_table_mapping_table_size = 426;
-constexpr std::size_t translation_table_string_table_size = 75635;
+constexpr std::size_t translation_table_string_table_size = 75630;
 constexpr std::size_t translation_table_locale_table_size = 35;
 
 QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
@@ -91,7 +91,7 @@ QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
           "'{0}' is not allowed for strings; use {1} instead"sv,
           "'{0}' is not allowed on methods"sv,
           "'{0}' operator cannot be used before '**' without parentheses"sv,
-          "'{1}' statement ends here"sv,
+          "'{1}' statement starts here"sv,
           "'}' is not allowed directly in JSX text; write {{'}'} instead"sv,
           "BigInt literal contains decimal point"sv,
           "BigInt literal contains exponent"sv,
@@ -212,6 +212,7 @@ QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
           "expected 'from' before module specifier"sv,
           "expected '{{'"sv,
           "expected at least one parameter in generic parameter list"sv,
+          "expected expression after '('"sv,
           "expected expression after 'case'"sv,
           "expected expression before newline"sv,
           "expected expression before semicolon"sv,
@@ -310,7 +311,6 @@ QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
           "missing condition for if statement"sv,
           "missing condition for switch statement"sv,
           "missing condition for while statement"sv,
-          "missing condition in '{1}' statement"sv,
           "missing end of array; expected ']'"sv,
           "missing expression between parentheses"sv,
           "missing for loop header"sv,

--- a/src/quick-lint-js/i18n/translation-table-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-generated.h
@@ -20,8 +20,8 @@ namespace quick_lint_js {
 using namespace std::literals::string_view_literals;
 
 constexpr std::uint32_t translation_table_locale_count = 5;
-constexpr std::uint16_t translation_table_mapping_table_size = 424;
-constexpr std::size_t translation_table_string_table_size = 75572;
+constexpr std::uint16_t translation_table_mapping_table_size = 426;
+constexpr std::size_t translation_table_string_table_size = 75635;
 constexpr std::size_t translation_table_locale_table_size = 35;
 
 QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
@@ -91,6 +91,7 @@ QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
           "'{0}' is not allowed for strings; use {1} instead"sv,
           "'{0}' is not allowed on methods"sv,
           "'{0}' operator cannot be used before '**' without parentheses"sv,
+          "'{1}' statement ends here"sv,
           "'}' is not allowed directly in JSX text; write {{'}'} instead"sv,
           "BigInt literal contains decimal point"sv,
           "BigInt literal contains exponent"sv,
@@ -309,6 +310,7 @@ QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
           "missing condition for if statement"sv,
           "missing condition for switch statement"sv,
           "missing condition for while statement"sv,
+          "missing condition in '{1}' statement"sv,
           "missing end of array; expected ']'"sv,
           "missing expression between parentheses"sv,
           "missing for loop header"sv,

--- a/test/quick-lint-js/test-translation-table-generated.h
+++ b/test/quick-lint-js/test-translation-table-generated.h
@@ -27,7 +27,7 @@ struct translated_string {
   const char8 *expected_per_locale[6];
 };
 
-extern const translated_string test_translation_table[423];
+extern const translated_string test_translation_table[425];
 }
 
 #endif

--- a/test/test-parse-statement.cpp
+++ b/test/test-parse-statement.cpp
@@ -269,8 +269,8 @@ TEST_F(test_parse_statement, empty_paren_after_control_statement) {
                 ElementsAreArray({
                     DIAG_TYPE_2_OFFSETS(
                         p.code, diag_empty_paren_after_control_statement,
-                        left_paren, strlen(u8"if"), u8"("_sv, right_paren,
-                        strlen(u8"if("), u8")"_sv),
+                        expected_expression, strlen(u8"if("), u8""_sv, token,
+                        strlen(u8""), u8"if"_sv),
                 }));
   }
 
@@ -281,8 +281,8 @@ TEST_F(test_parse_statement, empty_paren_after_control_statement) {
                 ElementsAreArray({
                     DIAG_TYPE_2_OFFSETS(
                         p.code, diag_empty_paren_after_control_statement,
-                        left_paren, strlen(u8"switch"), u8"("_sv, right_paren,
-                        strlen(u8"switch("), u8")"_sv),
+                        expected_expression, strlen(u8"switch("), u8""_sv,
+                        token, strlen(u8""), u8"switch"_sv),
                 }));
   }
 
@@ -293,8 +293,8 @@ TEST_F(test_parse_statement, empty_paren_after_control_statement) {
                 ElementsAreArray({
                     DIAG_TYPE_2_OFFSETS(
                         p.code, diag_empty_paren_after_control_statement,
-                        left_paren, strlen(u8"while"), u8"("_sv, right_paren,
-                        strlen(u8"while("), u8")"_sv),
+                        expected_expression, strlen(u8"while("), u8""_sv, token,
+                        strlen(u8""), u8"while"_sv),
                 }));
   }
 
@@ -305,15 +305,9 @@ TEST_F(test_parse_statement, empty_paren_after_control_statement) {
                 ElementsAreArray({
                     DIAG_TYPE_2_OFFSETS(
                         p.code, diag_empty_paren_after_control_statement,
-                        left_paren, strlen(u8"with"), u8"("_sv, right_paren,
-                        strlen(u8"with("), u8")"_sv),
+                        expected_expression, strlen(u8"with("), u8""_sv, token,
+                        strlen(u8""), u8"with"_sv),
                 }));
-  }
-
-  {
-    test_parser p(u8"if(true){}"_sv, capture_diags);
-    p.parse_and_visit_statement();
-    EXPECT_THAT(p.errors, IsEmpty());
   }
 }
 

--- a/test/test-parse-statement.cpp
+++ b/test/test-parse-statement.cpp
@@ -261,6 +261,62 @@ TEST_F(test_parse_statement, return_statement_disallows_newline_in_block) {
   }
 }
 
+TEST_F(test_parse_statement, empty_paren_after_control_statement) {
+  {
+    test_parser p(u8"if(){}"_sv, capture_diags);
+    p.parse_and_visit_statement();
+    EXPECT_THAT(p.errors,
+                ElementsAreArray({
+                    DIAG_TYPE_2_OFFSETS(
+                        p.code, diag_empty_paren_after_control_statement,
+                        left_paren, strlen(u8"if"), u8"("_sv, right_paren,
+                        strlen(u8"if("), u8")"_sv),
+                }));
+  }
+
+  {
+    test_parser p(u8"switch(){}"_sv, capture_diags);
+    p.parse_and_visit_statement();
+    EXPECT_THAT(p.errors,
+                ElementsAreArray({
+                    DIAG_TYPE_2_OFFSETS(
+                        p.code, diag_empty_paren_after_control_statement,
+                        left_paren, strlen(u8"switch"), u8"("_sv, right_paren,
+                        strlen(u8"switch("), u8")"_sv),
+                }));
+  }
+
+  {
+    test_parser p(u8"while(){}"_sv, capture_diags);
+    p.parse_and_visit_statement();
+    EXPECT_THAT(p.errors,
+                ElementsAreArray({
+                    DIAG_TYPE_2_OFFSETS(
+                        p.code, diag_empty_paren_after_control_statement,
+                        left_paren, strlen(u8"while"), u8"("_sv, right_paren,
+                        strlen(u8"while("), u8")"_sv),
+                }));
+  }
+
+  {
+    test_parser p(u8"with(){}"_sv, capture_diags);
+    p.parse_and_visit_statement();
+    EXPECT_THAT(p.errors,
+                ElementsAreArray({
+                    DIAG_TYPE_2_OFFSETS(
+                        p.code, diag_empty_paren_after_control_statement,
+                        left_paren, strlen(u8"with"), u8"("_sv, right_paren,
+                        strlen(u8"with("), u8")"_sv),
+                }));
+  }
+
+  {
+    test_parser p(u8"if(true){}"_sv, capture_diags);
+    p.parse_and_visit_statement();
+    EXPECT_THAT(p.errors, IsEmpty());
+  }
+}
+
 TEST_F(test_parse_statement, throw_statement) {
   {
     test_parser p(u8"throw new Error('ouch');"_sv);

--- a/test/test-translation-table-generated.cpp
+++ b/test/test-translation-table-generated.cpp
@@ -704,14 +704,14 @@ const translated_string test_translation_table[] = {
         },
     },
     {
-        "'{1}' statement ends here"_translatable,
+        "'{1}' statement starts here"_translatable,
         {
-            u8"'{1}' statement ends here",
-            u8"'{1}' statement ends here",
-            u8"'{1}' statement ends here",
-            u8"'{1}' statement ends here",
-            u8"'{1}' statement ends here",
-            u8"'{1}' statement ends here",
+            u8"'{1}' statement starts here",
+            u8"'{1}' statement starts here",
+            u8"'{1}' statement starts here",
+            u8"'{1}' statement starts here",
+            u8"'{1}' statement starts here",
+            u8"'{1}' statement starts here",
         },
     },
     {
@@ -2035,6 +2035,17 @@ const translated_string test_translation_table[] = {
         },
     },
     {
+        "expected expression after '('"_translatable,
+        {
+            u8"expected expression after '('",
+            u8"expected expression after '('",
+            u8"expected expression after '('",
+            u8"expected expression after '('",
+            u8"expected expression after '('",
+            u8"expected expression after '('",
+        },
+    },
+    {
         "expected expression after 'case'"_translatable,
         {
             u8"expected expression after 'case'",
@@ -3110,17 +3121,6 @@ const translated_string test_translation_table[] = {
             u8"condition manquante pour l'instruction while",
             u8"falta a condi\u00e7\u00e3o da instru\u00e7\u00e3o while",
             u8"saknar vilkor f\u00f6r while p\u00e5st\u00e5ende",
-        },
-    },
-    {
-        "missing condition in '{1}' statement"_translatable,
-        {
-            u8"missing condition in '{1}' statement",
-            u8"missing condition in '{1}' statement",
-            u8"missing condition in '{1}' statement",
-            u8"missing condition in '{1}' statement",
-            u8"missing condition in '{1}' statement",
-            u8"missing condition in '{1}' statement",
         },
     },
     {

--- a/test/test-translation-table-generated.cpp
+++ b/test/test-translation-table-generated.cpp
@@ -704,6 +704,17 @@ const translated_string test_translation_table[] = {
         },
     },
     {
+        "'{1}' statement ends here"_translatable,
+        {
+            u8"'{1}' statement ends here",
+            u8"'{1}' statement ends here",
+            u8"'{1}' statement ends here",
+            u8"'{1}' statement ends here",
+            u8"'{1}' statement ends here",
+            u8"'{1}' statement ends here",
+        },
+    },
+    {
         "'}' is not allowed directly in JSX text; write {{'}'} instead"_translatable,
         {
             u8"'}' is not allowed directly in JSX text; write {{'}'} instead",
@@ -3099,6 +3110,17 @@ const translated_string test_translation_table[] = {
             u8"condition manquante pour l'instruction while",
             u8"falta a condi\u00e7\u00e3o da instru\u00e7\u00e3o while",
             u8"saknar vilkor f\u00f6r while p\u00e5st\u00e5ende",
+        },
+    },
+    {
+        "missing condition in '{1}' statement"_translatable,
+        {
+            u8"missing condition in '{1}' statement",
+            u8"missing condition in '{1}' statement",
+            u8"missing condition in '{1}' statement",
+            u8"missing condition in '{1}' statement",
+            u8"missing condition in '{1}' statement",
+            u8"missing condition in '{1}' statement",
         },
     },
     {


### PR DESCRIPTION
This commit adds a new error diagnostic for empty parenthesis after control statements. The empty parenthesis after for statements are handled by [```E0096```](https://github.com/quick-lint/quick-lint-js/blob/master/docs/errors/E0096.md).

Closes #941 