### PR TITLE
BugFix: Fix copy and paste of code from demo.

### DIFF
--- a/website/public/main.css
+++ b/website/public/main.css
@@ -532,6 +532,7 @@ kbd.keystroke {
   padding: 5px;
   font-size: 0.8rem;
   max-width: 300px;
+  user-select: none;
   z-index: 100;
 }
 


### PR DESCRIPTION
Issue: #979 we use `user-select:none` on CSS with id `error-box`
gets rid of this message "0057 - use of undeclared variable: ocupationconsole.log(`Welcome, ${occupation}!`);note: creating worker"
 