### PR TITLE
Issue#937 - step one: script to create version-specific webinstaller/…

### DIFF
--- a/dist/webinstaller/README.md
+++ b/dist/webinstaller/README.md
@@ -1,0 +1,10 @@
+# quick-lint-js webinstaller manifest
+
+This directory contains manifests for [webinstaller][], a developer tools installer.
+
+The `make-webinstaller-manifest.js` script insert the ouput file with the appropriate release version number and its release date.
+
+## Manually building the manifest
+
+Run:
+   `node  dist/webinstaller/make-webinstaller-manifest.js -BaseURI https://c.quick-lint-js.com/releases/RELEASE_VERSION/ -releaseDate RELEASE_DATE -Out OUTPUT_FILE.json`

--- a/dist/webinstaller/README.md
+++ b/dist/webinstaller/README.md
@@ -1,10 +1,13 @@
 # quick-lint-js webinstaller manifest
 
-This directory contains manifests for [webinstaller][], a developer tools installer.
+This directory contains manifests for [webinstaller](https://webinstall.dev/), a developer tools installer.
 
-The `make-webinstaller-manifest.js` script insert the ouput file with the appropriate release version number and its release date.
+The `make-webinstaller-manifest.js` script creates the output file with the appropriate release version number and its release date.
 
 ## Manually building the manifest
 
 Run:
-   `node  dist/webinstaller/make-webinstaller-manifest.js -BaseURI https://c.quick-lint-js.com/releases/RELEASE_VERSION/ -releaseDate RELEASE_DATE -Out OUTPUT_FILE.json`
+
+```sh
+node  dist/webinstaller/make-webinstaller-manifest.js -releaseVersion VERSION -releaseDate RELEASE_DATE -Out OUTPUT_FILE.json
+```

--- a/dist/webinstaller/make-webinstaller-manifest.js
+++ b/dist/webinstaller/make-webinstaller-manifest.js
@@ -1,47 +1,63 @@
-const fs = require('fs');
+// Copyright (C) 2020  Matthew "strager" Glazar
+// See end of file for extended copyright information.
 
-const [, , ...args] = process.argv;
-const [baseUriArg, BaseURI, releaseDateArg, releaseDate, outputArg, outputFile] = args;
+const fs = require("fs");
 
-function validateArg(args, argName, regex) {
-    const argIndex = args.indexOf(argName);
-    if (argIndex < 0) {
-      console.log(`error: missing ${argName}`);
-      return false;
-    }
-  
-    const argValue = args[argIndex + 1];
-    if (!regex.test(argValue)) {
-      console.log(`error: invalid ${argName}; must match regular expression: ${regex}`);
-      return false;
-    }
-  
-    return true;
-  }
-  
-  if (!validateArg(args, '-BaseURI', /^https?:\/\/.*\/$/)) {
-    return 0;
-  }
-  
-  if (!validateArg(args, '-releaseDate', /^\d{4}-\d{2}-\d{2}$/)) {
-    return 0;
-  }
-  
+const args = process.argv.slice(2);
+const releaseVersion = process.argv[3];
+const releaseDate = process.argv[5];
+const outputFile = process.argv[7];
 
-//get the version
-const releasesRegex = /\/(\d+\.\d+\.\d+)\/$/;
-const releasesVersion = BaseURI.match(releasesRegex);
-
-const template = fs.readFileSync('quick-lint-js-template.json', 'utf8');
-
-const data = JSON.parse(template);
-
-// set version and insert download with the approriate value 
-for (const release of data.release) {
-    release.version = releasesVersion[1];
-    release.download = release.download.replace('${version}', releasesVersion[1]);
-    release.date = releaseDate;
+if (!args.includes("-releaseVersion")) {
+  console.log("error: missing -releaseVersion");
+  return 0;
+}
+if (!args.includes("-releaseDate")) {
+  console.log("error: missing -releaseDate");
+  return 0;
+}
+if (!args.includes("-Out")) {
+  console.log("error: missing -Out");
+  return 0;
 }
 
-// Write the modified data back to a file
-fs.writeFileSync(outputFile, JSON.stringify(data, null, 2), 'utf8');
+const releaseVersionRegex = /^\d+\.\d+\.\d+$/;
+if (!releaseVersionRegex.test(releaseVersion)) {
+  console.log(
+    "error: invalid -releaseVersion; must match regular expression: " +
+      releaseVersionRegex
+  );
+  return 0;
+}
+
+const releasesDateRegex = /^\d{4}-\d{2}-\d{2}$/;
+if (!releasesDateRegex.test(releaseDate)) {
+  console.log(
+    "error: invalid -releaseDate; must match regular expression: " +
+      releasesDateRegex
+  );
+  return 0;
+}
+
+let data = fs.readFileSync("quick-lint-js-template.json", "utf8");
+data = data.replace(/{version}/g, releaseVersion);
+data = data.replace(/\${releaseDate}/g, releaseDate);
+fs.writeFileSync(outputFile, data, "utf8");
+
+// quick-lint-js finds bugs in JavaScript programs.
+// Copyright (C) 2020  Matthew "strager" Glazar
+//
+// This file is part of quick-lint-js.
+//
+// quick-lint-js is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// quick-lint-js is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with quick-lint-js.  If not, see <https://www.gnu.org/licenses/>.

--- a/dist/webinstaller/make-webinstaller-manifest.js
+++ b/dist/webinstaller/make-webinstaller-manifest.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+
+const [, , ...args] = process.argv;
+const [baseUriArg, BaseURI, releaseDateArg, releaseDate, outputArg, outputFile] = args;
+
+function validateArg(args, argName, regex) {
+    const argIndex = args.indexOf(argName);
+    if (argIndex < 0) {
+      console.log(`error: missing ${argName}`);
+      return false;
+    }
+  
+    const argValue = args[argIndex + 1];
+    if (!regex.test(argValue)) {
+      console.log(`error: invalid ${argName}; must match regular expression: ${regex}`);
+      return false;
+    }
+  
+    return true;
+  }
+  
+  if (!validateArg(args, '-BaseURI', /^https?:\/\/.*\/$/)) {
+    return 0;
+  }
+  
+  if (!validateArg(args, '-releaseDate', /^\d{4}-\d{2}-\d{2}$/)) {
+    return 0;
+  }
+  
+
+//get the version
+const releasesRegex = /\/(\d+\.\d+\.\d+)\/$/;
+const releasesVersion = BaseURI.match(releasesRegex);
+
+const template = fs.readFileSync('quick-lint-js-template.json', 'utf8');
+
+const data = JSON.parse(template);
+
+// set version and insert download with the approriate value 
+for (const release of data.release) {
+    release.version = releasesVersion[1];
+    release.download = release.download.replace('${version}', releasesVersion[1]);
+    release.date = releaseDate;
+}
+
+// Write the modified data back to a file
+fs.writeFileSync(outputFile, JSON.stringify(data, null, 2), 'utf8');

--- a/dist/webinstaller/make-webinstaller-manifest.js
+++ b/dist/webinstaller/make-webinstaller-manifest.js
@@ -4,21 +4,37 @@
 const fs = require("fs");
 
 const args = process.argv.slice(2);
-const releaseVersion = process.argv[3];
-const releaseDate = process.argv[5];
-const outputFile = process.argv[7];
+let releaseVersion;
+let releaseDate;
+let outputFile;
 
-if (!args.includes("-releaseVersion")) {
+args.forEach((arg, index) => {
+  switch (arg) {
+    case "-releaseVersion":
+      releaseVersion = args[index + 1];
+      break;
+    case "-releaseDate":
+      releaseDate = args[index + 1];
+      break;
+    case "-Out":
+      outputFile = args[index + 1];
+      break;
+    default:
+      break;
+  }
+});
+
+if (!releaseVersion) {
   console.log("error: missing -releaseVersion");
-  return 0;
+  process.exit(1);
 }
-if (!args.includes("-releaseDate")) {
+if (!releaseDate) {
   console.log("error: missing -releaseDate");
-  return 0;
+  process.exit(1);
 }
-if (!args.includes("-Out")) {
-  console.log("error: missing -Out");
-  return 0;
+if (!outputFile) {
+  console.log("error: missing -outputFile");
+  process.exit(1);
 }
 
 const releaseVersionRegex = /^\d+\.\d+\.\d+$/;
@@ -27,7 +43,7 @@ if (!releaseVersionRegex.test(releaseVersion)) {
     "error: invalid -releaseVersion; must match regular expression: " +
       releaseVersionRegex
   );
-  return 0;
+  process.exit(1);
 }
 
 const releasesDateRegex = /^\d{4}-\d{2}-\d{2}$/;
@@ -36,11 +52,11 @@ if (!releasesDateRegex.test(releaseDate)) {
     "error: invalid -releaseDate; must match regular expression: " +
       releasesDateRegex
   );
-  return 0;
+  process.exit(1);
 }
 
 let data = fs.readFileSync("quick-lint-js-template.json", "utf8");
-data = data.replace(/{version}/g, releaseVersion);
+data = data.replace(/\${version}/g, releaseVersion);
 data = data.replace(/\${releaseDate}/g, releaseDate);
 fs.writeFileSync(outputFile, data, "utf8");
 

--- a/dist/webinstaller/quick-lint-js-template.json
+++ b/dist/webinstaller/quick-lint-js-template.json
@@ -1,103 +1,103 @@
 {
-  "release": [ 
-      {
+  "releases": [
+    {
       "name": "linux.tar.gz",
-      "version": "",
+      "version": "{version}",
       "lts": false,
       "channel": "stable",
-      "date": "",
+      "date": "${releaseDate}",
       "os": "linux",
       "arch": "",
       "ext": "tar.gz",
-      "download": "https://c.quick-lint-js.com/releases/${version}/manual/linux.tar.gz"
-      },
-       {
+      "download": "https://c.quick-lint-js.com/releases/{version}/manual/linux.tar.gz"
+    },
+    {
       "name": "linux-aarch64.tar.gz",
-      "version": "",
+      "version": "{version}",
       "lts": false,
       "channel": "stable",
-      "date": "",
+      "date": "${releaseDate}",
       "os": "linux",
       "arch": "aarch64",
       "ext": "tar.gz",
-      "download": "https://c.quick-lint-js.com/releases/${version}/manual/linux-aarch64.tar.gz"
-      },
-      {
+      "download": "https://c.quick-lint-js.com/releases/{version}/manual/linux-aarch64.tar.gz"
+    },
+    {
       "name": "linux-armhf.tar.gz",
-      "version": "",
+      "version": "{version}",
       "lts": false,
       "channel": "stable",
-      "date": "",
+      "date": "${releaseDate}",
       "os": "linux",
       "arch": "armhf",
       "ext": "tar.gz",
-      "download": "https://c.quick-lint-js.com/releases/${version}/manual/linux-armhf.tar.gz"
-      },
+      "download": "https://c.quick-lint-js.com/releases/{version}/manual/linux-armhf.tar.gz"
+    },
     {
       "name": "macos.tar.gz",
-      "version": "",
+      "version": "{version}",
       "lts": false,
       "channel": "stable",
-      "date": "",
+      "date": "${releaseDate}",
       "os": "macos",
       "arch": "",
       "ext": "tar.gz",
-      "download": "https://c.quick-lint-js.com/releases/${version}/manual/macos.tar.gz"
+      "download": "https://c.quick-lint-js.com/releases/{version}/manual/macos.tar.gz"
     },
     {
       "name": "macos-aarch64.tar.gz",
-      "version": "",
+      "version": "{version}",
       "lts": false,
       "channel": "stable",
-      "date": "",
+      "date": "${releaseDate}",
       "os": "macos",
       "arch": "aarch64",
       "ext": "tar.gz",
-      "download": "https://c.quick-lint-js.com/releases/${version}/manual/macos-aarch64.tar.gz"
+      "download": "https://c.quick-lint-js.com/releases/{version}/manual/macos-aarch64.tar.gz"
     },
     {
       "name": "windows.zip",
-      "version": "",
+      "version": "{version}",
       "lts": false,
       "channel": "stable",
-      "date": "",
+      "date": "${releaseDate}",
       "os": "windows",
       "arch": "",
       "ext": "zip",
-      "download": "https://c.quick-lint-js.com/releases/${version}/manual/windows.tar.gz"
+      "download": "https://c.quick-lint-js.com/releases/{version}/manual/windows.tar.gz"
     },
     {
       "name": "windows-arm.zip",
-      "version": "",
+      "version": "{version}",
       "lts": false,
       "channel": "stable",
-      "date": "",
+      "date": "${releaseDate}",
       "os": "windows",
       "arch": "arm",
       "ext": "zip",
-      "download": "https://c.quick-lint-js.com/releases/${version}/manual/windows-arm.zip"
-    },	
+      "download": "https://c.quick-lint-js.com/releases/{version}/manual/windows-arm.zip"
+    },
     {
       "name": "windows-arm64.zip",
-      "version": "",
+      "version": "{version}",
       "lts": false,
       "channel": "stable",
-      "date": "",
+      "date": "${releaseDate}",
       "os": "windows",
       "arch": "arm64",
       "ext": "zip",
-      "download": "https://c.quick-lint-js.com/releases/${version}/manual/windows-arm64.zip"
-    },	
+      "download": "https://c.quick-lint-js.com/releases/{version}/manual/windows-arm64.zip"
+    },
     {
       "name": "windows-x86.zip",
-      "version": "",
+      "version": "{version}",
       "lts": false,
       "channel": "stable",
-      "date": "",
+      "date": "${releaseDate}",
       "os": "windows",
       "arch": "x86",
       "ext": "zip",
-      "download": "https://c.quick-lint-js.com/releases/${version}/manual/windows-x86.zip"
+      "download": "https://c.quick-lint-js.com/releases/{version}/manual/windows-x86.zip"
     }
-]
+  ]
 }

--- a/dist/webinstaller/quick-lint-js-template.json
+++ b/dist/webinstaller/quick-lint-js-template.json
@@ -1,103 +1,75 @@
 {
   "releases": [
     {
-      "name": "linux.tar.gz",
-      "version": "${version}",
-      "lts": false,
-      "channel": "stable",
-      "date": "${releaseDate}",
-      "os": "linux",
-      "arch": "x86_64/amd64",
-      "ext": "tar.gz",
-      "download": "https://c.quick-lint-js.com/releases/${version}/manual/linux.tar.gz"
-    },
-    {
-      "name": "linux-aarch64.tar.gz",
-      "version": "${version}",
-      "lts": false,
-      "channel": "stable",
-      "date": "${releaseDate}",
-      "os": "linux",
-      "arch": "aarch64",
-      "ext": "tar.gz",
-      "download": "https://c.quick-lint-js.com/releases/${version}/manual/linux-aarch64.tar.gz"
-    },
-    {
-      "name": "linux-armhf.tar.gz",
-      "version": "${version}",
-      "lts": false,
-      "channel": "stable",
-      "date": "${releaseDate}",
-      "os": "linux",
-      "arch": "armhf",
-      "ext": "tar.gz",
-      "download": "https://c.quick-lint-js.com/releases/${version}/manual/linux-armhf.tar.gz"
-    },
-    {
-      "name": "macos.tar.gz",
-      "version": "${version}",
-      "lts": false,
-      "channel": "stable",
-      "date": "${releaseDate}",
-      "os": "macos",
-      "arch": "x86_64/amd64",
-      "ext": "tar.gz",
-      "download": "https://c.quick-lint-js.com/releases/${version}/manual/macos.tar.gz"
-    },
-    {
-      "name": "macos-aarch64.tar.gz",
-      "version": "${version}",
-      "lts": false,
-      "channel": "stable",
-      "date": "${releaseDate}",
-      "os": "macos",
-      "arch": "aarch64",
-      "ext": "tar.gz",
-      "download": "https://c.quick-lint-js.com/releases/${version}/manual/macos-aarch64.tar.gz"
-    },
-    {
-      "name": "windows.zip",
-      "version": "${version}",
-      "lts": false,
-      "channel": "stable",
-      "date": "${releaseDate}",
-      "os": "windows",
-      "arch": "x86_64/amd64",
-      "ext": "zip",
-      "download": "https://c.quick-lint-js.com/releases/${version}/manual/windows.tar.gz"
-    },
-    {
-      "name": "windows-arm.zip",
-      "version": "${version}",
-      "lts": false,
-      "channel": "stable",
-      "date": "${releaseDate}",
-      "os": "windows",
-      "arch": "arm",
-      "ext": "zip",
-      "download": "https://c.quick-lint-js.com/releases/${version}/manual/windows-arm.zip"
-    },
-    {
-      "name": "windows-arm64.zip",
-      "version": "${version}",
-      "lts": false,
-      "channel": "stable",
-      "date": "${releaseDate}",
-      "os": "windows",
-      "arch": "arm64",
-      "ext": "zip",
-      "download": "https://c.quick-lint-js.com/releases/${version}/manual/windows-arm64.zip"
-    },
-    {
-      "name": "windows-x86.zip",
-      "version": "${version}",
-      "lts": false,
-      "channel": "stable",
-      "date": "${releaseDate}",
-      "os": "windows",
-      "arch": "x86",
-      "ext": "zip",
-      "download": "https://c.quick-lint-js.com/releases/${version}/manual/windows-x86.zip"
+      "name": "linux.tar.gz", "version": "${version}", "lts":
+      false, "channel": "stable", "date": "${releaseDate}",
+      "os": "linux", "arch": "x86", "ext": "tar.gz", "download":
+      "https://c.quick-lint-js.com/releases/${version}/manual/linux.tar.gz"
+    },    {
+      "name": "linux.tar.gz", "version": "${version}", "lts":
+      false, "channel": "stable", "date": "${releaseDate}",
+      "os": "linux", "arch": "x64", "ext": "tar.gz", "download":
+      "https://c.quick-lint-js.com/releases/${version}/manual/linux.tar.gz"
+    },    {
+      "name": "linux.tar.gz", "version": "${version}", "lts":
+      false, "channel": "stable", "date": "${releaseDate}", "os":
+      "linux", "arch": "amd64", "ext": "tar.gz", "download":
+      "https://c.quick-lint-js.com/releases/${version}/manual/linux.tar.gz"
+    }, {
+      "name": "linux-aarch64.tar.gz", "version": "${version}",
+      "lts": false, "channel": "stable", "date": "${releaseDate}",
+      "os": "linux", "arch": "aarch64", "ext": "tar.gz", "download":
+      "https://c.quick-lint-js.com/releases/${version}/manual/linux-aarch64.tar.gz"
+    }, {
+      "name": "linux-armhf.tar.gz", "version": "${version}",
+      "lts": false, "channel": "stable", "date": "${releaseDate}",
+      "os": "linux", "arch": "armhf", "ext": "tar.gz", "download":
+      "https://c.quick-lint-js.com/releases/${version}/manual/linux-armhf.tar.gz"
+    }, {
+      "name": "macos.tar.gz", "version": "${version}", "lts":
+      false, "channel": "stable", "date": "${releaseDate}",
+      "os": "macos", "arch": "x86", "ext": "tar.gz", "download":
+      "https://c.quick-lint-js.com/releases/${version}/manual/macos.tar.gz"
+    },    {
+      "name": "macos.tar.gz", "version": "${version}", "lts":
+      false, "channel": "stable", "date": "${releaseDate}",
+      "os": "macos", "arch": "x64", "ext": "tar.gz", "download":
+      "https://c.quick-lint-js.com/releases/${version}/manual/macos.tar.gz"
+    },    {
+      "name": "macos.tar.gz", "version": "${version}", "lts":
+      false, "channel": "stable", "date": "${releaseDate}", "os":
+      "macos", "arch": "amd64", "ext": "tar.gz", "download":
+      "https://c.quick-lint-js.com/releases/${version}/manual/macos.tar.gz"
+    }, {
+      "name": "macos-aarch64.tar.gz", "version": "${version}",
+      "lts": false, "channel": "stable", "date": "${releaseDate}",
+      "os": "macos", "arch": "aarch64", "ext": "tar.gz", "download":
+      "https://c.quick-lint-js.com/releases/${version}/manual/macos-aarch64.tar.gz"
+    }, {
+      "name": "windows.zip", "version": "${version}", "lts":
+      false, "channel": "stable", "date": "${releaseDate}",
+      "os": "windows", "arch": "x64", "ext": "zip", "download":
+      "https://c.quick-lint-js.com/releases/${version}/manual/windows.tar.gz"
+    },    {
+      "name": "windows.zip", "version": "${version}", "lts":
+      false, "channel": "stable", "date": "${releaseDate}",
+      "os": "windows", "arch": "amd64", "ext": "zip", "download":
+      "https://c.quick-lint-js.com/releases/${version}/manual/windows.tar.gz"
+    }, {
+      "name": "windows-arm.zip", "version": "${version}", "lts":
+      false, "channel": "stable", "date": "${releaseDate}",
+      "os": "windows", "arch": "arm", "ext": "zip", "download":
+      "https://c.quick-lint-js.com/releases/${version}/manual/windows-arm.zip"
+    }, {
+      "name": "windows-arm64.zip", "version": "${version}",
+      "lts": false, "channel": "stable", "date": "${releaseDate}",
+      "os": "windows", "arch": "arm64", "ext": "zip", "download":
+      "https://c.quick-lint-js.com/releases/${version}/manual/windows-arm64.zip"
+    }, {
+      "name": "windows-x86.zip", "version": "${version}", "lts":
+      false, "channel": "stable", "date": "${releaseDate}",
+      "os": "windows", "arch": "x86", "ext": "zip", "download":
+      "https://c.quick-lint-js.com/releases/${version}/manual/windows-x86.zip"
     }
   ]
 }

--- a/dist/webinstaller/quick-lint-js-template.json
+++ b/dist/webinstaller/quick-lint-js-template.json
@@ -2,102 +2,102 @@
   "releases": [
     {
       "name": "linux.tar.gz",
-      "version": "{version}",
+      "version": "${version}",
       "lts": false,
       "channel": "stable",
       "date": "${releaseDate}",
       "os": "linux",
       "arch": "",
       "ext": "tar.gz",
-      "download": "https://c.quick-lint-js.com/releases/{version}/manual/linux.tar.gz"
+      "download": "https://c.quick-lint-js.com/releases/${version}/manual/linux.tar.gz"
     },
     {
       "name": "linux-aarch64.tar.gz",
-      "version": "{version}",
+      "version": "${version}",
       "lts": false,
       "channel": "stable",
       "date": "${releaseDate}",
       "os": "linux",
       "arch": "aarch64",
       "ext": "tar.gz",
-      "download": "https://c.quick-lint-js.com/releases/{version}/manual/linux-aarch64.tar.gz"
+      "download": "https://c.quick-lint-js.com/releases/${version}/manual/linux-aarch64.tar.gz"
     },
     {
       "name": "linux-armhf.tar.gz",
-      "version": "{version}",
+      "version": "${version}",
       "lts": false,
       "channel": "stable",
       "date": "${releaseDate}",
       "os": "linux",
       "arch": "armhf",
       "ext": "tar.gz",
-      "download": "https://c.quick-lint-js.com/releases/{version}/manual/linux-armhf.tar.gz"
+      "download": "https://c.quick-lint-js.com/releases/${version}/manual/linux-armhf.tar.gz"
     },
     {
       "name": "macos.tar.gz",
-      "version": "{version}",
+      "version": "${version}",
       "lts": false,
       "channel": "stable",
       "date": "${releaseDate}",
       "os": "macos",
       "arch": "",
       "ext": "tar.gz",
-      "download": "https://c.quick-lint-js.com/releases/{version}/manual/macos.tar.gz"
+      "download": "https://c.quick-lint-js.com/releases/${version}/manual/macos.tar.gz"
     },
     {
       "name": "macos-aarch64.tar.gz",
-      "version": "{version}",
+      "version": "${version}",
       "lts": false,
       "channel": "stable",
       "date": "${releaseDate}",
       "os": "macos",
       "arch": "aarch64",
       "ext": "tar.gz",
-      "download": "https://c.quick-lint-js.com/releases/{version}/manual/macos-aarch64.tar.gz"
+      "download": "https://c.quick-lint-js.com/releases/${version}/manual/macos-aarch64.tar.gz"
     },
     {
       "name": "windows.zip",
-      "version": "{version}",
+      "version": "${version}",
       "lts": false,
       "channel": "stable",
       "date": "${releaseDate}",
       "os": "windows",
       "arch": "",
       "ext": "zip",
-      "download": "https://c.quick-lint-js.com/releases/{version}/manual/windows.tar.gz"
+      "download": "https://c.quick-lint-js.com/releases/${version}/manual/windows.tar.gz"
     },
     {
       "name": "windows-arm.zip",
-      "version": "{version}",
+      "version": "${version}",
       "lts": false,
       "channel": "stable",
       "date": "${releaseDate}",
       "os": "windows",
       "arch": "arm",
       "ext": "zip",
-      "download": "https://c.quick-lint-js.com/releases/{version}/manual/windows-arm.zip"
+      "download": "https://c.quick-lint-js.com/releases/${version}/manual/windows-arm.zip"
     },
     {
       "name": "windows-arm64.zip",
-      "version": "{version}",
+      "version": "${version}",
       "lts": false,
       "channel": "stable",
       "date": "${releaseDate}",
       "os": "windows",
       "arch": "arm64",
       "ext": "zip",
-      "download": "https://c.quick-lint-js.com/releases/{version}/manual/windows-arm64.zip"
+      "download": "https://c.quick-lint-js.com/releases/${version}/manual/windows-arm64.zip"
     },
     {
       "name": "windows-x86.zip",
-      "version": "{version}",
+      "version": "${version}",
       "lts": false,
       "channel": "stable",
       "date": "${releaseDate}",
       "os": "windows",
       "arch": "x86",
       "ext": "zip",
-      "download": "https://c.quick-lint-js.com/releases/{version}/manual/windows-x86.zip"
+      "download": "https://c.quick-lint-js.com/releases/${version}/manual/windows-x86.zip"
     }
   ]
 }

--- a/dist/webinstaller/quick-lint-js-template.json
+++ b/dist/webinstaller/quick-lint-js-template.json
@@ -1,0 +1,103 @@
+{
+  "release": [ 
+      {
+      "name": "linux.tar.gz",
+      "version": "",
+      "lts": false,
+      "channel": "stable",
+      "date": "",
+      "os": "linux",
+      "arch": "",
+      "ext": "tar.gz",
+      "download": "https://c.quick-lint-js.com/releases/${version}/manual/linux.tar.gz"
+      },
+       {
+      "name": "linux-aarch64.tar.gz",
+      "version": "",
+      "lts": false,
+      "channel": "stable",
+      "date": "",
+      "os": "linux",
+      "arch": "aarch64",
+      "ext": "tar.gz",
+      "download": "https://c.quick-lint-js.com/releases/${version}/manual/linux-aarch64.tar.gz"
+      },
+      {
+      "name": "linux-armhf.tar.gz",
+      "version": "",
+      "lts": false,
+      "channel": "stable",
+      "date": "",
+      "os": "linux",
+      "arch": "armhf",
+      "ext": "tar.gz",
+      "download": "https://c.quick-lint-js.com/releases/${version}/manual/linux-armhf.tar.gz"
+      },
+    {
+      "name": "macos.tar.gz",
+      "version": "",
+      "lts": false,
+      "channel": "stable",
+      "date": "",
+      "os": "macos",
+      "arch": "",
+      "ext": "tar.gz",
+      "download": "https://c.quick-lint-js.com/releases/${version}/manual/macos.tar.gz"
+    },
+    {
+      "name": "macos-aarch64.tar.gz",
+      "version": "",
+      "lts": false,
+      "channel": "stable",
+      "date": "",
+      "os": "macos",
+      "arch": "aarch64",
+      "ext": "tar.gz",
+      "download": "https://c.quick-lint-js.com/releases/${version}/manual/macos-aarch64.tar.gz"
+    },
+    {
+      "name": "windows.zip",
+      "version": "",
+      "lts": false,
+      "channel": "stable",
+      "date": "",
+      "os": "windows",
+      "arch": "",
+      "ext": "zip",
+      "download": "https://c.quick-lint-js.com/releases/${version}/manual/windows.tar.gz"
+    },
+    {
+      "name": "windows-arm.zip",
+      "version": "",
+      "lts": false,
+      "channel": "stable",
+      "date": "",
+      "os": "windows",
+      "arch": "arm",
+      "ext": "zip",
+      "download": "https://c.quick-lint-js.com/releases/${version}/manual/windows-arm.zip"
+    },	
+    {
+      "name": "windows-arm64.zip",
+      "version": "",
+      "lts": false,
+      "channel": "stable",
+      "date": "",
+      "os": "windows",
+      "arch": "arm64",
+      "ext": "zip",
+      "download": "https://c.quick-lint-js.com/releases/${version}/manual/windows-arm64.zip"
+    },	
+    {
+      "name": "windows-x86.zip",
+      "version": "",
+      "lts": false,
+      "channel": "stable",
+      "date": "",
+      "os": "windows",
+      "arch": "x86",
+      "ext": "zip",
+      "download": "https://c.quick-lint-js.com/releases/${version}/manual/windows-x86.zip"
+    }
+]
+}

--- a/dist/webinstaller/quick-lint-js-template.json
+++ b/dist/webinstaller/quick-lint-js-template.json
@@ -7,7 +7,7 @@
       "channel": "stable",
       "date": "${releaseDate}",
       "os": "linux",
-      "arch": "",
+      "arch": "x86_64/amd64",
       "ext": "tar.gz",
       "download": "https://c.quick-lint-js.com/releases/${version}/manual/linux.tar.gz"
     },
@@ -40,7 +40,7 @@
       "channel": "stable",
       "date": "${releaseDate}",
       "os": "macos",
-      "arch": "",
+      "arch": "x86_64/amd64",
       "ext": "tar.gz",
       "download": "https://c.quick-lint-js.com/releases/${version}/manual/macos.tar.gz"
     },
@@ -62,7 +62,7 @@
       "channel": "stable",
       "date": "${releaseDate}",
       "os": "windows",
-      "arch": "",
+      "arch": "x86_64/amd64",
       "ext": "zip",
       "download": "https://c.quick-lint-js.com/releases/${version}/manual/windows.tar.gz"
     },

--- a/dist/webinstaller/quick-lint-js-template.json
+++ b/dist/webinstaller/quick-lint-js-template.json
@@ -1,75 +1,103 @@
 {
   "releases": [
     {
-      "name": "linux.tar.gz", "version": "${version}", "lts":
-      false, "channel": "stable", "date": "${releaseDate}",
-      "os": "linux", "arch": "x86", "ext": "tar.gz", "download":
-      "https://c.quick-lint-js.com/releases/${version}/manual/linux.tar.gz"
-    },    {
-      "name": "linux.tar.gz", "version": "${version}", "lts":
-      false, "channel": "stable", "date": "${releaseDate}",
-      "os": "linux", "arch": "x64", "ext": "tar.gz", "download":
-      "https://c.quick-lint-js.com/releases/${version}/manual/linux.tar.gz"
-    },    {
-      "name": "linux.tar.gz", "version": "${version}", "lts":
-      false, "channel": "stable", "date": "${releaseDate}", "os":
-      "linux", "arch": "amd64", "ext": "tar.gz", "download":
-      "https://c.quick-lint-js.com/releases/${version}/manual/linux.tar.gz"
-    }, {
-      "name": "linux-aarch64.tar.gz", "version": "${version}",
-      "lts": false, "channel": "stable", "date": "${releaseDate}",
-      "os": "linux", "arch": "aarch64", "ext": "tar.gz", "download":
-      "https://c.quick-lint-js.com/releases/${version}/manual/linux-aarch64.tar.gz"
-    }, {
-      "name": "linux-armhf.tar.gz", "version": "${version}",
-      "lts": false, "channel": "stable", "date": "${releaseDate}",
-      "os": "linux", "arch": "armhf", "ext": "tar.gz", "download":
-      "https://c.quick-lint-js.com/releases/${version}/manual/linux-armhf.tar.gz"
-    }, {
-      "name": "macos.tar.gz", "version": "${version}", "lts":
-      false, "channel": "stable", "date": "${releaseDate}",
-      "os": "macos", "arch": "x86", "ext": "tar.gz", "download":
-      "https://c.quick-lint-js.com/releases/${version}/manual/macos.tar.gz"
-    },    {
-      "name": "macos.tar.gz", "version": "${version}", "lts":
-      false, "channel": "stable", "date": "${releaseDate}",
-      "os": "macos", "arch": "x64", "ext": "tar.gz", "download":
-      "https://c.quick-lint-js.com/releases/${version}/manual/macos.tar.gz"
-    },    {
-      "name": "macos.tar.gz", "version": "${version}", "lts":
-      false, "channel": "stable", "date": "${releaseDate}", "os":
-      "macos", "arch": "amd64", "ext": "tar.gz", "download":
-      "https://c.quick-lint-js.com/releases/${version}/manual/macos.tar.gz"
-    }, {
-      "name": "macos-aarch64.tar.gz", "version": "${version}",
-      "lts": false, "channel": "stable", "date": "${releaseDate}",
-      "os": "macos", "arch": "aarch64", "ext": "tar.gz", "download":
-      "https://c.quick-lint-js.com/releases/${version}/manual/macos-aarch64.tar.gz"
-    }, {
-      "name": "windows.zip", "version": "${version}", "lts":
-      false, "channel": "stable", "date": "${releaseDate}",
-      "os": "windows", "arch": "x64", "ext": "zip", "download":
-      "https://c.quick-lint-js.com/releases/${version}/manual/windows.tar.gz"
-    },    {
-      "name": "windows.zip", "version": "${version}", "lts":
-      false, "channel": "stable", "date": "${releaseDate}",
-      "os": "windows", "arch": "amd64", "ext": "zip", "download":
-      "https://c.quick-lint-js.com/releases/${version}/manual/windows.tar.gz"
-    }, {
-      "name": "windows-arm.zip", "version": "${version}", "lts":
-      false, "channel": "stable", "date": "${releaseDate}",
-      "os": "windows", "arch": "arm", "ext": "zip", "download":
-      "https://c.quick-lint-js.com/releases/${version}/manual/windows-arm.zip"
-    }, {
-      "name": "windows-arm64.zip", "version": "${version}",
-      "lts": false, "channel": "stable", "date": "${releaseDate}",
-      "os": "windows", "arch": "arm64", "ext": "zip", "download":
-      "https://c.quick-lint-js.com/releases/${version}/manual/windows-arm64.zip"
-    }, {
-      "name": "windows-x86.zip", "version": "${version}", "lts":
-      false, "channel": "stable", "date": "${releaseDate}",
-      "os": "windows", "arch": "x86", "ext": "zip", "download":
-      "https://c.quick-lint-js.com/releases/${version}/manual/windows-x86.zip"
+      "name": "linux.tar.gz",
+      "version": "${version}",
+      "lts": false,
+      "channel": "stable",
+      "date": "${releaseDate}",
+      "os": "linux",
+      "arch": "amd64",
+      "ext": "tar",
+      "download": "https://c.quick-lint-js.com/releases/${version}/manual/linux.tar.gz"
+    },
+    {
+      "name": "linux-aarch64.tar.gz",
+      "version": "${version}",
+      "lts": false,
+      "channel": "stable",
+      "date": "${releaseDate}",
+      "os": "linux",
+      "arch": "arm64",
+      "ext": "tar",
+      "download": "https://c.quick-lint-js.com/releases/${version}/manual/linux-aarch64.tar.gz"
+    },
+    {
+      "name": "linux-armhf.tar.gz",
+      "version": "${version}",
+      "lts": false,
+      "channel": "stable",
+      "date": "${releaseDate}",
+      "os": "linux",
+      "arch": "armv7l",
+      "ext": "tar",
+      "download": "https://c.quick-lint-js.com/releases/${version}/manual/linux-armhf.tar.gz"
+    },
+    {
+      "name": "macos.tar.gz",
+      "version": "${version}",
+      "lts": false,
+      "channel": "stable",
+      "date": "${releaseDate}",
+      "os": "macos",
+      "arch": "amd64",
+      "ext": "tar",
+      "download": "https://c.quick-lint-js.com/releases/${version}/manual/macos.tar.gz"
+    },
+    {
+      "name": "macos-aarch64.tar.gz",
+      "version": "${version}",
+      "lts": false,
+      "channel": "stable",
+      "date": "${releaseDate}",
+      "os": "macos",
+      "arch": "arm64",
+      "ext": "tar",
+      "download": "https://c.quick-lint-js.com/releases/${version}/manual/macos-aarch64.tar.gz"
+    },
+    {
+      "name": "windows.zip",
+      "version": "${version}",
+      "lts": false,
+      "channel": "stable",
+      "date": "${releaseDate}",
+      "os": "windows",
+      "arch": "amd64",
+      "ext": "zip",
+      "download": "https://c.quick-lint-js.com/releases/${version}/manual/windows.zip"
+    },
+    {
+      "name": "windows-arm.zip",
+      "version": "${version}",
+      "lts": false,
+      "channel": "stable",
+      "date": "${releaseDate}",
+      "os": "windows",
+      "arch": "armv7l",
+      "ext": "zip",
+      "download": "https://c.quick-lint-js.com/releases/${version}/manual/windows-arm.zip"
+    },
+    {
+      "name": "windows-arm64.zip",
+      "version": "${version}",
+      "lts": false,
+      "channel": "stable",
+      "date": "${releaseDate}",
+      "os": "windows",
+      "arch": "arm64",
+      "ext": "zip",
+      "download": "https://c.quick-lint-js.com/releases/${version}/manual/windows-arm64.zip"
+    },
+    {
+      "name": "windows-x86.zip",
+      "version": "${version}",
+      "lts": false,
+      "channel": "stable",
+      "date": "${releaseDate}",
+      "os": "windows",
+      "arch": "x86",
+      "ext": "zip",
+      "download": "https://c.quick-lint-js.com/releases/${version}/manual/windows-x86.zip"
     }
   ]
 }


### PR DESCRIPTION
In order to add quick-lint-js to webi, we need a file called releases.js that needs a bunch of informations about each QLJS release.
the > make-webinstaller-manifest.js
create a json file that contains all the informations releases.js will need based on quick-lint-js-template.json.
this version of the script is better than the one I showed you in stream, this version takes in arguments, checks if they are valid and display an error message as appropriate.