### PR TITLE
Update Shell completion

### DIFF
--- a/completions/_quick-lint-js
+++ b/completions/_quick-lint-js
@@ -14,16 +14,19 @@ function _quick-lint-js() {
         local -a args
 
         args+=(
-        '(- *)'--help'[Print help message]'
-        '(- *)'--version'[Print version information]'
+        '(- *)'--help'[Print a help message and exit]'
+        '(- *)'--version'[Print version information and exit]'
         '(--lsp-server)*:file:_files'
-        '(--config-file --stdin --exit-fail-on --diagnostic-hyperlinks --output-format *)'--lsp-server'[Run quick-lint-js in LSP server mode]'
+        '(--config-file --stdin --exit-fail-on --diagnostic-hyperlinks --output-format --path-for-config-search --language *)'--lsp-server'[Run quick-lint-js in LSP server mode]'
         '(--lsp-server)--config-file=[Read configuration from a JSON file for later input files]:file:_files'
         '(--lsp-server)--stdin[Read standard input as a JavaScript file]'
         '(--lsp-server)--exit-fail-on=[Fail with a non-zero exit code if any of these errors are found (default\: "all")]'
         '(--lsp-server)--output-format=[Format to print feedback]:format:((vim-qflist-json\:"machine-readable JSON which can be given to Vim'\''s setqflist function" gnu-like\:"a human-readable format similar to GCC" emacs-lisp\:"Emacs Lisp association list format"))'
         '(--lsp-server)--diagnostic-hyperlinks=[Control whether to hyperlink error codes or not]:when:((auto\:"shows error codes as hyperlinks only if the error output is a terminal" always\:"always shows error codes as hyperlinks" never\:"never shows error codes as hyperlinks"))'
+        '(--lsp-server)--path-for-config-search=[Use path as the file\’s path when searching for a configuration file]:file:_path_files'
+        '(--lsp-server)--language=[Interpret input files which are given later in the command line]:when:((default\:"infer the languageid from the file’s extension" javascript\:"the latest ECMAScript standard with proposed features" javascript-jsx\:"like javascript but with JSX (React) extensions" experimental-typescript\:"the latest TypeScript version. (EXPERIMENTAL)" experimental-typescript-jsx\:"like experimental-typescript but with JSX (React) extensions. (EXPERIMENTAL)"))'
         '--snarky[Add spice to your failures]'
+        '--debug-apps[Print a list of running quick-lint-js instances which have the debug app enabled]'
         '--vim-file-bufnr=[Select a vim buffer for outputting feedback]')
 
         _arguments -M "r:|[_]=* r:|=*" -S "${args[@]}" && ret=0

--- a/completions/quick-lint-js.bash
+++ b/completions/quick-lint-js.bash
@@ -1,11 +1,15 @@
 # Copyright (C) 2020  Matthew "strager" Glazar
 # See end of file for extended copyright information.
 
+_quick_lint_js_output_formats="gnu-like vim-qflist-json emacs-lisp"
+_quick_lint_js_diagnostic_hyperlink_modes="auto always never"
+_quick_lint_js_languages="default javascript javascript-jsx experimental-typescript experimental-typescript-jsx"
+
 _quick-lint-js () {
         local cur opts
         _init_completion -n = || return
 
-        opts='--help --version --lsp-server --config-file= --stdin --exit-fail-on= --output-format= --diagnostic-hyperlinks= --vim-file-bufnr='
+        opts="--help --version --lsp-server --config-file= --stdin --exit-fail-on= --output-format= --diagnostic-hyperlinks= --vim-file-bufnr= --language= --path-for-config-search= --snarky --debug-apps"
 
         case $cur in
                 --config-file=*)
@@ -14,20 +18,30 @@ _quick-lint-js () {
                         return
                         ;;
                 --output-format=*)
-                        COMPREPLY=($(compgen -W 'gnu-like vim-qflist-json emacs-lisp' -- "${cur#*=}"))
+                        COMPREPLY=($(compgen -W "${_quick_lint_js_output_formats}" -- "${cur#*=}"))
                         return
                         ;;
                 --diagnostic-hyperlinks=*)
-                        COMPREPLY=($(compgen -W 'auto always never' -- "${cur#*=}"))
+                        COMPREPLY=($(compgen -W "${_quick_lint_js_diagnostic_hyperlink_modes}" -- "${cur#*=}"))
                         return
                         ;;
                 --exit-fail-on=*|--vim-file-bufnr=*)
                         return
                         ;;
+                --path-for-config-search=*)
+                        _split_longopt
+                        _filedir
+                        return
+                        ;;
+                
+                --language=*)
+                        COMPREPLY=($(compgen -W "${_quick_lint_js_languages}" -- "${cur#*=}"))
+                        return
+                        ;;
         esac
 
         if [[ $cur == -* ]]; then
-                COMPREPLY=($(compgen -W '${opts}' -- $cur))
+                COMPREPLY=($(compgen -W "${opts}" -- $cur))
                 [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
                 return
         else

--- a/completions/quick-lint-js.fish
+++ b/completions/quick-lint-js.fish
@@ -7,10 +7,13 @@ complete -c quick-lint-js -l lsp-server -d 'Run quick-lint-js in LSP server mode
 complete -c quick-lint-js -l config-file -d 'Read configuration from a JSON file for later input files' -r
 complete -c quick-lint-js -l stdin -d 'Read standard input as a JavaScript file' -r
 complete -c quick-lint-js -l exit-fail-on -d 'Fail with a non-zero exit code if any of these errors are found (default: "all")' -r
-complete -c quick-lint-js -l output-format -d 'Format to print feedback' -xa 'gnu-like\t"(default) a human-readable format similar to GCC" vim-qflist-json\t"machine-readable JSON which can be given to Vim\'s setqflist function" emacs-lisp\t"Emacs Lisp association list format"'
+complete -c quick-lint-js -l output-format -d 'Customize how errors are printed' -xa 'gnu-like\t"(default) a human-readable format similar to GCC" vim-qflist-json\t"machine-readable JSON which can be given to Vim\'s setqflist function" emacs-lisp\t"Emacs Lisp association list format"'
 complete -c quick-lint-js -l diagnostic-hyperlinks -d 'Control whether to hyperlink error codes or not' -xa 'auto\t"(default) shows error codes as hyperlinks only if the error output is a terminal" always\t"always shows error codes as hyperlinks" never\t"never shows error codes as hyperlinks"'
 complete -c quick-lint-js -l snarky -d 'Add spice to your failures' -r
 complete -c quick-lint-js -l vim-file-bufnr -d 'Select a vim buffer for outputting feedback' -r
+complete -c quick-lint-js -l path-for-config-search -d 'For the following input file or --stdin, use path as the file’s path' -r
+complete -c quick-lint-js -l language -d 'Customize how errors are printed' -xa 'default\t"(default) infer the languageid from the file’s extension" javascript\t"the latest ECMAScript standard with proposed features" javascript-jsx\t"like javascript but with JSX (React) extensions" experimental-typescript\t"the latest TypeScript version (EXPERIMENTAL. Subject to change in future versions of quick-lint-js)" experimental-typescript-jsx\t"like experimental-typescript but with JSX (React) extensions (EXPERIMENTAL. Subject to change in future versions of quick-lint-js)"' -r
+complete -c quick-lint-js -l debug-apps -d 'Print a list of running quick-lint-js instances which have the debug app enabled' -r
 
 # quick-lint-js finds bugs in JavaScript programs.
 # Copyright (C) 2020  Matthew "strager" Glazar

--- a/completions/quick-lint-js.ps1
+++ b/completions/quick-lint-js.ps1
@@ -7,11 +7,11 @@
     $Options = @(
         @{
             CompletionText = '--help'
-            ToolTip = 'Print help message'
+            ToolTip = 'Print a help message and exit'
         },
         @{
             CompletionText = '--version'
-            ToolTip = 'Print version information'
+            ToolTip = 'Print version information and exit'
         },
         @{
             CompletionText = '--lsp-server'
@@ -19,7 +19,7 @@
         },
         @{
             CompletionText = '--config-file='
-            ToolTip = 'Read configuration from a JSON file for later input files'
+            ToolTip = 'Read configuration options from file and apply them to input files which are given later in the command line'
         },
         @{
             CompletionText = '--stdin'
@@ -31,7 +31,7 @@
         },
         @{
             CompletionText = '--output-format='
-            ToolTip = "Format to print feedback format`n`nvim-qflist-json: machine-readable JSON which can be given to Vim's setqflist function`ngnu-like: a human-readable format similar to GCC`nemacs-lisp: Emacs Lisp association list format"
+            ToolTip = "Customize how errors are printed`n`nvim-qflist-json: machine-readable JSON which can be given to Vim's setqflist function`ngnu-like: a human-readable format similar to GCC`nemacs-lisp: Emacs Lisp association list format"
         },
         @{
             CompletionText = '--diagnostic-hyperlinks='
@@ -44,7 +44,20 @@
         @{
             CompletionText = '--vim-file-bufnr='
             ToolTip = 'Select a vim buffer for outputting feedback'
+        },
+        @{
+            CompletionText = '--path-for-config-search'
+            ToolTip = "For the input file or --stdin, use path as the file's path"
+        },
+        @{
+            CompletionText = '--language'
+            ToolTip = "Interpret input files which are given later in the command line as if they were written in languageid`n`ndefault: infer the languageid from the file’s extension`njavascript: the latest ECMAScript standard with proposed features`njavascript-jsx: like javascript but with JSX (React) extensions`nexperimental-typescript: the latest TypeScript version. (EXPERIMENTAL. Subject to change in future versions of quick-lint-js.)`nexperimental-typescript-jsx: like experimental-typescript but with JSX (React) extensions. (EXPERIMENTAL. Subject to change in future versions of quick-lint-js.)"
+        },
+        @{
+            CompletionText = '--debug-apps'
+            ToolTip = 'Print a list of running quick-lint-js instances which have the debug app enabled'
         }
+
     )
 
     $Options.Where({$_.CompletionText -like "$wordToComplete*"}) | ForEach-Object {


### PR DESCRIPTION
Fixes: #918 

The list of options [[ref](https://quick-lint-js.com/cli/#_options)]:

`*` means (helper text may need to change)

**zsh:**
- [x] --output-format=format *
- [x] --diagnostic-hyperlinks=when
- [x] --vim-file-bufnr=number *
- [x] --path-for-config-search=path (new)
- [x] --config-file=file
- [x] --language=languageid (new)
- [x] --exit-fail-on=errors *
- [x] --stdin
- [x] --lsp / --lsp-server
- [x] --snarky
- [x] -h / --help *
- [x] --debug-apps (new)
- [x] -v / --version *

**bash:**
- [x] --output-format=format
- [x] --diagnostic-hyperlinks=when
- [x] --vim-file-bufnr=number
- [x] --path-for-config-search=path (new)
- [x] --config-file=file
- [x] --language=languageid (new)
- [x] --exit-fail-on=errors
- [x] --stdin
- [x] --lsp / --lsp-server
- [x] --snarky (new)
- [x] -h / --help
- [x] --debug-apps (new)
- [x] -v / --version

**fish:**
- [x] --output-format=format
- [x] --diagnostic-hyperlinks=when
- [x] --vim-file-bufnr=number
- [x] --path-for-config-search=path (new)
- [x] --config-file=file
- [x] --language=languageid (new)
- [x] --exit-fail-on=errors
- [x] --stdin
- [x] --lsp / --lsp-server
- [x] --snarky
- [x] -h / --help
- [x] --debug-apps (new)
- [x] -v / --version

powershell:
- [x] --output-format=format *
- [x] --diagnostic-hyperlinks=when
- [x] --vim-file-bufnr=number
- [x] --path-for-config-search=path (new)
- [x] --config-file=file
- [x] --language=languageid (new)
- [x] --exit-fail-on=errors
- [x] --stdin
- [x] --lsp / --lsp-server
- [x] --snarky
- [x] -h / --help *
- [x] --debug-apps (new)
- [x] -v / --version *