### PR TITLE
fix(website): mobile blog page updates #617

### DIFF
--- a/website/public/main.css
+++ b/website/public/main.css
@@ -763,6 +763,19 @@ kbd.keystroke {
   #editors-support img {
     padding-bottom: 1rem;
   }
+
+  .eslint-comparison {
+    border-bottom: solid 1px #aaaa;
+    grid-template-areas: "eslint" "qljs";
+    grid-template-columns: 100%;
+    grid-gap: 0;
+    padding-bottom: 1rem;
+    margin-bottom: 2rem;
+  }
+
+  .eslint-comparison figure {
+    margin-bottom: 0;
+  }
 }
 
 @media only screen and (max-width: 37em) {


### PR DESCRIPTION
Updated blog page for mobile displays, eslint/quick-lint-js comparisons are now displayed beneath each other for displays up to 43 rem.
Added separators between comparisons on mobile view.

#617

Light mode:

![obraz](https://user-images.githubusercontent.com/67511510/233124960-13e21c60-4301-45ac-a015-71ef5aa6ad6a.png)

Dark mode:

![obraz](https://user-images.githubusercontent.com/67511510/233125015-4d89da16-0808-45e7-a2d1-0815a4da641c.png)
