### PR TITLE
fix(fp): improve diagnostics for type annotations in arrow function

### DIFF
--- a/src/quick-lint-js/fe/parse-expression.cpp
+++ b/src/quick-lint-js/fe/parse-expression.cpp
@@ -505,6 +505,7 @@ expression* parser::parse_primary_expression(parse_visitor_base& v,
     // (x + y * z)
     expression* child = this->parse_expression(
         v, precedence{
+               .colon_type_annotation = allow_type_annotations::always,
                .trailing_identifiers = true,
                .colon_question_is_typescript_optional_with_type_annotation =
                    this->options_.typescript,

--- a/test/test-parse-typescript-function.cpp
+++ b/test/test-parse-typescript-function.cpp
@@ -282,6 +282,23 @@ TEST_F(test_parse_typescript_function,
 }
 
 TEST_F(test_parse_typescript_function,
+       arrow_with_parameter_type_annotation_is_disallowed_in_javascript) {
+  {
+    test_parser p(u8"(p: T) => {}"_sv, capture_diags);
+    p.parse_and_visit_statement();
+    EXPECT_THAT(p.variable_uses, ElementsAreArray({u8"T"}));
+    EXPECT_THAT(
+        p.errors,
+        ElementsAreArray({
+            DIAG_TYPE_OFFSETS(
+                p.code,
+                diag_typescript_type_annotations_not_allowed_in_javascript,  //
+                type_colon, strlen(u8"(p"), u8":"_sv),
+        }));
+  }
+}
+
+TEST_F(test_parse_typescript_function,
        arrow_with_complex_return_type_annotation_including_arrow) {
   {
     test_parser p(u8"((): (() => ReturnType) | Other => {})"_sv,


### PR DESCRIPTION
#976 
I've set `.colon_type_annotation = allow_type_annotations::always` when parsing arrow function's params.
This seems to solve the problem.
If I understand it correctly, we force parsing type annotations regardless of TypeScript/JavaScript to avoid all of those syntax errors and then in function `parse_typescript_colon_for_type()` error is reported when not in JavaScript mode.