### PR TITLE
use aria-current to indicate current nav

### DIFF
--- a/website/public/common-nav.ejs.html
+++ b/website/public/common-nav.ejs.html
@@ -248,7 +248,7 @@
       }
       let titleHTML = ejs.escapeXML(page.title);
       if (page.uri === currentURI) {
-        return html`<li class="${classes}"><span class="current-page">${titleHTML}</span></li>`;
+        return html`<li class="${classes}"><span class="current-page" aria-current="page">${titleHTML}</span></li>`;
       } else {
         return html`<li class="${classes}">
           <a href="${ejs.escapeXML(makeRelativeURI(page.uri))}">${titleHTML}</a>
@@ -258,7 +258,7 @@
     if (page.pattern instanceof RegExp) {
       assert.match(currentURI, page.pattern, "Linkifying pattern subpages only supported for current URI");
       let titleHTML = ejs.escapeXML(page.makeTitle(currentURI, currentURI.match(page.pattern)));
-      return html`<li><span class="current-page">${titleHTML}</span></li>`;
+      return html`<li><span class="current-page" aria-current="page">${titleHTML}</span></li>`;
     }
     throw new Error("Malformed page or subpage: " + JSON.stringify(subpage));
   }


### PR DESCRIPTION
#1024 
Added aria-current="page" to the correct main nav element. This was done by taking advantage of the pageLinkHTML function which already includes a check for if the current nav item is the current page.

