### PR TITLE
feat: warning on xor operator as exponentiation

### DIFF
--- a/docs/errors/E0710.md
+++ b/docs/errors/E0710.md
@@ -1,8 +1,7 @@
 # E0710: '^' is the XOR operator; to exponentiate, use '**' instead
 
 The Exclusive OR operator ^ can sometimes be mistaken for the
-exponentiation operator **, especially when applied to literal bases 2 and 10
-and literal exponent operations (which could be written as literal itself)
+exponentiation operator **.
 
 ```javascript
 let x = 2 ^ 8
@@ -16,7 +15,7 @@ let x = 2 ** 8
 ```
 
 Alternatively, if the intention was to use the ^ operator for XOR operation,
-The resulting literal could just be used directly (2 ^ 8 = 10)
+The resulting literal could be used directly (2 ^ 8 = 10)
 
 ```javascript
 let x = 10

--- a/docs/errors/E0710.md
+++ b/docs/errors/E0710.md
@@ -1,0 +1,23 @@
+# E0710: '^' is the XOR operator; to exponentiate, use '**' instead
+
+The Exclusive OR operator ^ can sometimes be mistaken for the
+exponentiation operator **, especially when applied to literal bases 2 and 10
+and literal exponent operations (which could be written as literal itself)
+
+```javascript
+let x = 2 ^ 8
+```
+
+If the intention was to exponentiate, the operator ^ should be replaced
+with **
+
+```javascript
+let x = 2 ** 8
+```
+
+Alternatively, if the intention was to use the ^ operator for XOR operation,
+The resulting literal could just be used directly (2 ^ 8 = 10)
+
+```javascript
+let x = 10
+```

--- a/po/de.po
+++ b/po/de.po
@@ -2197,6 +2197,10 @@ msgstr "Variablenname für 'catch' fehlt"
 msgid "variable assignment to self is no-op"
 msgstr "Zuweisung an Variable vor Deklaration"
 
+#: src/quick-lint-js/diag/diagnostic-types.h
+msgid "'^' is the XOR operator; to exponentiate, use '**' instead"
+msgstr ""
+
 #: test/test-diagnostic-formatter.cpp
 #: test/test-vim-qflist-json-diag-reporter.cpp
 msgid "something happened"

--- a/po/en_US@snarky.po
+++ b/po/en_US@snarky.po
@@ -2041,6 +2041,10 @@ msgstr "name your variable, please"
 msgid "variable assignment to self is no-op"
 msgstr "why are you assignin' before you be makin'? 🤏"
 
+#: src/quick-lint-js/diag/diagnostic-types.h
+msgid "'^' is the XOR operator; to exponentiate, use '**' instead"
+msgstr ""
+
 #: test/test-diagnostic-formatter.cpp
 #: test/test-vim-qflist-json-diag-reporter.cpp
 msgid "something happened"

--- a/po/fr_FR.po
+++ b/po/fr_FR.po
@@ -2217,6 +2217,10 @@ msgstr "nom de variable requis pour 'catch'"
 msgid "variable assignment to self is no-op"
 msgstr "variable affectée avant sa déclaration"
 
+#: src/quick-lint-js/diag/diagnostic-types.h
+msgid "'^' is the XOR operator; to exponentiate, use '**' instead"
+msgstr ""
+
 #: test/test-diagnostic-formatter.cpp
 #: test/test-vim-qflist-json-diag-reporter.cpp
 msgid "something happened"

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -1867,6 +1867,10 @@ msgstr ""
 msgid "variable assignment to self is no-op"
 msgstr ""
 
+#: src/quick-lint-js/diag/diagnostic-types.h
+msgid "'^' is the XOR operator; to exponentiate, use '**' instead"
+msgstr ""
+
 #: test/test-diagnostic-formatter.cpp
 #: test/test-vim-qflist-json-diag-reporter.cpp
 msgid "something happened"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1972,6 +1972,10 @@ msgstr "esperado um nome de variável para o 'catch'"
 msgid "variable assignment to self is no-op"
 msgstr "variável atribuída antes de ser declarada"
 
+#: src/quick-lint-js/diag/diagnostic-types.h
+msgid "'^' is the XOR operator; to exponentiate, use '**' instead"
+msgstr ""
+
 #: test/test-diagnostic-formatter.cpp
 #: test/test-vim-qflist-json-diag-reporter.cpp
 msgid "something happened"

--- a/po/sv_SE.po
+++ b/po/sv_SE.po
@@ -2043,6 +2043,10 @@ msgstr "förväntade variabel namn för 'catch'"
 msgid "variable assignment to self is no-op"
 msgstr "tilldelar variabel före deklaration"
 
+#: src/quick-lint-js/diag/diagnostic-types.h
+msgid "'^' is the XOR operator; to exponentiate, use '**' instead"
+msgstr ""
+
 #: test/test-diagnostic-formatter.cpp
 #: test/test-vim-qflist-json-diag-reporter.cpp
 msgid "something happened"

--- a/src/quick-lint-js/diag/diagnostic-types.h
+++ b/src/quick-lint-js/diag/diagnostic-types.h
@@ -3105,7 +3105,15 @@
       MESSAGE(QLJS_TRANSLATABLE("variable assignment to self is no-op"),        \
               assignment_statement))                                            \
                                                                                 \
-  /* END */
+  QLJS_DIAG_TYPE(                                                               \
+      diag_xor_used_as_exponentiation, "E0710", diagnostic_severity::warning,   \
+      { source_code_span xor_operator; },                                       \
+      MESSAGE(                                                                  \
+          QLJS_TRANSLATABLE(                                                    \
+              "'^' is the XOR operator; to exponentiate, use '**' instead"),    \
+          xor_operator))
+
+/* END */
 
 // QLJS_X_RESERVED_DIAG_TYPES lists reserved error codes. These codes were used
 // in the past but no longer mean anything.

--- a/src/quick-lint-js/fe/parse-expression.cpp
+++ b/src/quick-lint-js/fe/parse-expression.cpp
@@ -72,6 +72,8 @@ void parser::visit_expression(expression* ast, parse_visitor_base& v,
         static_cast<expression::binary_operator*>(ast));
     this->error_on_pointless_nullish_coalescing_operator(
         static_cast<expression::binary_operator*>(ast));
+    this->warn_on_xor_operator_as_exponentiation(
+        static_cast<expression::binary_operator*>(ast));
     break;
   case expression_kind::trailing_comma: {
     auto& trailing_comma_ast = static_cast<expression::trailing_comma&>(*ast);

--- a/src/quick-lint-js/fe/parse.h
+++ b/src/quick-lint-js/fe/parse.h
@@ -454,6 +454,7 @@ class parser {
   void error_on_sketchy_condition(expression *);
   void warn_on_comma_operator_in_conditional_statement(expression *);
   void warn_on_comma_operator_in_index(expression *, source_code_span);
+  void warn_on_xor_operator_as_exponentiation(expression::binary_operator *);
   void error_on_pointless_string_compare(expression::binary_operator *);
   void error_on_pointless_compare_against_literal(
       expression::binary_operator *);

--- a/src/quick-lint-js/i18n/translation-table-generated.cpp
+++ b/src/quick-lint-js/i18n/translation-table-generated.cpp
@@ -32,7 +32,8 @@ const translation_table translation_data = {
         {0, 0, 0, 0, 0, 61},                 //
         {93, 63, 151, 70, 130, 71},          //
         {0, 0, 0, 0, 0, 37},                 //
-        {0, 0, 0, 36, 0, 14},                //
+        {0, 0, 0, 0, 0, 14},                 //
+        {0, 0, 0, 36, 0, 59},                //
         {0, 0, 0, 100, 0, 89},               //
         {0, 0, 0, 0, 0, 24},                 //
         {50, 77, 41, 27, 0, 60},             //
@@ -1771,6 +1772,7 @@ const translation_table translation_data = {
         u8"'?' belongs only after the tuple element name, not also after the type\0"
         u8"'?' creates a conditional expression\0"
         u8"'?' goes here\0"
+        u8"'^' is the XOR operator; to exponentiate, use '**' instead\0"
         u8"'as const' is only allowed on literals (array, object, string, boolean) and enum members\0"
         u8"'as const' located here\0"
         u8"'async export' is not allowed; write 'export async' instead\0"

--- a/src/quick-lint-js/i18n/translation-table-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-generated.h
@@ -20,8 +20,8 @@ namespace quick_lint_js {
 using namespace std::literals::string_view_literals;
 
 constexpr std::uint32_t translation_table_locale_count = 5;
-constexpr std::uint16_t translation_table_mapping_table_size = 463;
-constexpr std::size_t translation_table_string_table_size = 77248;
+constexpr std::uint16_t translation_table_mapping_table_size = 464;
+constexpr std::size_t translation_table_string_table_size = 77307;
 constexpr std::size_t translation_table_locale_table_size = 35;
 
 QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
@@ -49,6 +49,7 @@ QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
           "'?' belongs only after the tuple element name, not also after the type"sv,
           "'?' creates a conditional expression"sv,
           "'?' goes here"sv,
+          "'^' is the XOR operator; to exponentiate, use '**' instead"sv,
           "'as const' is only allowed on literals (array, object, string, boolean) and enum members"sv,
           "'as const' located here"sv,
           "'async export' is not allowed; write 'export async' instead"sv,

--- a/test/quick-lint-js/test-translation-table-generated.h
+++ b/test/quick-lint-js/test-translation-table-generated.h
@@ -27,7 +27,7 @@ struct translated_string {
   const char8 *expected_per_locale[6];
 };
 
-extern const translated_string test_translation_table[462];
+extern const translated_string test_translation_table[463];
 }
 
 #endif

--- a/test/test-parse-expression-statement.cpp
+++ b/test/test-parse-expression-statement.cpp
@@ -29,7 +29,7 @@ namespace {
 class test_parse_expression_statement : public test_parse_expression {};
 
 TEST_F(test_parse_expression_statement, parse_math_expression) {
-  for (string8_view input : {u8"2"_sv, u8"2+2"_sv, u8"2^2"_sv, u8"2 + + 2"_sv,
+  for (string8_view input : {u8"2"_sv, u8"2+2"_sv, u8"3^2"_sv, u8"2 + + 2"_sv,
                              u8"2 * (3 + 4)"_sv, u8"1+1+1+1+1"_sv}) {
     SCOPED_TRACE(out_string8(u8"input = " + string8(input)));
     test_parser p(input);

--- a/test/test-parse-warning.cpp
+++ b/test/test-parse-warning.cpp
@@ -795,6 +795,62 @@ TEST_F(test_parse_warning, warn_on_variable_assigned_to_self_is_noop) {
     EXPECT_THAT(p.errors, IsEmpty());
   }
 }
+
+TEST_F(test_parse_warning, warn_on_xor_operation_used_as_exponentiation) {
+  {
+    test_parser p(u8"2 ^ 8"_sv, capture_diags);
+    p.parse_and_visit_expression();
+    EXPECT_THAT(p.errors,
+                ElementsAreArray({
+                    DIAG_TYPE_OFFSETS(p.code, diag_xor_used_as_exponentiation,
+                                      xor_operator, strlen(u8"2 "), u8"^"_sv),
+                }));
+  }
+  {
+    test_parser p(u8"let a = 2 ^ 5"_sv, capture_diags);
+    p.parse_and_visit_statement();
+    EXPECT_THAT(
+        p.errors,
+        ElementsAreArray({
+            DIAG_TYPE_OFFSETS(p.code, diag_xor_used_as_exponentiation,
+                              xor_operator, strlen(u8"let a = 2 "), u8"^"_sv),
+        }));
+  }
+  {
+    test_parser p(u8"10 ^ 5"_sv, capture_diags);
+    p.parse_and_visit_expression();
+    EXPECT_THAT(p.errors,
+                ElementsAreArray({
+                    DIAG_TYPE_OFFSETS(p.code, diag_xor_used_as_exponentiation,
+                                      xor_operator, strlen(u8"10 "), u8"^"_sv),
+                }));
+  }
+  {
+    test_parser p(u8"x ^ a"_sv, capture_diags);
+    p.parse_and_visit_expression();
+    EXPECT_THAT(p.errors, IsEmpty());
+  }
+  {
+    test_parser p(u8"10 ^ x"_sv, capture_diags);
+    p.parse_and_visit_expression();
+    EXPECT_THAT(p.errors, IsEmpty());
+  }
+  {
+    test_parser p(u8"3 ^ x"_sv, capture_diags);
+    p.parse_and_visit_expression();
+    EXPECT_THAT(p.errors, IsEmpty());
+  }
+  {
+    test_parser p(u8"4 ^ 3"_sv, capture_diags);
+    p.parse_and_visit_expression();
+    EXPECT_THAT(p.errors, IsEmpty());
+  }
+  {
+    test_parser p(u8"(x+2)^a"_sv, capture_diags);
+    p.parse_and_visit_expression();
+    EXPECT_THAT(p.errors, IsEmpty());
+  }
+}
 }
 }
 

--- a/test/test-translation-table-generated.cpp
+++ b/test/test-translation-table-generated.cpp
@@ -242,6 +242,17 @@ const translated_string test_translation_table[] = {
         },
     },
     {
+        "'^' is the XOR operator; to exponentiate, use '**' instead"_translatable,
+        {
+            u8"'^' is the XOR operator; to exponentiate, use '**' instead",
+            u8"'^' is the XOR operator; to exponentiate, use '**' instead",
+            u8"'^' is the XOR operator; to exponentiate, use '**' instead",
+            u8"'^' is the XOR operator; to exponentiate, use '**' instead",
+            u8"'^' is the XOR operator; to exponentiate, use '**' instead",
+            u8"'^' is the XOR operator; to exponentiate, use '**' instead",
+        },
+    },
+    {
         "'as const' is only allowed on literals (array, object, string, boolean) and enum members"_translatable,
         {
             u8"'as const' is only allowed on literals (array, object, string, boolean) and enum members",


### PR DESCRIPTION
Closes #997 

As proposed in the original issue, we only diagnose for cases with a base of 2 or 10 and a literal exponent.

(Had to change a test not created by me because it involved the operation `2 ^ 2` and expected no diagnostics. Changed the operation to  `3 ^ 2`, if another solution is preferred for this just let me know)