### PR TITLE
Partially fix build failure of test suite on FreeBSD

### DIFF
--- a/test/test-file.cpp
+++ b/test/test-file.cpp
@@ -46,6 +46,10 @@
 #include <sys/stat.h>
 #endif
 
+#if QLJS_HAVE_SYS_WAIT_H
+#include <sys/wait.h>
+#endif
+
 using ::testing::HasSubstr;
 using namespace std::literals::chrono_literals;
 


### PR DESCRIPTION
This fixes the following build failure when building the current master on FreeBSD:

```
test/test-file.cpp:264:20: error: no member named 'waitpid' in the global namespace
    ::pid_t rc = ::waitpid(pid, &status, /*options=*/0);
                 ~~^
test/test-file.cpp:267:17: error: use of undeclared identifier 'WIFEXITED'
    EXPECT_TRUE(WIFEXITED(status)) << "child should not have crashed";
                ^
test/test-file.cpp:268:9: error: use of undeclared identifier 'WIFEXITED'
    if (WIFEXITED(status)) {
        ^
test/test-file.cpp:269:17: error: use of undeclared identifier 'WEXITSTATUS'
      EXPECT_EQ(WEXITSTATUS(status), 0)
                ^
```

Fix by adding missing include of `sys/wait.h`.

I haven't looked at a different build failure (`test/test-event-loop.cpp:818:10: error: use of undeclared identifier 'NOTE_CRITICAL'`) which seems to be more involved.

