### PR TITLE
#1063: Improve error recovery for missing } in parameter destructure

### DIFF
--- a/src/quick-lint-js/fe/parse-expression.cpp
+++ b/src/quick-lint-js/fe/parse-expression.cpp
@@ -3019,7 +3019,8 @@ Expression* Parser::parse_object_literal(Parse_Visitor_Base& v) {
           }
         }
         break;
-
+      
+      case Token_Type::right_paren:
       // {x  // Invalid.
       case Token_Type::end_of_file:
         // We'll report Diag_Unclosed_Object_Literal later when we look for the

--- a/test/test-parse-expression.cpp
+++ b/test/test-parse-expression.cpp
@@ -2836,7 +2836,7 @@ TEST_F(Test_Parse_Expression, function_with_destructuring_parameters) {
     Expression* ast = p.parse_expression();
     EXPECT_EQ(summarize(ast), "function");
   }
-  
+
   {
     Test_Parser p(u8"function({ a ) { c }"_sv, capture_diags);
     p.parse_expression();
@@ -3037,8 +3037,8 @@ TEST_F(Test_Parse_Expression, arrow_function_with_destructuring_parameters) {
     EXPECT_EQ(ast->attributes(), Function_Attributes::normal);
     EXPECT_EQ(ast->child_count(), 1);
     EXPECT_EQ(summarize(ast->child(0)), "spread(var args)");
-  } 
-  
+  }
+
   {
     Test_Parser p(u8"({ a, b ) => c"_sv, capture_diags);
     p.parse_expression();

--- a/test/test-parse-expression.cpp
+++ b/test/test-parse-expression.cpp
@@ -2836,6 +2836,17 @@ TEST_F(Test_Parse_Expression, function_with_destructuring_parameters) {
     Expression* ast = p.parse_expression();
     EXPECT_EQ(summarize(ast), "function");
   }
+  
+  {
+    Test_Parser p(u8"function({ a ) { c }"_sv, capture_diags);
+    p.parse_expression();
+    assert_diagnostics(
+        p.code, p.errors,
+        {
+            u8"         ^ Diag_Unclosed_Object_Literal.object_open\n"_diag
+            u8"            ` .expected_object_close"_diag,
+        });
+  }
 }
 
 TEST_F(Test_Parse_Expression, function_with_spread_and_comma) {
@@ -3026,6 +3037,17 @@ TEST_F(Test_Parse_Expression, arrow_function_with_destructuring_parameters) {
     EXPECT_EQ(ast->attributes(), Function_Attributes::normal);
     EXPECT_EQ(ast->child_count(), 1);
     EXPECT_EQ(summarize(ast->child(0)), "spread(var args)");
+  } 
+  
+  {
+    Test_Parser p(u8"({ a, b ) => c"_sv, capture_diags);
+    p.parse_expression();
+    assert_diagnostics(
+        p.code, p.errors,
+        {
+            u8" ^ Diag_Unclosed_Object_Literal.object_open\n"_diag
+            u8"       ` .expected_object_close"_diag,
+        });
   }
 }
 


### PR DESCRIPTION
Fixes #1063 :
Token_Type::right_paren has the same case as Token_Type::end_of_file ( in the next line ), whereby it will eventually break and the next iteration of the loop will catch the Token_Type::right_paren and add the diagnostic error