### PR TITLE
Fix/improve diagnostic for e0018

### DIFF
--- a/src/quick-lint-js/fe/parse-expression.cpp
+++ b/src/quick-lint-js/fe/parse-expression.cpp
@@ -2065,6 +2065,16 @@ next:
     break;
 
   case Token_Type::left_curly: {
+    auto has_comma_operator = [](Binary_Expression_Builder* binary_builder) -> bool {
+      Expression::Binary_Operator* expr = static_cast<Expression::Binary_Operator*>(binary_builder->last_expression()->without_paren());
+      bool comma = false;
+      for(int i=0; i < expr->children_.size()-1; i++){
+        if (expr->operator_spans_[i].string_view() == u8","_sv) {
+          comma = true;
+        }
+      }
+      return comma;
+    };                            
     bool looks_like_arrow_function_body =
         prec.trailing_curly_is_arrow_body &&
         !binary_builder.has_multiple_children() &&
@@ -2073,7 +2083,7 @@ next:
              // TODO(strager): Check for ',' operator explicitly, not any binary
              // operator.
              binary_builder.last_expression()->without_paren()->kind() ==
-                 Expression_Kind::Binary_Operator) ||
+                 Expression_Kind::Binary_Operator && has_comma_operator(&binary_builder)) ||
          (  // one identifier: (a)
              binary_builder.last_expression()->kind() ==
                  Expression_Kind::Paren &&

--- a/src/quick-lint-js/fe/parse-expression.cpp
+++ b/src/quick-lint-js/fe/parse-expression.cpp
@@ -2065,11 +2065,10 @@ next:
     break;
 
   case Token_Type::left_curly: {
-    auto has_comma_operator =
-        [](Binary_Expression_Builder* binary_builder) -> bool {
+    auto has_comma_operator = [&binary_builder]() -> bool {
       Expression::Binary_Operator* expr =
           static_cast<Expression::Binary_Operator*>(
-              binary_builder->last_expression()->without_paren());
+              binary_builder.last_expression()->without_paren());
       bool comma = false;
       for (int i = 0; i < expr->children_.size() - 1; i++) {
         if (expr->operator_spans_[i].string_view() == u8","_sv) {
@@ -2083,11 +2082,9 @@ next:
         !binary_builder.has_multiple_children() &&
         ((  // multiple identifiers: (a, b)
              !this->peek().has_leading_newline &&
-             // TODO(strager): Check for ',' operator explicitly, not any binary
-             // operator.
              binary_builder.last_expression()->without_paren()->kind() ==
                  Expression_Kind::Binary_Operator &&
-             has_comma_operator(&binary_builder)) ||
+             has_comma_operator()) ||
          (  // one identifier: (a)
              binary_builder.last_expression()->kind() ==
                  Expression_Kind::Paren &&

--- a/src/quick-lint-js/fe/parse-expression.cpp
+++ b/src/quick-lint-js/fe/parse-expression.cpp
@@ -2065,16 +2065,19 @@ next:
     break;
 
   case Token_Type::left_curly: {
-    auto has_comma_operator = [](Binary_Expression_Builder* binary_builder) -> bool {
-      Expression::Binary_Operator* expr = static_cast<Expression::Binary_Operator*>(binary_builder->last_expression()->without_paren());
+    auto has_comma_operator =
+        [](Binary_Expression_Builder* binary_builder) -> bool {
+      Expression::Binary_Operator* expr =
+          static_cast<Expression::Binary_Operator*>(
+              binary_builder->last_expression()->without_paren());
       bool comma = false;
-      for(int i=0; i < expr->children_.size()-1; i++){
+      for (int i = 0; i < expr->children_.size() - 1; i++) {
         if (expr->operator_spans_[i].string_view() == u8","_sv) {
           comma = true;
         }
       }
       return comma;
-    };                            
+    };
     bool looks_like_arrow_function_body =
         prec.trailing_curly_is_arrow_body &&
         !binary_builder.has_multiple_children() &&
@@ -2083,7 +2086,8 @@ next:
              // TODO(strager): Check for ',' operator explicitly, not any binary
              // operator.
              binary_builder.last_expression()->without_paren()->kind() ==
-                 Expression_Kind::Binary_Operator && has_comma_operator(&binary_builder)) ||
+                 Expression_Kind::Binary_Operator &&
+             has_comma_operator(&binary_builder)) ||
          (  // one identifier: (a)
              binary_builder.last_expression()->kind() ==
                  Expression_Kind::Paren &&

--- a/test/test-parse-statement.cpp
+++ b/test/test-parse-statement.cpp
@@ -661,7 +661,7 @@ TEST_F(Test_Parse_Statement, if_without_parens) {
                               "visit_exit_block_scope",
                           }));
   }
-  
+
   {
     Spy_Visitor p = test_parse_and_visit_statement(
         u8"if (!(cond_1 && cond_2) { body; }"_sv,  //

--- a/test/test-parse-statement.cpp
+++ b/test/test-parse-statement.cpp
@@ -661,6 +661,19 @@ TEST_F(Test_Parse_Statement, if_without_parens) {
                               "visit_exit_block_scope",
                           }));
   }
+  
+  {
+    Spy_Visitor p = test_parse_and_visit_statement(
+        u8"if (!(cond_1 && cond_2) { body; }"_sv,  //
+        u8"                       ` Diag_Expected_Parenthesis_Around_If_Condition.where{.token=)}"_diag);
+    EXPECT_THAT(p.visits, ElementsAreArray({
+                              "visit_variable_use",       // cond_1
+                              "visit_variable_use",       // cond_2
+                              "visit_enter_block_scope",  //
+                              "visit_variable_use",       // body
+                              "visit_exit_block_scope",
+                          }));
+  }
 
   {
     Spy_Visitor p = test_parse_and_visit_statement(


### PR DESCRIPTION
fixes: #1060 
In this case, instead of just checking for just any binary operator, we can check for commas within the binary operator to confirm that there are multiple parameters of a function