### PR TITLE
refactor(website): Use `article` in `og:type` tag in blog articles.

### DIFF
--- a/website/public/blog/blog-head.ejs.html
+++ b/website/public/blog/blog-head.ejs.html
@@ -1,7 +1,15 @@
 <%#
 <!-- Copyright (C) 2020  Matthew "strager" Glazar -->
 <!-- See end of file for extended copyright information. -->
-%>
+%> <% if (typeof meta.blogDate !== 'undefined') { %>
+<meta property="og:type" content="article" />
+<meta property="article:section" content="Technology" />
+<meta property="article:published_time" content="<%= meta.blogDate %>" />
+<% } %> <% if (typeof meta.blogModifiedDate !== 'undefined') { %>
+<meta property="article:modified_time" content="<%= meta.blogModifiedDate %>" />
+<% } %> <% if (typeof meta.blogAuthor !== 'undefined') { %>
+<meta property="article:author" content="<%= meta.blogAuthor %>" />
+<% } %>
 
 <link
   rel="alternate"

--- a/website/public/blog/bug-journey/index.ejs.html
+++ b/website/public/blog/bug-journey/index.ejs.html
@@ -3,6 +3,7 @@
 "linkLabelHTML": "Sometimes it <em>is</em> a compiler bug",
 "description": "My journey in finding and fixing a bug in a C++ toolchain",
 "navTitle": "Compiler bug",
+"blogAuthor": "Matthew \"strager\" Glazar",
 "blogDate": "2022-05-25T21:04:02-07:00"
 }--->
 
@@ -652,7 +653,7 @@ if test -r ../../../bfd/../mkinstalldirs; then \
   ../../../bfd/../mkinstalldirs /ucrt64/share; \
 else \
   ../../../bfd/mkinstalldirs /ucrt64/share; \
-fi 
+fi
 installing da.gmo as <mark>/ucrt64/share/locale/da/LC_MESSAGES/bfd.mo</mark>
 installing es.gmo as <mark>/ucrt64/share/locale/es/LC_MESSAGES/bfd.mo</mark>
 installing fi.gmo as <mark>/ucrt64/share/locale/fi/LC_MESSAGES/bfd.mo</mark>

--- a/website/public/blog/cpp-vs-rust-build-times/index.ejs.html
+++ b/website/public/blog/cpp-vs-rust-build-times/index.ejs.html
@@ -4,7 +4,8 @@
 "navTitle": "C++ vs Rust",
 "image": "/blog/cpp-vs-rust-build-times/cpp-vs-rust.jpg",
 "blogAuthor": "Matthew \"strager\" Glazar",
-"blogDate": "2023-01-05T21:32:37-08:00"
+"blogDate": "2023-01-05T21:32:37-08:00",
+"blogLastModified": "2023-01-07T16:48:07.000-07:00"
 }--->
 
 <!DOCTYPE html>

--- a/website/public/blog/cpp-vs-rust-build-times/index.ejs.html
+++ b/website/public/blog/cpp-vs-rust-build-times/index.ejs.html
@@ -3,6 +3,7 @@
 "description": "A practical comparison of build and test speed between C++ and Rust.",
 "navTitle": "C++ vs Rust",
 "image": "/blog/cpp-vs-rust-build-times/cpp-vs-rust.jpg",
+"blogAuthor": "Matthew \"strager\" Glazar",
 "blogDate": "2023-01-05T21:32:37-08:00"
 }--->
 

--- a/website/public/blog/show-js-errors-neovim-macos/index.ejs.html
+++ b/website/public/blog/show-js-errors-neovim-macos/index.ejs.html
@@ -3,6 +3,7 @@
 "description": "How to install Homebrew, Neovim, and quick-lint-js on macOS to show JavaScript syntax errors while editing",
 "navTitle": "Neovim for JS",
 "image": "/blog/show-js-errors-neovim-macos/neovim-demo.png",
+"blogAuthor": "Matthew \"strager\" Glazar",
 "blogDate": "2022-02-16T21:48:38-08:00"
 }--->
 

--- a/website/public/blog/show-js-errors-neovim-macos/index.ejs.html
+++ b/website/public/blog/show-js-errors-neovim-macos/index.ejs.html
@@ -4,7 +4,8 @@
 "navTitle": "Neovim for JS",
 "image": "/blog/show-js-errors-neovim-macos/neovim-demo.png",
 "blogAuthor": "Matthew \"strager\" Glazar",
-"blogDate": "2022-02-16T21:48:38-08:00"
+"blogDate": "2022-02-16T21:48:38-08:00",
+"blogLastModified": "2023-08-01T16:48:07.000-07:00"
 }--->
 
 <!DOCTYPE html>

--- a/website/public/blog/syntax-errors-2021/index.ejs.html
+++ b/website/public/blog/syntax-errors-2021/index.ejs.html
@@ -4,7 +4,7 @@
 "navTitle": "JS errors",
 "blogAuthor": "Matthew \"strager\" Glazar",
 "blogDate": "2021-12-11T17:19:10-08:00",
-"blogModified": "2023-08-01T16:48:07.000-07:00"
+"blogModifiedDate": "2023-07-29T02:15:59-07:00"
 }--->
 
 <!DOCTYPE html>

--- a/website/public/blog/syntax-errors-2021/index.ejs.html
+++ b/website/public/blog/syntax-errors-2021/index.ejs.html
@@ -2,7 +2,9 @@
 "title": "JavaScript syntax errors compared (2021)",
 "description": "Comparison of errors produced by different JavaScript parsers",
 "navTitle": "JS errors",
-"blogDate": "2021-12-11T17:19:10-08:00"
+"blogAuthor": "Matthew \"strager\" Glazar",
+"blogDate": "2021-12-11T17:19:10-08:00",
+"blogModified": "2023-08-01T16:48:07.000-07:00"
 }--->
 
 <!DOCTYPE html>

--- a/website/public/blog/version-1.0/index.ejs.html
+++ b/website/public/blog/version-1.0/index.ejs.html
@@ -3,6 +3,7 @@
 "linkLabelHTML": "Release: version 1.0",
 "description": "Faster, easier, friendlier: how quick-lint-js will take over ESLint",
 "navTitle": "Release 1.0",
+"blogAuthor": "Matthew \"strager\" Glazar",
 "blogDate": "2021-12-13T19:27:37-08:00"
 }--->
 

--- a/website/public/blog/version-2.0/index.ejs.html
+++ b/website/public/blog/version-2.0/index.ejs.html
@@ -3,6 +3,7 @@
 "linkLabelHTML": "Release: version 2.0",
 "description": "We are proud to announce version 2.0 of quick-lint-js!",
 "navTitle": "Release 2.0",
+"blogAuthor": "Matthew \"strager\" Glazar",
 "blogDate": "2022-02-04T21:43:20-08:00"
 }--->
 

--- a/website/public/common-head.ejs.html
+++ b/website/public/common-head.ejs.html
@@ -41,7 +41,11 @@
   content="<%= locals.image ?? meta.image ?? '/vscode-demo-small.gif' %>"
 />
 <meta name="theme-color" content="#a76851" />
+<% if (typeof locals.blogDate === 'undefined' && typeof meta.blogDate ===
+'undefined') { %>
 <meta property="og:type" content="website" />
+<% } %> <%# NOTE: See blog.head.ejs.html for blog article related tags %>
+
 <meta name="twitter:card" content="summary_large_image" />
 <%#
 <!--

--- a/website/public/common-head.ejs.html
+++ b/website/public/common-head.ejs.html
@@ -41,10 +41,9 @@
   content="<%= locals.image ?? meta.image ?? '/vscode-demo-small.gif' %>"
 />
 <meta name="theme-color" content="#a76851" />
-<% if (typeof locals.blogDate === 'undefined' && typeof meta.blogDate ===
-'undefined') { %>
+<% if (typeof meta.blogDate === 'undefined') { %>
 <meta property="og:type" content="website" />
-<% } %> <%# NOTE: See blog.head.ejs.html for blog article related tags %>
+<% } %> <%# NOTE: See /website/public/blog/blog-head.ejs.html for blog article related tags %>
 
 <meta name="twitter:card" content="summary_large_image" />
 <%#


### PR DESCRIPTION
See #1080 for the intention of this pull request.