### PR TITLE
feat: new diag for missing commas between array elements

### DIFF
--- a/docs/errors/E0712.md
+++ b/docs/errors/E0712.md
@@ -1,0 +1,15 @@
+# E0711: missing ',' between array elements
+
+This error occurs when there is a missing comma (',') between elements in an array
+declaration or initialization. In JavaScript, commas are used to separate individual
+elements within an array, and the absence of a comma will lead to a syntax error.
+
+```javascript
+let myArray = [1 2 3];
+```
+
+To fix this error, you need to add a comma between each element within the array declaration or initialization
+
+```javascript
+let myArray = [1, 2, 3];
+```

--- a/docs/errors/E0712.md
+++ b/docs/errors/E0712.md
@@ -1,4 +1,4 @@
-# E0711: missing ',' between array elements
+# E0712: missing ',' between array elements
 
 This error occurs when there is a missing comma (',') between elements in an array
 declaration or initialization. In JavaScript, commas are used to separate individual

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -1929,6 +1929,10 @@ msgstr ""
 msgid "missing expression in placeholder within template literal"
 msgstr ""
 
+#: src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
+msgid "missing ',' between array elements"
+msgstr ""
+
 #: test/test-diagnostic-formatter.cpp
 #: test/test-vim-qflist-json-diag-reporter.cpp
 msgid "something happened"

--- a/src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
+++ b/src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
@@ -5961,6 +5961,20 @@ const QLJS_CONSTINIT Diagnostic_Info all_diagnostic_infos[] = {
         },
       },
     },
+
+    // Diag_Missing_Comma_Between_Array_Elements
+    {
+      .code = 712,
+      .severity = Diagnostic_Severity::error,
+      .message_formats = {
+        QLJS_TRANSLATABLE("missing ',' between array elements"),
+      },
+      .message_args = {
+        {
+          Diagnostic_Message_Arg_Info(offsetof(Diag_Missing_Comma_Between_Array_Elements, expected_comma), Diagnostic_Arg_Type::source_code_span),
+        },
+      },
+    },
 };
 }
 

--- a/src/quick-lint-js/diag/diagnostic-metadata-generated.h
+++ b/src/quick-lint-js/diag/diagnostic-metadata-generated.h
@@ -412,10 +412,11 @@ namespace quick_lint_js {
   QLJS_DIAG_TYPE_NAME(Diag_Variable_Assigned_To_Self_Is_Noop) \
   QLJS_DIAG_TYPE_NAME(Diag_Xor_Used_As_Exponentiation) \
   QLJS_DIAG_TYPE_NAME(Diag_Expected_Expression_In_Template_Literal) \
+  QLJS_DIAG_TYPE_NAME(Diag_Missing_Comma_Between_Array_Elements) \
   /* END */
 // clang-format on
 
-inline constexpr int Diag_Type_Count = 401;
+inline constexpr int Diag_Type_Count = 402;
 
 extern const Diagnostic_Info all_diagnostic_infos[Diag_Type_Count];
 }

--- a/src/quick-lint-js/diag/diagnostic-types-2.h
+++ b/src/quick-lint-js/diag/diagnostic-types-2.h
@@ -3065,8 +3065,21 @@ struct Diag_Expected_Expression_In_Template_Literal {
                   ARG(placeholder))]]  //
   Source_Code_Span placeholder;
 };
-}
 
+struct Diag_Missing_Comma_Between_Array_Elements {
+  [[qljs::diag("E0712", Diagnostic_Severity::error)]]  //
+  [[qljs::message("missing ',' between array elements",
+                  ARG(expected_comma))]]  //
+  Source_Code_Span expected_comma;
+};
+
+// struct Diag_Comma_In_Middle_Of_Array {
+//   [[qljs::diag("E0713", Diagnostic_Severity::warning)]]  //
+//   [[qljs::message("unexpected comma in middle of array",
+//                   ARG(unexpected_comma))]]              //
+//   Source_Code_Span unexpected_comma;
+// };
+}
 QLJS_WARNING_POP
 
 // quick-lint-js finds bugs in JavaScript programs.

--- a/src/quick-lint-js/diag/diagnostic-types-2.h
+++ b/src/quick-lint-js/diag/diagnostic-types-2.h
@@ -3072,13 +3072,6 @@ struct Diag_Missing_Comma_Between_Array_Elements {
                   ARG(expected_comma))]]  //
   Source_Code_Span expected_comma;
 };
-
-// struct Diag_Comma_In_Middle_Of_Array {
-//   [[qljs::diag("E0713", Diagnostic_Severity::warning)]]  //
-//   [[qljs::message("unexpected comma in middle of array",
-//                   ARG(unexpected_comma))]]              //
-//   Source_Code_Span unexpected_comma;
-// };
 }
 QLJS_WARNING_POP
 

--- a/src/quick-lint-js/fe/parse-expression.cpp
+++ b/src/quick-lint-js/fe/parse-expression.cpp
@@ -497,11 +497,10 @@ Expression* Parser::parse_primary_expression(Parse_Visitor_Base& v,
     Expression* ast =
         type == Token_Type::kw_delete
             ? this->make_expression<Expression::Delete>(child, operator_span)
-            : type == Token_Type::kw_typeof
-                  ? this->make_expression<Expression::Typeof>(child,
-                                                              operator_span)
-                  : this->make_expression<Expression::Unary_Operator>(
-                        child, operator_span);
+        : type == Token_Type::kw_typeof
+            ? this->make_expression<Expression::Typeof>(child, operator_span)
+            : this->make_expression<Expression::Unary_Operator>(child,
+                                                                operator_span);
     return ast;
   }
 
@@ -591,16 +590,12 @@ Expression* Parser::parse_primary_expression(Parse_Visitor_Base& v,
       }
 
       if (this->peek().type == Token_Type::comma) {
-        // if(!met_expression) {
-        //   this->diag_reporter_->report(Diag_Comma_In_Middle_Of_Array{
-        //     .unexpected_comma = Source_Code_Span::unit(this->lexer_.end_of_previous_token()),
-        //   });
-        // }
         met_expression = false;
         this->skip();
         continue;
       }
-      const Char8* previous_expession_end = this->lexer_.end_of_previous_token();
+      const Char8* previous_expession_end =
+          this->lexer_.end_of_previous_token();
       const Char8* child_begin = this->peek().begin;
       Expression* child =
           this->parse_expression(v, Precedence{.commas = false});
@@ -619,8 +614,8 @@ Expression* Parser::parse_primary_expression(Parse_Visitor_Base& v,
         });
         right_square_end = expected_right_square;
         break;
-      } 
-      if(met_expression) {
+      }
+      if (met_expression) {
         this->diag_reporter_->report(Diag_Missing_Comma_Between_Array_Elements{
             .expected_comma = Source_Code_Span::unit(previous_expession_end),
         });
@@ -3739,10 +3734,11 @@ next:
             .opening_tag_name =
                 tag_namespace
                     ? Source_Code_Span(tag_namespace->span().begin(), tag_end)
-                    : !tag_members.empty()
-                          ? Source_Code_Span(tag_members.front().span().begin(),
-                                             tag_end)
-                          : tag ? tag->span() : Source_Code_Span::unit(tag_end),
+                : !tag_members.empty()
+                    ? Source_Code_Span(tag_members.front().span().begin(),
+                                       tag_end)
+                : tag ? tag->span()
+                      : Source_Code_Span::unit(tag_end),
             .closing_tag_name =
                 closing_tag_begin <= closing_tag_end
                     ? Source_Code_Span(closing_tag_begin, closing_tag_end)

--- a/src/quick-lint-js/fe/parse-expression.cpp
+++ b/src/quick-lint-js/fe/parse-expression.cpp
@@ -578,6 +578,7 @@ Expression* Parser::parse_primary_expression(Parse_Visitor_Base& v,
   case Token_Type::left_square: {
     const Char8* left_square_begin = this->peek().begin;
     const Char8* right_square_end;
+    bool met_expression = false;
     this->skip();
 
     Expression_Arena::Vector<Expression*> children(
@@ -588,11 +589,18 @@ Expression* Parser::parse_primary_expression(Parse_Visitor_Base& v,
         this->skip();
         break;
       }
-      // TODO(strager): Require commas between expressions.
+
       if (this->peek().type == Token_Type::comma) {
+        // if(!met_expression) {
+        //   this->diag_reporter_->report(Diag_Comma_In_Middle_Of_Array{
+        //     .unexpected_comma = Source_Code_Span::unit(this->lexer_.end_of_previous_token()),
+        //   });
+        // }
+        met_expression = false;
         this->skip();
         continue;
       }
+      const Char8* previous_expession_end = this->lexer_.end_of_previous_token();
       const Char8* child_begin = this->peek().begin;
       Expression* child =
           this->parse_expression(v, Precedence{.commas = false});
@@ -611,7 +619,13 @@ Expression* Parser::parse_primary_expression(Parse_Visitor_Base& v,
         });
         right_square_end = expected_right_square;
         break;
+      } 
+      if(met_expression) {
+        this->diag_reporter_->report(Diag_Missing_Comma_Between_Array_Elements{
+            .expected_comma = Source_Code_Span::unit(previous_expession_end),
+        });
       }
+      met_expression = true;
       children.emplace_back(child);
     }
     Expression* ast = this->make_expression<Expression::Array>(

--- a/src/quick-lint-js/i18n/translation-table-generated.cpp
+++ b/src/quick-lint-js/i18n/translation-table-generated.cpp
@@ -302,7 +302,8 @@ const Translation_Table translation_data = {
         {0, 0, 0, 0, 0, 46},                 //
         {0, 0, 0, 0, 0, 56},                 //
         {68, 21, 0, 52, 0, 40},              //
-        {59, 43, 61, 49, 50, 39},            //
+        {0, 0, 0, 0, 0, 39},                 //
+        {59, 43, 61, 49, 50, 35},            //
         {0, 0, 0, 44, 0, 42},                //
         {44, 2, 0, 64, 0, 57},               //
         {35, 20, 49, 55, 39, 38},            //
@@ -2057,6 +2058,7 @@ const Translation_Table translation_data = {
         u8"misleading use of ',' operator in conditional statement\0"
         u8"misleading use of ',' operator in index\0"
         u8"mismatched JSX tags; expected '</{1}>'\0"
+        u8"missing ',' between array elements\0"
         u8"missing ',' between variable declarations\0"
         u8"missing ',', ';', or newline between object type entries\0"
         u8"missing '...' in JSX attribute spread\0"

--- a/src/quick-lint-js/i18n/translation-table-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-generated.h
@@ -18,8 +18,8 @@ namespace quick_lint_js {
 using namespace std::literals::string_view_literals;
 
 constexpr std::uint32_t translation_table_locale_count = 5;
-constexpr std::uint16_t translation_table_mapping_table_size = 484;
-constexpr std::size_t translation_table_string_table_size = 78112;
+constexpr std::uint16_t translation_table_mapping_table_size = 485;
+constexpr std::size_t translation_table_string_table_size = 78147;
 constexpr std::size_t translation_table_locale_table_size = 35;
 
 QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
@@ -317,6 +317,7 @@ QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
           "misleading use of ',' operator in conditional statement"sv,
           "misleading use of ',' operator in index"sv,
           "mismatched JSX tags; expected '</{1}>'"sv,
+          "missing ',' between array elements"sv,
           "missing ',' between variable declarations"sv,
           "missing ',', ';', or newline between object type entries"sv,
           "missing '...' in JSX attribute spread"sv,

--- a/src/quick-lint-js/i18n/translation-table-test-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-test-generated.h
@@ -27,7 +27,7 @@ struct Translated_String {
 };
 
 // clang-format off
-inline const Translated_String test_translation_table[483] = {
+inline const Translated_String test_translation_table[484] = {
     {
         "\"global-groups\" entries must be strings"_translatable,
         u8"\"global-groups\" entries must be strings",
@@ -3227,6 +3227,17 @@ inline const Translated_String test_translation_table[483] = {
             u8"mismatched JSX tags; expected '</{1}>'",
             u8"tags JSX sem correspond\u00eancia; esperado '</{1}>'",
             u8"mismatched JSX tags; expected '</{1}>'",
+        },
+    },
+    {
+        "missing ',' between array elements"_translatable,
+        u8"missing ',' between array elements",
+        {
+            u8"missing ',' between array elements",
+            u8"missing ',' between array elements",
+            u8"missing ',' between array elements",
+            u8"missing ',' between array elements",
+            u8"missing ',' between array elements",
         },
     },
     {

--- a/test/test-parse-expression.cpp
+++ b/test/test-parse-expression.cpp
@@ -1823,7 +1823,7 @@ TEST_F(Test_Parse_Expression, malformed_array_literal) {
   }
 
   {
-    Test_Parser p(u8"[ x "_sv, capture_diags);
+    Test_Parser p(u8"[ x"_sv, capture_diags);
     Expression* ast = p.parse_expression();
     assert_diagnostics(p.code, p.errors,
                        {
@@ -1842,6 +1842,16 @@ TEST_F(Test_Parse_Expression, malformed_array_literal) {
                            u8" ` .expected_right_square"_diag,
                        });
     EXPECT_EQ(summarize(ast), "array()");
+  }
+
+  {
+    Test_Parser p(u8"[a b]"_sv, capture_diags);
+    Expression* ast = p.parse_expression();
+    assert_diagnostics(p.code, p.errors,
+        {
+            u8"Diag_Missing_Comma_Between_Array_Elements"_diag,
+        });
+    EXPECT_EQ(summarize(ast), "array(var a, var b)");
   }
 }
 

--- a/test/test-parse-expression.cpp
+++ b/test/test-parse-expression.cpp
@@ -1823,7 +1823,7 @@ TEST_F(Test_Parse_Expression, malformed_array_literal) {
   }
 
   {
-    Test_Parser p(u8"[ x"_sv, capture_diags);
+    Test_Parser p(u8"[ x "_sv, capture_diags);
     Expression* ast = p.parse_expression();
     assert_diagnostics(p.code, p.errors,
                        {
@@ -1848,9 +1848,9 @@ TEST_F(Test_Parse_Expression, malformed_array_literal) {
     Test_Parser p(u8"[a b]"_sv, capture_diags);
     Expression* ast = p.parse_expression();
     assert_diagnostics(p.code, p.errors,
-        {
-            u8"Diag_Missing_Comma_Between_Array_Elements"_diag,
-        });
+                       {
+                           u8"Diag_Missing_Comma_Between_Array_Elements"_diag,
+                       });
     EXPECT_EQ(summarize(ast), "array(var a, var b)");
   }
 }


### PR DESCRIPTION
closes #1077
Had to use previous_expession_end  because otherwise the test ```[ a``` fails
I've also added warnings for sparse arrays (commented lines), do we need them?