### PR TITLE
fix: new diag for async/generator on getter/setter

### DIFF
--- a/docs/errors/E0713.md
+++ b/docs/errors/E0713.md
@@ -1,0 +1,36 @@
+# E0713: '*' keyword is not allowed on getters or setters
+
+Use of the '*' character, defining generator functions, is not allowed on getters or setters. 
+Getters and setters are synchronous operations and do not support the generator functionality.
+
+```javascript
+class C {
+  constructor() {
+    this._value = 0;
+  }
+
+  get *value() {
+    return this._value;
+  }
+  set *value(newValue) {
+    this._value = newValue;
+  }
+}
+```
+
+To fix this error define with a getter or setter, using regular function syntax.
+
+```javascript
+class C {
+  constructor() {
+    this._value = 0;
+  }
+
+  get value() {
+    return this._value;
+  }
+  set value(newValue) {
+    this._value = newValue;
+  }
+}
+```

--- a/docs/errors/E0713.md
+++ b/docs/errors/E0713.md
@@ -1,4 +1,4 @@
-# E0713: '*' keyword is not allowed on getters or setters
+# E0713: getters and setters cannot be generators
 
 Use of the '*' character, defining generator functions, is not allowed on getters or setters. 
 Getters and setters are synchronous operations and do not support the generator functionality.
@@ -18,7 +18,7 @@ class C {
 }
 ```
 
-To fix this error define with a getter or setter, using regular function syntax.
+To fix this error define a getter or setter, using regular function syntax.
 
 ```javascript
 class C {

--- a/docs/errors/E0714.md
+++ b/docs/errors/E0714.md
@@ -51,14 +51,11 @@ class C {
   }
 
   async getValueAsync() {
-    // Perform asynchronous operations here
-    return await asyncFuctnion();
+    return await fetch(this._value);
   }
 
   async setValueAsync(newValue) {
-    // Perform asynchronous operations here
-    await asyncFuctnion();
-    this._value = newValue;
+    this._value = await fetch(newValue);
   }
 }
 ```

--- a/docs/errors/E0714.md
+++ b/docs/errors/E0714.md
@@ -1,0 +1,64 @@
+# E0714: 'async' keyword is not allowed on getters or setters
+
+Use of 'async' keyword, defining asynchronous functions, is not allowed on getters or setters.
+Getters and setters are synchronous operations and do not support the asynchronous functionality.
+
+
+```javascript
+class C {
+  constructor() {
+    this._value = 0;
+  }
+
+  async get value() {
+    return this._value;
+  }
+
+  async set value(newValue) {
+    this._value = newValue;
+  }
+}
+```
+
+To fix this error simply remove 'async' keyword from getters and setters, 
+so they can function properly as synchronous operations
+
+
+```javascript
+class C {
+  constructor() {
+    this._value = 0;
+  }
+
+  get value() {
+    return this._value;
+  }
+
+  set value(newValue) {
+    this._value = newValue;
+  }
+}
+```
+
+However, if you require asynchronous behavior within getters or setters, 
+you can achieve this by implementing separate asynchronous methods
+
+
+```javascript
+class C {
+  constructor() {
+    this._value = 0;
+  }
+
+  async getValueAsync() {
+    // Perform asynchronous operations here
+    return await asyncFuctnion();
+  }
+
+  async setValueAsync(newValue) {
+    // Perform asynchronous operations here
+    await asyncFuctnion();
+    this._value = newValue;
+  }
+}
+```

--- a/docs/errors/E0714.md
+++ b/docs/errors/E0714.md
@@ -21,7 +21,7 @@ class C {
 ```
 
 To fix this error simply remove 'async' keyword from getters and setters, 
-so they can function properly as synchronous operations
+so they can function properly as synchronous operations.
 
 
 ```javascript
@@ -41,7 +41,7 @@ class C {
 ```
 
 However, if you require asynchronous behavior within getters or setters, 
-you can achieve this by implementing separate asynchronous methods
+you can achieve this by implementing separate asynchronous methods.
 
 
 ```javascript

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -2057,6 +2057,14 @@ msgstr ""
 msgid "missing ',' between array elements"
 msgstr ""
 
+#: src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
+msgid "'*' keyword is not allowed on getters or setters"
+msgstr ""
+
+#: src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
+msgid "'async' keyword is not allowed on getters or setters"
+msgstr ""
+
 #: test/test-diagnostic-formatter.cpp
 #: test/test-vim-qflist-json-diag-reporter.cpp
 msgid "something happened"

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -2058,7 +2058,7 @@ msgid "missing ',' between array elements"
 msgstr ""
 
 #: src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
-msgid "'*' keyword is not allowed on getters or setters"
+msgid "getters and setters cannot be generators"
 msgstr ""
 
 #: src/quick-lint-js/diag/diagnostic-metadata-generated.cpp

--- a/src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
+++ b/src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
@@ -6325,6 +6325,42 @@ const QLJS_CONSTINIT Diagnostic_Info all_diagnostic_infos[] = {
         },
       },
     },
+
+    // Diag_Class_Generator_On_Getter_Or_Setter
+    {
+      .code = 713,
+      .severity = Diagnostic_Severity::error,
+      .message_formats = {
+        QLJS_TRANSLATABLE("'*' keyword is not allowed on getters or setters"),
+        QLJS_TRANSLATABLE("'{0}' here"),
+      },
+      .message_args = {
+        {
+          Diagnostic_Message_Arg_Info(offsetof(Diag_Class_Generator_On_Getter_Or_Setter, generator_keyword), Diagnostic_Arg_Type::source_code_span),
+        },
+        {
+          Diagnostic_Message_Arg_Info(offsetof(Diag_Class_Generator_On_Getter_Or_Setter, getter_setter_keyword), Diagnostic_Arg_Type::source_code_span),
+        },
+      },
+    },
+
+    // Diag_Class_Async_On_Getter_Or_Setter
+    {
+      .code = 714,
+      .severity = Diagnostic_Severity::error,
+      .message_formats = {
+        QLJS_TRANSLATABLE("'async' keyword is not allowed on getters or setters"),
+        QLJS_TRANSLATABLE("'{0}' here"),
+      },
+      .message_args = {
+        {
+          Diagnostic_Message_Arg_Info(offsetof(Diag_Class_Async_On_Getter_Or_Setter, async_keyword), Diagnostic_Arg_Type::source_code_span),
+        },
+        {
+          Diagnostic_Message_Arg_Info(offsetof(Diag_Class_Async_On_Getter_Or_Setter, getter_setter_keyword), Diagnostic_Arg_Type::source_code_span),
+        },
+      },
+    },
 };
 }
 

--- a/src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
+++ b/src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
@@ -6331,12 +6331,12 @@ const QLJS_CONSTINIT Diagnostic_Info all_diagnostic_infos[] = {
       .code = 713,
       .severity = Diagnostic_Severity::error,
       .message_formats = {
-        QLJS_TRANSLATABLE("'*' keyword is not allowed on getters or setters"),
+        QLJS_TRANSLATABLE("getters and setters cannot be generators"),
         QLJS_TRANSLATABLE("'{0}' here"),
       },
       .message_args = {
         {
-          Diagnostic_Message_Arg_Info(offsetof(Diag_Class_Generator_On_Getter_Or_Setter, generator_keyword), Diagnostic_Arg_Type::source_code_span),
+          Diagnostic_Message_Arg_Info(offsetof(Diag_Class_Generator_On_Getter_Or_Setter, star_token), Diagnostic_Arg_Type::source_code_span),
         },
         {
           Diagnostic_Message_Arg_Info(offsetof(Diag_Class_Generator_On_Getter_Or_Setter, getter_setter_keyword), Diagnostic_Arg_Type::source_code_span),

--- a/src/quick-lint-js/diag/diagnostic-metadata-generated.h
+++ b/src/quick-lint-js/diag/diagnostic-metadata-generated.h
@@ -434,10 +434,12 @@ namespace quick_lint_js {
   QLJS_DIAG_TYPE_NAME(Diag_Xor_Used_As_Exponentiation) \
   QLJS_DIAG_TYPE_NAME(Diag_Expected_Expression_In_Template_Literal) \
   QLJS_DIAG_TYPE_NAME(Diag_Missing_Comma_Between_Array_Elements) \
+  QLJS_DIAG_TYPE_NAME(Diag_Class_Generator_On_Getter_Or_Setter) \
+  QLJS_DIAG_TYPE_NAME(Diag_Class_Async_On_Getter_Or_Setter) \
   /* END */
 // clang-format on
 
-inline constexpr int Diag_Type_Count = 423;
+inline constexpr int Diag_Type_Count = 425;
 
 extern const Diagnostic_Info all_diagnostic_infos[Diag_Type_Count];
 }

--- a/src/quick-lint-js/diag/diagnostic-types-2.h
+++ b/src/quick-lint-js/diag/diagnostic-types-2.h
@@ -3261,6 +3261,26 @@ struct Diag_Missing_Comma_Between_Array_Elements {
                   ARG(expected_comma))]]  //
   Source_Code_Span expected_comma;
 };
+
+struct Diag_Class_Generator_On_Getter_Or_Setter {
+  [[qljs::diag("E0713", Diagnostic_Severity::error)]]  //
+  [[qljs::message("'*' keyword is not allowed on getters or setters",
+                  ARG(generator_keyword))]]                    //
+  [[qljs::message("'{0}' here", ARG(getter_setter_keyword))]]  //
+  Source_Code_Span method_start;
+  Source_Code_Span generator_keyword;
+  Source_Code_Span getter_setter_keyword;
+};
+
+struct Diag_Class_Async_On_Getter_Or_Setter {
+  [[qljs::diag("E0714", Diagnostic_Severity::error)]]  //
+  [[qljs::message("'async' keyword is not allowed on getters or setters",
+                  ARG(async_keyword))]]                        //
+  [[qljs::message("'{0}' here", ARG(getter_setter_keyword))]]  //
+  Source_Code_Span method_start;
+  Source_Code_Span async_keyword;
+  Source_Code_Span getter_setter_keyword;
+};
 }
 QLJS_WARNING_POP
 

--- a/src/quick-lint-js/diag/diagnostic-types-2.h
+++ b/src/quick-lint-js/diag/diagnostic-types-2.h
@@ -3264,11 +3264,10 @@ struct Diag_Missing_Comma_Between_Array_Elements {
 
 struct Diag_Class_Generator_On_Getter_Or_Setter {
   [[qljs::diag("E0713", Diagnostic_Severity::error)]]  //
-  [[qljs::message("'*' keyword is not allowed on getters or setters",
-                  ARG(generator_keyword))]]                    //
+  [[qljs::message("getters and setters cannot be generators",
+                  ARG(star_token))]]                           //
   [[qljs::message("'{0}' here", ARG(getter_setter_keyword))]]  //
-  Source_Code_Span method_start;
-  Source_Code_Span generator_keyword;
+  Source_Code_Span star_token;
   Source_Code_Span getter_setter_keyword;
 };
 
@@ -3277,7 +3276,6 @@ struct Diag_Class_Async_On_Getter_Or_Setter {
   [[qljs::message("'async' keyword is not allowed on getters or setters",
                   ARG(async_keyword))]]                        //
   [[qljs::message("'{0}' here", ARG(getter_setter_keyword))]]  //
-  Source_Code_Span method_start;
   Source_Code_Span async_keyword;
   Source_Code_Span getter_setter_keyword;
 };

--- a/src/quick-lint-js/fe/parse-class.cpp
+++ b/src/quick-lint-js/fe/parse-class.cpp
@@ -1155,6 +1155,8 @@ void Parser::parse_and_visit_class_or_interface_member(
     void check_modifiers_for_method() {
       error_if_accessor_method();
       error_if_declare_method();
+      error_if_generator_method();
+      error_if_async_method();
       error_if_readonly_method();
       error_if_async_or_generator_without_method_body();
       error_if_invalid_access_specifier();
@@ -1321,6 +1323,47 @@ void Parser::parse_and_visit_class_or_interface_member(
         p->diag_reporter_->report(Diag_TypeScript_Declare_Method{
             .declare_keyword = declare_modifier->span,
         });
+      }
+    }
+
+    void error_if_generator_method() {
+      if (const Modifier *star_modifier = find_modifier(Token_Type::star)) {
+        Source_Code_Span method_start = p->peek().span();
+        if (const Modifier *get_modifier = find_modifier(Token_Type::kw_get)) {
+          p->diag_reporter_->report(Diag_Class_Generator_On_Getter_Or_Setter{
+              .method_start = method_start,
+              .generator_keyword = star_modifier->span,
+              .getter_setter_keyword = get_modifier->span,
+          });
+        } else if (const Modifier *set_modifier =
+                       find_modifier(Token_Type::kw_set)) {
+          p->diag_reporter_->report(Diag_Class_Generator_On_Getter_Or_Setter{
+              .method_start = method_start,
+              .generator_keyword = star_modifier->span,
+              .getter_setter_keyword = set_modifier->span,
+          });
+        }
+      }
+    }
+
+    void error_if_async_method() {
+      if (const Modifier *async_modifier =
+              find_modifier(Token_Type::kw_async)) {
+        Source_Code_Span method_start = p->peek().span();
+        if (const Modifier *get_modifier = find_modifier(Token_Type::kw_get)) {
+          p->diag_reporter_->report(Diag_Class_Async_On_Getter_Or_Setter{
+              .method_start = method_start,
+              .async_keyword = async_modifier->span,
+              .getter_setter_keyword = get_modifier->span,
+          });
+        } else if (const Modifier *set_modifier =
+                       find_modifier(Token_Type::kw_set)) {
+          p->diag_reporter_->report(Diag_Class_Async_On_Getter_Or_Setter{
+              .method_start = method_start,
+              .async_keyword = async_modifier->span,
+              .getter_setter_keyword = set_modifier->span,
+          });
+        }
       }
     }
 

--- a/src/quick-lint-js/fe/parse-class.cpp
+++ b/src/quick-lint-js/fe/parse-class.cpp
@@ -1155,8 +1155,8 @@ void Parser::parse_and_visit_class_or_interface_member(
     void check_modifiers_for_method() {
       error_if_accessor_method();
       error_if_declare_method();
-      error_if_generator_method();
-      error_if_async_method();
+      error_if_generator_getter_or_setter();
+      error_if_async_getter_or_setter();
       error_if_readonly_method();
       error_if_async_or_generator_without_method_body();
       error_if_invalid_access_specifier();
@@ -1326,40 +1326,34 @@ void Parser::parse_and_visit_class_or_interface_member(
       }
     }
 
-    void error_if_generator_method() {
+    void error_if_generator_getter_or_setter() {
       if (const Modifier *star_modifier = find_modifier(Token_Type::star)) {
-        Source_Code_Span method_start = p->peek().span();
         if (const Modifier *get_modifier = find_modifier(Token_Type::kw_get)) {
           p->diag_reporter_->report(Diag_Class_Generator_On_Getter_Or_Setter{
-              .method_start = method_start,
-              .generator_keyword = star_modifier->span,
+              .star_token = star_modifier->span,
               .getter_setter_keyword = get_modifier->span,
           });
         } else if (const Modifier *set_modifier =
                        find_modifier(Token_Type::kw_set)) {
           p->diag_reporter_->report(Diag_Class_Generator_On_Getter_Or_Setter{
-              .method_start = method_start,
-              .generator_keyword = star_modifier->span,
+              .star_token = star_modifier->span,
               .getter_setter_keyword = set_modifier->span,
           });
         }
       }
     }
 
-    void error_if_async_method() {
+    void error_if_async_getter_or_setter() {
       if (const Modifier *async_modifier =
               find_modifier(Token_Type::kw_async)) {
-        Source_Code_Span method_start = p->peek().span();
         if (const Modifier *get_modifier = find_modifier(Token_Type::kw_get)) {
           p->diag_reporter_->report(Diag_Class_Async_On_Getter_Or_Setter{
-              .method_start = method_start,
               .async_keyword = async_modifier->span,
               .getter_setter_keyword = get_modifier->span,
           });
         } else if (const Modifier *set_modifier =
                        find_modifier(Token_Type::kw_set)) {
           p->diag_reporter_->report(Diag_Class_Async_On_Getter_Or_Setter{
-              .method_start = method_start,
               .async_keyword = async_modifier->span,
               .getter_setter_keyword = set_modifier->span,
           });

--- a/src/quick-lint-js/i18n/translation-table-generated.cpp
+++ b/src/quick-lint-js/i18n/translation-table-generated.cpp
@@ -18,7 +18,8 @@ const Translation_Table translation_data = {
         {74, 87, 79, 56, 0, 59},             //
         {71, 80, 60, 58, 0, 52},             //
         {0, 0, 0, 0, 0, 28},                 //
-        {31, 56, 0, 32, 0, 63},              //
+        {0, 0, 0, 0, 0, 63},                 //
+        {31, 56, 0, 32, 0, 49},              //
         {0, 0, 0, 0, 0, 67},                 //
         {0, 0, 0, 70, 0, 26},                //
         {79, 25, 30, 63, 49593, 66},         //
@@ -40,7 +41,8 @@ const Translation_Table translation_data = {
         {0, 0, 0, 100, 0, 89},               //
         {0, 0, 0, 0, 0, 24},                 //
         {50, 77, 41, 27, 0, 60},             //
-        {70, 31, 69, 53, 0, 60},             //
+        {0, 0, 0, 0, 0, 60},                 //
+        {70, 31, 69, 53, 0, 53},             //
         {93, 15, 80, 68, 26, 69},            //
         {0, 0, 0, 0, 0, 43},                 //
         {0, 0, 0, 0, 0, 44},                 //
@@ -1805,6 +1807,7 @@ const Translation_Table translation_data = {
         u8"\"globals\" descriptor must be a boolean or an object\0"
         u8"\"globals\" must be an object\0"
         u8"'!' here treated as the TypeScript non-null assertion operator\0"
+        u8"'*' keyword is not allowed on getters or setters\0"
         u8"'**' operator cannot be used after unary '{1}' without parentheses\0"
         u8"',' should be ';' instead\0"
         u8"'.' is not allowed after generic arguments; write [\"{1}\"] instead\0"
@@ -1827,6 +1830,7 @@ const Translation_Table translation_data = {
         u8"'as const' located here\0"
         u8"'async export' is not allowed; write 'export async' instead\0"
         u8"'async static' is not allowed; write 'static async' instead\0"
+        u8"'async' keyword is not allowed on getters or setters\0"
         u8"'await' cannot be followed by an arrow function; use 'async' instead\0"
         u8"'await' is only allowed in async functions\0"
         u8"'declare class' cannot contain static block\0"

--- a/src/quick-lint-js/i18n/translation-table-generated.cpp
+++ b/src/quick-lint-js/i18n/translation-table-generated.cpp
@@ -18,8 +18,7 @@ const Translation_Table translation_data = {
         {74, 87, 79, 56, 0, 59},             //
         {71, 80, 60, 58, 0, 52},             //
         {0, 0, 0, 0, 0, 28},                 //
-        {0, 0, 0, 0, 0, 63},                 //
-        {31, 56, 0, 32, 0, 49},              //
+        {31, 56, 0, 32, 0, 63},              //
         {0, 0, 0, 0, 0, 67},                 //
         {0, 0, 0, 70, 0, 26},                //
         {79, 25, 30, 63, 49593, 66},         //
@@ -284,6 +283,7 @@ const Translation_Table translation_data = {
         {84, 28, 66, 75, 25, 54},            //
         {0, 0, 0, 70, 0, 52},                //
         {0, 0, 0, 0, 0, 45},                 //
+        {0, 0, 0, 0, 0, 41},                 //
         {70, 27, 0, 57, 0, 52},              //
         {0, 0, 0, 5, 0, 5},                  //
         {5, 11, 66, 52, 54, 42},             //
@@ -1807,7 +1807,6 @@ const Translation_Table translation_data = {
         u8"\"globals\" descriptor must be a boolean or an object\0"
         u8"\"globals\" must be an object\0"
         u8"'!' here treated as the TypeScript non-null assertion operator\0"
-        u8"'*' keyword is not allowed on getters or setters\0"
         u8"'**' operator cannot be used after unary '{1}' without parentheses\0"
         u8"',' should be ';' instead\0"
         u8"'.' is not allowed after generic arguments; write [\"{1}\"] instead\0"
@@ -2072,6 +2071,7 @@ const Translation_Table translation_data = {
         u8"generator function '*' belongs after keyword function\0"
         u8"generator function '*' belongs before function name\0"
         u8"generic arrow function needs ',' here in TSX\0"
+        u8"getters and setters cannot be generators\0"
         u8"getters and setters cannot have overload signatures\0"
         u8"here\0"
         u8"here is the assignment assertion operator\0"

--- a/src/quick-lint-js/i18n/translation-table-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-generated.h
@@ -18,8 +18,8 @@ namespace quick_lint_js {
 using namespace std::literals::string_view_literals;
 
 constexpr std::uint32_t translation_table_locale_count = 5;
-constexpr std::uint16_t translation_table_mapping_table_size = 516;
-constexpr std::size_t translation_table_string_table_size = 79639;
+constexpr std::uint16_t translation_table_mapping_table_size = 518;
+constexpr std::size_t translation_table_string_table_size = 79741;
 constexpr std::size_t translation_table_locale_table_size = 35;
 
 QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
@@ -33,6 +33,7 @@ QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
           "\"globals\" descriptor must be a boolean or an object"sv,
           "\"globals\" must be an object"sv,
           "'!' here treated as the TypeScript non-null assertion operator"sv,
+          "'*' keyword is not allowed on getters or setters"sv,
           "'**' operator cannot be used after unary '{1}' without parentheses"sv,
           "',' should be ';' instead"sv,
           "'.' is not allowed after generic arguments; write [\"{1}\"] instead"sv,
@@ -55,6 +56,7 @@ QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
           "'as const' located here"sv,
           "'async export' is not allowed; write 'export async' instead"sv,
           "'async static' is not allowed; write 'static async' instead"sv,
+          "'async' keyword is not allowed on getters or setters"sv,
           "'await' cannot be followed by an arrow function; use 'async' instead"sv,
           "'await' is only allowed in async functions"sv,
           "'declare class' cannot contain static block"sv,

--- a/src/quick-lint-js/i18n/translation-table-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-generated.h
@@ -19,7 +19,7 @@ using namespace std::literals::string_view_literals;
 
 constexpr std::uint32_t translation_table_locale_count = 5;
 constexpr std::uint16_t translation_table_mapping_table_size = 518;
-constexpr std::size_t translation_table_string_table_size = 79741;
+constexpr std::size_t translation_table_string_table_size = 79733;
 constexpr std::size_t translation_table_locale_table_size = 35;
 
 QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
@@ -33,7 +33,6 @@ QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
           "\"globals\" descriptor must be a boolean or an object"sv,
           "\"globals\" must be an object"sv,
           "'!' here treated as the TypeScript non-null assertion operator"sv,
-          "'*' keyword is not allowed on getters or setters"sv,
           "'**' operator cannot be used after unary '{1}' without parentheses"sv,
           "',' should be ';' instead"sv,
           "'.' is not allowed after generic arguments; write [\"{1}\"] instead"sv,
@@ -298,6 +297,7 @@ QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
           "generator function '*' belongs after keyword function"sv,
           "generator function '*' belongs before function name"sv,
           "generic arrow function needs ',' here in TSX"sv,
+          "getters and setters cannot be generators"sv,
           "getters and setters cannot have overload signatures"sv,
           "here"sv,
           "here is the assignment assertion operator"sv,

--- a/src/quick-lint-js/i18n/translation-table-test-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-test-generated.h
@@ -27,7 +27,7 @@ struct Translated_String {
 };
 
 // clang-format off
-inline const Translated_String test_translation_table[515] = {
+inline const Translated_String test_translation_table[517] = {
     {
         "\"global-groups\" entries must be strings"_translatable,
         u8"\"global-groups\" entries must be strings",
@@ -103,6 +103,17 @@ inline const Translated_String test_translation_table[515] = {
             u8"'!' here treated as the TypeScript non-null assertion operator",
             u8"'!' here treated as the TypeScript non-null assertion operator",
             u8"'!' here treated as the TypeScript non-null assertion operator",
+        },
+    },
+    {
+        "'*' keyword is not allowed on getters or setters"_translatable,
+        u8"'*' keyword is not allowed on getters or setters",
+        {
+            u8"'*' keyword is not allowed on getters or setters",
+            u8"'*' keyword is not allowed on getters or setters",
+            u8"'*' keyword is not allowed on getters or setters",
+            u8"'*' keyword is not allowed on getters or setters",
+            u8"'*' keyword is not allowed on getters or setters",
         },
     },
     {
@@ -345,6 +356,17 @@ inline const Translated_String test_translation_table[515] = {
             u8"'async static' n'est pas autoris\u00e9 ; utiliser plut\u00f4t 'static async'",
             u8"'async static' n\u00e3o \u00e9 permitido; use 'static async'",
             u8"'async static' is not allowed; write 'static async' instead",
+        },
+    },
+    {
+        "'async' keyword is not allowed on getters or setters"_translatable,
+        u8"'async' keyword is not allowed on getters or setters",
+        {
+            u8"'async' keyword is not allowed on getters or setters",
+            u8"'async' keyword is not allowed on getters or setters",
+            u8"'async' keyword is not allowed on getters or setters",
+            u8"'async' keyword is not allowed on getters or setters",
+            u8"'async' keyword is not allowed on getters or setters",
         },
     },
     {

--- a/src/quick-lint-js/i18n/translation-table-test-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-test-generated.h
@@ -106,17 +106,6 @@ inline const Translated_String test_translation_table[517] = {
         },
     },
     {
-        "'*' keyword is not allowed on getters or setters"_translatable,
-        u8"'*' keyword is not allowed on getters or setters",
-        {
-            u8"'*' keyword is not allowed on getters or setters",
-            u8"'*' keyword is not allowed on getters or setters",
-            u8"'*' keyword is not allowed on getters or setters",
-            u8"'*' keyword is not allowed on getters or setters",
-            u8"'*' keyword is not allowed on getters or setters",
-        },
-    },
-    {
         "'**' operator cannot be used after unary '{1}' without parentheses"_translatable,
         u8"'**' operator cannot be used after unary '{1}' without parentheses",
         {
@@ -3018,6 +3007,17 @@ inline const Translated_String test_translation_table[517] = {
             u8"generic arrow function needs ',' here in TSX",
             u8"aqui no TSX, uma arrow function gen\u00e9rica precisa de ','",
             u8"generic arrow function needs ',' here in TSX",
+        },
+    },
+    {
+        "getters and setters cannot be generators"_translatable,
+        u8"getters and setters cannot be generators",
+        {
+            u8"getters and setters cannot be generators",
+            u8"getters and setters cannot be generators",
+            u8"getters and setters cannot be generators",
+            u8"getters and setters cannot be generators",
+            u8"getters and setters cannot be generators",
         },
     },
     {

--- a/test/test-parse-class.cpp
+++ b/test/test-parse-class.cpp
@@ -836,6 +836,48 @@ TEST_F(Test_Parse_Class, accessor_cannot_be_method) {
       javascript_options);
 }
 
+TEST_F(Test_Parse_Class, async_keyword_on_getters_and_setters) {
+  test_parse_and_visit_statement(
+      u8"class C { get async myMethod() { } }"_sv,  //
+      u8"                            ^ Diag_Class_Async_On_Getter_Or_Setter.method_start\n"_diag
+      u8"              ^^^^^ .async_keyword\n"_diag
+      u8"          ^^^ .getter_setter_keyword"_diag,
+      javascript_options);
+  test_parse_and_visit_statement(
+      u8"class C { set async myMethod() { } }"_sv,  //
+      u8"                            ^ Diag_Class_Async_On_Getter_Or_Setter.method_start\n"_diag
+      u8"              ^^^^^ .async_keyword\n"_diag
+      u8"          ^^^ .getter_setter_keyword"_diag,
+      javascript_options);
+  test_parse_and_visit_statement(
+      u8"class C { async get myMethod() { } }"_sv,  //
+      u8"                            ^ Diag_Class_Async_On_Getter_Or_Setter.method_start\n"_diag
+      u8"                ^^^ .getter_setter_keyword\n"_diag
+      u8"          ^^^^^ .async_keyword"_diag,
+      javascript_options);
+  test_parse_and_visit_statement(
+      u8"class C { async set myMethod() { } }"_sv,  //
+      u8"                            ^ Diag_Class_Async_On_Getter_Or_Setter.method_start\n"_diag
+      u8"                ^^^ .getter_setter_keyword\n"_diag
+      u8"          ^^^^^ .async_keyword"_diag,
+      javascript_options);
+}
+
+TEST_F(Test_Parse_Class, getters_and_setters_cannot_be_generator) {
+  test_parse_and_visit_statement(
+      u8"class C { get *myMethod() { } }"_sv,  //
+      u8"                       ^ Diag_Class_Generator_On_Getter_Or_Setter.method_start\n"_diag
+      u8"              ^ .generator_keyword\n"_diag
+      u8"          ^^^ .getter_setter_keyword"_diag,
+      javascript_options);
+  test_parse_and_visit_statement(
+      u8"class C { set *myMethod() { } }"_sv,  //
+      u8"                       ^ Diag_Class_Generator_On_Getter_Or_Setter.method_start\n"_diag
+      u8"              ^ .generator_keyword\n"_diag
+      u8"          ^^^ .getter_setter_keyword"_diag,
+      javascript_options);
+}
+
 TEST_F(Test_Parse_Class, class_methods_should_not_use_function_keyword) {
   {
     Spy_Visitor p = test_parse_and_visit_statement(

--- a/test/test-parse-class.cpp
+++ b/test/test-parse-class.cpp
@@ -839,26 +839,22 @@ TEST_F(Test_Parse_Class, accessor_cannot_be_method) {
 TEST_F(Test_Parse_Class, async_keyword_on_getters_and_setters) {
   test_parse_and_visit_statement(
       u8"class C { get async myMethod() { } }"_sv,  //
-      u8"                            ^ Diag_Class_Async_On_Getter_Or_Setter.method_start\n"_diag
-      u8"              ^^^^^ .async_keyword\n"_diag
+      u8"              ^^^^^ Diag_Class_Async_On_Getter_Or_Setter.async_keyword\n"_diag
       u8"          ^^^ .getter_setter_keyword"_diag,
       javascript_options);
   test_parse_and_visit_statement(
       u8"class C { set async myMethod() { } }"_sv,  //
-      u8"                            ^ Diag_Class_Async_On_Getter_Or_Setter.method_start\n"_diag
-      u8"              ^^^^^ .async_keyword\n"_diag
+      u8"              ^^^^^ Diag_Class_Async_On_Getter_Or_Setter.async_keyword\n"_diag
       u8"          ^^^ .getter_setter_keyword"_diag,
       javascript_options);
   test_parse_and_visit_statement(
       u8"class C { async get myMethod() { } }"_sv,  //
-      u8"                            ^ Diag_Class_Async_On_Getter_Or_Setter.method_start\n"_diag
-      u8"                ^^^ .getter_setter_keyword\n"_diag
+      u8"                ^^^ Diag_Class_Async_On_Getter_Or_Setter.getter_setter_keyword\n"_diag
       u8"          ^^^^^ .async_keyword"_diag,
       javascript_options);
   test_parse_and_visit_statement(
       u8"class C { async set myMethod() { } }"_sv,  //
-      u8"                            ^ Diag_Class_Async_On_Getter_Or_Setter.method_start\n"_diag
-      u8"                ^^^ .getter_setter_keyword\n"_diag
+      u8"                ^^^ Diag_Class_Async_On_Getter_Or_Setter.getter_setter_keyword\n"_diag
       u8"          ^^^^^ .async_keyword"_diag,
       javascript_options);
 }
@@ -866,14 +862,12 @@ TEST_F(Test_Parse_Class, async_keyword_on_getters_and_setters) {
 TEST_F(Test_Parse_Class, getters_and_setters_cannot_be_generator) {
   test_parse_and_visit_statement(
       u8"class C { get *myMethod() { } }"_sv,  //
-      u8"                       ^ Diag_Class_Generator_On_Getter_Or_Setter.method_start\n"_diag
-      u8"              ^ .generator_keyword\n"_diag
+      u8"              ^ Diag_Class_Generator_On_Getter_Or_Setter.star_token\n"_diag
       u8"          ^^^ .getter_setter_keyword"_diag,
       javascript_options);
   test_parse_and_visit_statement(
       u8"class C { set *myMethod() { } }"_sv,  //
-      u8"                       ^ Diag_Class_Generator_On_Getter_Or_Setter.method_start\n"_diag
-      u8"              ^ .generator_keyword\n"_diag
+      u8"              ^ Diag_Class_Generator_On_Getter_Or_Setter.star_token\n"_diag
       u8"          ^^^ .getter_setter_keyword"_diag,
       javascript_options);
 }


### PR DESCRIPTION
closes #1066 

Can you check new tests? Did I place them right and do they need ```Spy_Visitor``` with ```EXPECT_THAT(p.visits, ...)```?
And what do you think about code repetition (```error_if_generator_method```, ```error_if_async_method```)? Looks like this is the only clean solution without compromising readability