### PR TITLE
fix(fe): don't report missing `else` for bad `if` expression

### DIFF
--- a/src/quick-lint-js/fe/parse.h
+++ b/src/quick-lint-js/fe/parse.h
@@ -1172,7 +1172,7 @@ void Parser::parse_and_visit_parenthesized_expression(
 
   const Char8 *expression_begin = this->peek().begin;
 
-  Expression *ast = this->parse_expression(v);
+  Expression *ast = this->parse_expression(v, {.trailing_identifiers = true});
   this->visit_expression(ast, v, Variable_Context::rhs);
 
   if constexpr (check_for_sketchy_conditions) {

--- a/test/test-parse.cpp
+++ b/test/test-parse.cpp
@@ -320,8 +320,9 @@ TEST_F(Test_Parse, utter_garbage) {
     assert_diagnostics(
         p.code, p.errors,
         {
-            u8"   ^ Diag_Expected_Parentheses_Around_If_Condition"_diag,  //
-            u8"   ^ Diag_Unexpected_Token"_diag,
+            u8"   ^ Diag_Unexpected_Token"_diag,  // :
+            u8"      ^^^^^^^^ Diag_Unexpected_Identifier_In_Expression"_diag,  // kjaslkjd
+            u8"   ^^^^^^^^^^^ Diag_Expected_Parentheses_Around_If_Condition"_diag,  // :\nkjaskljd
         });
   }
 }


### PR DESCRIPTION
This one line change (potentially) closes #1008. However, test `Test_Parse.utter_garbage` fails -- despite my edits. I don't understand the reason it fails either. To me, it appears like the conditions the test asserts hold true.

The issue provides this snippet of code.
```javascript
function DataNotLoadedError() {}
const e = new DataNotLoadedError();

if (e isntanceof DataNotLoadedError) {
} else {
  throw e;
}
```

For convenience, the CLI version of quick-lint-js behaves like so _before_ this change for the snippet of code provided in the issue.
```sh
$ ~/code/quick-lint-js/build/quick-lint-js x.js 
x.js:4:6: error: if statement is missing ')' around condition [E0018]
x.js:4:17: error: missing semicolon after statement [E0027]
x.js:4:36: error: unmatched parenthesis [E0056]
x.js:7:1: error: 'else' has no corresponding 'if' [E0065]
x.js:4:7: warning: use of undeclared variable: isntanceof [E0057]
```

With the change, it behaves like this.
```sh
$ ~/code/quick-lint-js-fork/build/quick-lint-js x.js 
x.js:4:7: error: unexpected identifier in expression; missing operator before [E0147]
x.js:4:18: error: unexpected identifier in expression; missing operator before [E0147]
x.js:4:7: warning: use of undeclared variable: isntanceof [E0057]
```

For test `Test_Parse.utter_garbage` that it currently fails, the program produces this output.
```
Value of: diagnostics
Expected: has 3 elements and there exists some permutation of elements such that:
 - element #0 has type Diag_Unexpected_Token, and
 - element #1 has type Diag_Unexpected_Identifier_In_Expression, and
 - element #2 has type Diag_Expected_Parentheses_Around_If_Condition
  Actual: { Diag_Unexpected_Token, Diag_Unexpected_Identifier_In_Expression, Diag_Expected_Parentheses_Around_If_Condition }, where the following matchers don't match any elements:
matcher #1: has type Diag_Unexpected_Identifier_In_Expression,
matcher #2: has type Diag_Expected_Parentheses_Around_If_Condition
and where the following elements don't match any matchers:
element #1: Diag_Unexpected_Identifier_In_Expression,
element #2: Diag_Expected_Parentheses_Around_If_Condition
```
But it appears like all the expected diagnoses appear in the actual results, no? A element corresponds to each matcher.