### PR TITLE
feat(website): update macOS build instructions

### DIFF
--- a/website/public/contribute/build-from-source/macos/index.ejs.html
+++ b/website/public/contribute/build-from-source/macos/index.ejs.html
@@ -63,7 +63,7 @@
   CXX=clang++ \
   CPPFLAGS=&quot;-I$(brew --prefix)/opt/llvm/include&quot; \
   CXXFLAGS=-D_LIBCPP_DISABLE_AVAILABILITY \
-  LDFLAGS=&quot;-L$(brew --prefix)/opt/llvm/lib&quot; \
+  LDFLAGS=&quot;-L$(brew --prefix)/opt/llvm/lib -L$(brew --prefix)/opt/llvm/lib/c++&quot; \
   cmake -G Ninja -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_BUILD_TYPE=Debug -S . -B build</kbd></code></pre>
         </blockquote>
 


### PR DESCRIPTION
I updated the macOS instructions for building from source.

I had a few linker errors when I first tried building from source, and after a bit of debugging I realized that [Homebrew's LLVM formula installs `libc++` in `$(brew --previx)/llvm/lib/c++`](https://github.com/Homebrew/homebrew-core/commit/d3999fcadc162f4f55b3237d5636ef3e6355738a). Updating `LDFLAGS` fixed the build.
