### PR TITLE
fix(typescript): report E0429 for class 'extends' clause

### DIFF
--- a/po/messages.pot
+++ b/po/messages.pot
@@ -78,6 +78,10 @@ msgid "class 'implements' clause"
 msgstr ""
 
 #: src/quick-lint-js/diag/diagnostic-formatter.cpp
+msgid "class 'extends' clause"
+msgstr ""
+
+#: src/quick-lint-js/diag/diagnostic-formatter.cpp
 msgid "interface 'extends' clause"
 msgstr ""
 
@@ -111,6 +115,10 @@ msgstr ""
 
 #: src/quick-lint-js/diag/diagnostic-formatter.cpp
 msgid "a class's 'implements' clause"
+msgstr ""
+
+#: src/quick-lint-js/diag/diagnostic-formatter.cpp
+msgid "a class's 'extends' clause"
 msgstr ""
 
 #: src/quick-lint-js/diag/diagnostic-formatter.cpp

--- a/src/quick-lint-js/diag/diagnostic-formatter.cpp
+++ b/src/quick-lint-js/diag/diagnostic-formatter.cpp
@@ -48,6 +48,8 @@ Translatable_Message headlinese_statement_kind(Statement_Kind sk) {
     return QLJS_TRANSLATABLE("labelled statement");
   case Statement_Kind::class_implements_clause:
     return QLJS_TRANSLATABLE("class 'implements' clause");
+  case Statement_Kind::class_extends_clause:
+    return QLJS_TRANSLATABLE("class 'extends' clause");
   case Statement_Kind::interface_extends_clause:
     return QLJS_TRANSLATABLE("interface 'extends' clause");
   case Statement_Kind::typeof_type:
@@ -72,6 +74,8 @@ Translatable_Message singular_statement_kind(Statement_Kind sk) {
     return QLJS_TRANSLATABLE("a labelled statement");
   case Statement_Kind::class_implements_clause:
     return QLJS_TRANSLATABLE("a class's 'implements' clause");
+  case Statement_Kind::class_extends_clause:
+    return QLJS_TRANSLATABLE("a class's 'extends' clause");
   case Statement_Kind::interface_extends_clause:
     return QLJS_TRANSLATABLE("an interface's 'extends' clause");
   case Statement_Kind::typeof_type:

--- a/src/quick-lint-js/fe/language-debug.cpp
+++ b/src/quick-lint-js/fe/language-debug.cpp
@@ -20,6 +20,7 @@ std::ostream& operator<<(std::ostream& out, Statement_Kind kind) {
     QLJS_CASE(with_statement)
     QLJS_CASE(labelled_statement)
     QLJS_CASE(class_implements_clause)
+    QLJS_CASE(class_extends_clause)
     QLJS_CASE(interface_extends_clause)
     QLJS_CASE(typeof_type)
   }

--- a/src/quick-lint-js/fe/language.h
+++ b/src/quick-lint-js/fe/language.h
@@ -18,6 +18,7 @@ enum class Statement_Kind {
   labelled_statement,
 
   class_implements_clause,
+  class_extends_clause,
   interface_extends_clause,
   typeof_type,
 };

--- a/src/quick-lint-js/i18n/translation-table-generated.cpp
+++ b/src/quick-lint-js/i18n/translation-table-generated.cpp
@@ -163,6 +163,7 @@ const Translation_Table translation_data = {
         {20, 16, 0, 16, 0, 15},              //
         {20, 40, 63, 23, 66, 19},            //
         {0, 0, 0, 0, 0, 61},                 //
+        {0, 0, 0, 0, 0, 27},                 //
         {0, 0, 0, 0, 0, 30},                 //
         {67, 28, 78, 78, 61, 40},            //
         {0, 0, 0, 62, 0, 64},                //
@@ -219,6 +220,7 @@ const Translation_Table translation_data = {
         {72, 31, 71, 68, 56, 61},            //
         {34, 30, 0, 46, 0, 40},              //
         {0, 0, 0, 0, 0, 18},                 //
+        {0, 0, 0, 0, 0, 23},                 //
         {0, 0, 0, 20, 0, 26},                //
         {20, 12, 47, 37, 44, 29},            //
         {47, 34, 39, 35, 0, 30},             //
@@ -1974,6 +1976,7 @@ const Translation_Table translation_data = {
         u8"a 'while' loop\0"
         u8"a 'with' statement\0"
         u8"a class statement is not allowed as the body of {1:singular}\0"
+        u8"a class's 'extends' clause\0"
         u8"a class's 'implements' clause\0"
         u8"a decorator exists here before 'export'\0"
         u8"a function statement is not allowed as the body of {1:singular}\0"
@@ -2030,6 +2033,7 @@ const Translation_Table translation_data = {
         u8"catch variable can only be typed as '*', 'any', or 'unknown'\0"
         u8"character is not allowed in identifiers\0"
         u8"children end here\0"
+        u8"class 'extends' clause\0"
         u8"class 'implements' clause\0"
         u8"class is not marked abstract\0"
         u8"classes cannot be named 'let'\0"

--- a/src/quick-lint-js/i18n/translation-table-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-generated.h
@@ -18,8 +18,8 @@ namespace quick_lint_js {
 using namespace std::literals::string_view_literals;
 
 constexpr std::uint32_t translation_table_locale_count = 5;
-constexpr std::uint16_t translation_table_mapping_table_size = 541;
-constexpr std::size_t translation_table_string_table_size = 80778;
+constexpr std::uint16_t translation_table_mapping_table_size = 543;
+constexpr std::size_t translation_table_string_table_size = 80828;
 constexpr std::size_t translation_table_locale_table_size = 35;
 
 QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
@@ -177,6 +177,7 @@ QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
           "a 'while' loop"sv,
           "a 'with' statement"sv,
           "a class statement is not allowed as the body of {1:singular}"sv,
+          "a class's 'extends' clause"sv,
           "a class's 'implements' clause"sv,
           "a decorator exists here before 'export'"sv,
           "a function statement is not allowed as the body of {1:singular}"sv,
@@ -233,6 +234,7 @@ QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
           "catch variable can only be typed as '*', 'any', or 'unknown'"sv,
           "character is not allowed in identifiers"sv,
           "children end here"sv,
+          "class 'extends' clause"sv,
           "class 'implements' clause"sv,
           "class is not marked abstract"sv,
           "classes cannot be named 'let'"sv,

--- a/src/quick-lint-js/i18n/translation-table-test-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-test-generated.h
@@ -27,7 +27,7 @@ struct Translated_String {
 };
 
 // clang-format off
-inline const Translated_String test_translation_table[540] = {
+inline const Translated_String test_translation_table[542] = {
     {
         "\"global-groups\" entries must be strings"_translatable,
         u8"\"global-groups\" entries must be strings",
@@ -1690,6 +1690,17 @@ inline const Translated_String test_translation_table[540] = {
         },
     },
     {
+        "a class's 'extends' clause"_translatable,
+        u8"a class's 'extends' clause",
+        {
+            u8"a class's 'extends' clause",
+            u8"a class's 'extends' clause",
+            u8"a class's 'extends' clause",
+            u8"a class's 'extends' clause",
+            u8"a class's 'extends' clause",
+        },
+    },
+    {
         "a class's 'implements' clause"_translatable,
         u8"a class's 'implements' clause",
         {
@@ -2303,6 +2314,17 @@ inline const Translated_String test_translation_table[540] = {
             u8"children end here",
             u8"os n\u00f3s acabam aqui",
             u8"children end here",
+        },
+    },
+    {
+        "class 'extends' clause"_translatable,
+        u8"class 'extends' clause",
+        {
+            u8"class 'extends' clause",
+            u8"class 'extends' clause",
+            u8"class 'extends' clause",
+            u8"class 'extends' clause",
+            u8"class 'extends' clause",
         },
     },
     {

--- a/test/quick-lint-js/diagnostic-assertion.cpp
+++ b/test/quick-lint-js/diagnostic-assertion.cpp
@@ -553,6 +553,7 @@ std::optional<Statement_Kind> try_parse_statement_kind(String8_View s) {
   QLJS_CASE(with_statement)
   QLJS_CASE(labelled_statement)
   QLJS_CASE(class_implements_clause)
+  QLJS_CASE(class_extends_clause)
   QLJS_CASE(interface_extends_clause)
   QLJS_CASE(typeof_type)
   return std::nullopt;

--- a/test/test-parse-typescript-class.cpp
+++ b/test/test-parse-typescript-class.cpp
@@ -1546,7 +1546,6 @@ TEST_F(Test_Parse_TypeScript_Class, implement_multiple_things) {
               ElementsAreArray({u8"Apple", u8"Banana", u8"Carrot"}));
 }
 
-// TODO(#1114): Report the same diagnostic for 'extends'.
 TEST_F(Test_Parse_TypeScript_Class,
        implements_generic_with_arrow_type_requires_space) {
   {
@@ -1571,6 +1570,33 @@ TEST_F(Test_Parse_TypeScript_Class,
         ElementsAreArray({generic_param_decl(u8"T"), class_decl(u8"C")}));
     EXPECT_THAT(p.variable_uses,
                 ElementsAreArray({u8"I", u8"ReturnType", u8"T"}));
+  }
+}
+
+TEST_F(Test_Parse_TypeScript_Class,
+       extends_generic_with_arrow_type_requires_space) {
+  {
+    Spy_Visitor p = test_parse_and_visit_module(
+        u8"export class C extends I<<T>() => ReturnType<T>> {}"_sv,  //
+        u8"                         ` Diag_TypeScript_Generic_Less_Less_Not_Split.expected_space"_diag
+        u8"{.context=Statement_Kind::class_extends_clause}"_diag,
+        typescript_options);
+    EXPECT_THAT(
+        p.variable_declarations,
+        ElementsAreArray({generic_param_decl(u8"T"), class_decl(u8"C")}));
+    EXPECT_THAT(p.variable_uses,
+                ElementsAreArray({u8"ReturnType", u8"T", u8"I"}));
+  }
+
+  {
+    Spy_Visitor p = test_parse_and_visit_module(
+        u8"export class C extends I< <T>() => ReturnType<T>> {}"_sv, no_diags,
+        typescript_options);
+    EXPECT_THAT(
+        p.variable_declarations,
+        ElementsAreArray({generic_param_decl(u8"T"), class_decl(u8"C")}));
+    EXPECT_THAT(p.variable_uses,
+                ElementsAreArray({u8"ReturnType", u8"T", u8"I"}));
   }
 }
 


### PR DESCRIPTION
This closes #1114.

It matches functionality of `implements` and `interface ... extends` by reporting an error when the user defines a class that uses a generic within an `extends` clause without a space between `<` like so `<<`.

For clarity, quick-lint-js reports an error in the following snippet that uses `<<`.
```
export class D<T> {}
export class D2 extends D<<U>() => number> {}
```

quick-lint-js does _not_ report an error in this snippet since it uses `< <`.
```
export class D<T> {}
export class D2 extends D< <U>() => number> {}
```