### PR TITLE
fix(typescript): fix cyclic type false positive

### DIFF
--- a/src/quick-lint-js/fe/parse-statement.cpp
+++ b/src/quick-lint-js/fe/parse-statement.cpp
@@ -3215,7 +3215,9 @@ void Parser::parse_and_visit_typescript_type_alias(
   this->skip();
 
   v.visit_enter_type_alias_scope();
+  bool had_generic_arguments = false;
   if (this->peek().type == Token_Type::less) {
+    had_generic_arguments = true;
     this->parse_and_visit_typescript_generic_parameters(v);
   }
   QLJS_PARSER_UNIMPLEMENTED_IF_NOT_TOKEN(Token_Type::equal);
@@ -3226,6 +3228,7 @@ void Parser::parse_and_visit_typescript_type_alias(
           .type_being_declared = TypeScript_Type_Parse_Options::Declaring_Type{
               .name = name,
               .kind = kind,
+              .has_generic_arguments = had_generic_arguments,
           }});
   v.visit_exit_type_alias_scope();
 

--- a/src/quick-lint-js/fe/parse.h
+++ b/src/quick-lint-js/fe/parse.h
@@ -206,11 +206,13 @@ class Parser {
     struct Declaring_Type {
       Identifier name;
       Variable_Kind kind;
+      bool has_generic_arguments = false;
     };
 
     std::optional<Declaring_Type> type_being_declared = std::nullopt;
     bool parse_question_as_invalid = true;
     bool allow_parenthesized_type = true;
+    bool allow_circular_reference = false;
     // If false, assertion predicates and type predicates are parsed but a
     // diagnostic is reported.
     bool allow_assertion_signature_or_type_predicate = false;

--- a/test/test-parse-typescript-type-alias.cpp
+++ b/test/test-parse-typescript-type-alias.cpp
@@ -126,6 +126,20 @@ TEST_F(Test_Parse_TypeScript_Type_Alias,
                                  typescript_options);
   test_parse_and_visit_statement(u8"type T = <U>(param: T) => number;"_sv,
                                  no_diags, typescript_options);
+  test_parse_and_visit_statement(u8"type T = Array<number | T>;"_sv, no_diags,
+                                 typescript_options);
+  test_parse_and_visit_statement(u8"type T<U> = Array<T<U>>;"_sv, no_diags,
+                                 typescript_options);
+  test_parse_and_visit_statement(u8"type T<U> = T<U>[];"_sv, no_diags,
+                                 typescript_options);
+  test_parse_and_visit_statement(u8"type T = string | [string, { [key: string]: any }, ...T[]];"_sv, no_diags,
+                                 typescript_options);
+  test_parse_and_visit_statement(u8"type Last<T extends Array<any>> = T extends [infer Head] ? Head : T extends [infer _, ...infer Tail] ? Last<Tail> : unknown;"_sv, no_diags,
+                                 typescript_options);
+  test_parse_and_visit_statement(u8"type T<U> = U extends infer V ? T<V> : unknown;"_sv, no_diags,
+                                 typescript_options);
+  test_parse_and_visit_statement(u8"type T<U> = [U, T<number>];"_sv, no_diags,
+                                 typescript_options);
 
   // NOTE(strager): These are not a reference of type 'T', but they look like
   // they are.
@@ -199,6 +213,12 @@ TEST_F(Test_Parse_TypeScript_Type_Alias, type_alias_cannot_be_directly_cyclic) {
   test_parse_and_visit_statement(
       u8"type T<U> = T<number>;"_sv,
       u8"            ^ Diag_Cyclic_TypeScript_Type_Definition.use\n"_diag
+      u8"     ^ .declaration"_diag
+      u8"{.kind=Variable_Kind::_type_alias}"_diag,
+      typescript_options);
+  test_parse_and_visit_statement(
+      u8"type T<U> = U | T<number>;"_sv,
+      u8"                ^ Diag_Cyclic_TypeScript_Type_Definition.use\n"_diag
       u8"     ^ .declaration"_diag
       u8"{.kind=Variable_Kind::_type_alias}"_diag,
       typescript_options);


### PR DESCRIPTION
This fixes a false positive that was reported when linting recursive type definitions such as these:

```ts
type Last<T extends Array<any>> =
  T extends [infer Head] ?
    Head :
    T extends [infer _, ...infer Tail] ?
      Last<Tail> :
      unknown;
```