### PR TITLE
fix(typescript): interface properties can be keywords followed by a type

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -69,6 +69,7 @@ Semantic Versioning.
   * `T extends () => RT ? A : B` no longer falsely reports [E0348][] ("invalid
     usage of ? as a prefix or suffix in the a type " expression").
   * `<T extends />` is now correctly parsed as a JSX element.
+  * `interface I { get: any }` no longer reports [E0054][] ("unexpected token").
 
 ## 2.18.0 (2023-11-03)
 

--- a/src/quick-lint-js/fe/parse-class.cpp
+++ b/src/quick-lint-js/fe/parse-class.cpp
@@ -578,9 +578,11 @@ void Parser::parse_and_visit_class_or_interface_member(
       // async?() {}
       // class C { get }  // Field named 'get'
       // get = init;
+      // set: any
       case Token_Type::equal:
       case Token_Type::question:
       case Token_Type::right_curly:
+      case Token_Type::colon:
         if (!this->overload_signatures.empty()) {
           // class C { method(); }  // Invalid.
           this->error_on_overload_signatures();

--- a/test/test-parse-typescript-interface.cpp
+++ b/test/test-parse-typescript-interface.cpp
@@ -837,6 +837,15 @@ TEST_F(Test_Parse_TypeScript_Interface, interface_with_keyword_property) {
         p.parse_and_visit_statement();
         EXPECT_THAT(p.property_declarations, ElementsAreArray({keyword}));
       }
+
+      {
+        Test_Parser p(
+            concat(u8"interface I { "_sv, keyword, suffix, u8": any; }"_sv),
+            typescript_options);
+        SCOPED_TRACE(p.code);
+        p.parse_and_visit_statement();
+        EXPECT_THAT(p.property_declarations, ElementsAreArray({keyword}));
+      }
     }
 
     for (String8_View keyword : strict_reserved_keywords) {


### PR DESCRIPTION
This fixes an `E0054` (unexpected token) error that was reported whenever an interface property matched a keyword followed by a type.

For example, 
```ts
interface I { get: any }
```
is valid TypeScript, but quick-lint-js was reporting: 

```sh
/test.ts:1:18: error: unexpected token [E0054]
```