### PR TITLE
feat: new diag for using ‘.’ after ‘?.’

### DIFF
--- a/docs/errors/E0717.md
+++ b/docs/errors/E0717.md
@@ -7,40 +7,18 @@
 }
 ```
 
-In Javascript, the `?.` operator performs a conditional access only if the left-hand side is not `null` or `undefined`. If the left-hand side is `null` or `undefined`, the expression returns `undefined` and the right-hand side is not evaluated. Using it suppresses the error that would otherwise be thrown if the left-hand side were `null` or `undefined` and the operator `.` were used instead. However, if the left-hand side is not `null` or `undefined`, the expression returns the value of the right-hand side, which may be `null` or `undefined`. If the right-hand side is `null` or `undefined`, using the `.` operator will throw an error:
+In JavaScript, `x?.y` ignores `y` and returns `undefined` if `x` is `null` or `undefined`. If `?.` returns `undefined`, then using `.` after will throw an error:
 
 ```js
-let a = { b: 1 };
-let b = a?.b; // ok
-let c = a?.b?.a; // ok
-let d = a?.b?.a.c; // throws an error
-```
-
-In the example above, the last statement will throw an error, because `a.b` is not `null` or `undefined`, but `a.b.a` is `undefined`, and `undefined.c` throws an error.
-
-This also affects optional chaining with function calls (`?.()`):
-
-```js
-let _a = (_arg) => {
-  return; // so returns undefined
-};
-
-let e = _a?.(a)?.(_a)?.(a); // ok
-let f = _a?.(a).b; // throws an error since _a(a) is undefined
-```
-
-and optional chaining with index expressions (`?.[]`) for the same reason:
-
-```js
-let g = [1, [2, { a: 3 }]];
-let h = g?.[1]; // ok
-let j = g?.[1]?.[2].b; // throws an error since g[1][2] is undefined
+let bug = { milestone: null  };
+console.log(bug.milestone);               // null
+console.log(bug.milestone?.name);         // undefined
+console.log(bug.milestone?.name.trim());  // throws an error
 ```
 
 Replacing the `.` with `?.` will prevent the errors from being thrown at runtime:
 
 ```js
-let d = a?.b?.a?.c; // ok
-let f = _a?.(a)?.b; // ok
-let j = g?.[1]?.[2]?.b; // ok
+let bug = { milestone: null  };
+console.log(bug.milestone?.name?.trim());  // undefined
 ```

--- a/docs/errors/E0717.md
+++ b/docs/errors/E0717.md
@@ -1,0 +1,46 @@
+# E0717: using a '.' after a '?.' might fail, since '?.' might return 'undefined'
+
+```config-for-examples
+{
+  "globals": {
+  }
+}
+```
+
+In Javascript, the `?.` operator performs a conditional access only if the left-hand side is not `null` or `undefined`. If the left-hand side is `null` or `undefined`, the expression returns `undefined` and the right-hand side is not evaluated. Using it suppresses the error that would otherwise be thrown if the left-hand side were `null` or `undefined` and the operator `.` were used instead. However, if the left-hand side is not `null` or `undefined`, the expression returns the value of the right-hand side, which may be `null` or `undefined`. If the right-hand side is `null` or `undefined`, using the `.` operator will throw an error:
+
+```js
+let a = { b: 1 };
+let b = a?.b; // ok
+let c = a?.b?.a; // ok
+let d = a?.b?.a.c; // throws an error
+```
+
+In the example above, the last statement will throw an error, because `a.b` is not `null` or `undefined`, but `a.b.a` is `undefined`, and `undefined.c` throws an error.
+
+This also affects optional chaining with function calls (`?.()`):
+
+```js
+let _a = (_arg) => {
+  return; // so returns undefined
+};
+
+let e = _a?.(a)?.(_a)?.(a); // ok
+let f = _a?.(a).b; // throws an error since _a(a) is undefined
+```
+
+and optional chaining with index expressions (`?.[]`) for the same reason:
+
+```js
+let g = [1, [2, { a: 3 }]];
+let h = g?.[1]; // ok
+let j = g?.[1]?.[2].b; // throws an error since g[1][2] is undefined
+```
+
+Replacing the `.` with `?.` will prevent the errors from being thrown at runtime:
+
+```js
+let d = a?.b?.a?.c; // ok
+let f = _a?.(a)?.b; // ok
+let j = g?.[1]?.[2]?.b; // ok
+```

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -2357,6 +2357,10 @@ msgstr ""
 msgid "'&' here"
 msgstr ""
 
+#: src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
+msgid "using a '{0}' after a '{1}' might fail, since '{1}' might return 'undefined'."
+msgstr ""
+
 #: test/test-diagnostic-formatter.cpp
 #: test/test-vim-qflist-json-diag-reporter.cpp
 msgid "something happened"

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -2358,7 +2358,7 @@ msgid "'&' here"
 msgstr ""
 
 #: src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
-msgid "using a '{0}' after a '{1}' might fail, since '{1}' might return 'undefined'."
+msgid "using a '.' after a '?.' might fail, since '?.' might return 'undefined'."
 msgstr ""
 
 #: test/test-diagnostic-formatter.cpp

--- a/src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
+++ b/src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
@@ -6722,6 +6722,21 @@ const QLJS_CONSTINIT Diagnostic_Info all_diagnostic_infos[] = {
         },
       },
     },
+
+    // Diag_Using_Dot_After_Optional_Chaining
+    {
+      .code = 717,
+      .severity = Diagnostic_Severity::warning,
+      .message_formats = {
+        QLJS_TRANSLATABLE("using a '{0}' after a '{1}' might fail, since '{1}' might return 'undefined'."),
+      },
+      .message_args = {
+        {
+          Diagnostic_Message_Arg_Info(offsetof(Diag_Using_Dot_After_Optional_Chaining, dot_op), Diagnostic_Arg_Type::source_code_span),
+          Diagnostic_Message_Arg_Info(offsetof(Diag_Using_Dot_After_Optional_Chaining, optional_chain_op), Diagnostic_Arg_Type::source_code_span),
+        },
+      },
+    },
 };
 }
 

--- a/src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
+++ b/src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
@@ -6728,7 +6728,7 @@ const QLJS_CONSTINIT Diagnostic_Info all_diagnostic_infos[] = {
       .code = 717,
       .severity = Diagnostic_Severity::warning,
       .message_formats = {
-        QLJS_TRANSLATABLE("using a '{0}' after a '{1}' might fail, since '{1}' might return 'undefined'."),
+        QLJS_TRANSLATABLE("using a '.' after a '?.' might fail, since '?.' might return 'undefined'."),
       },
       .message_args = {
         {

--- a/src/quick-lint-js/diag/diagnostic-metadata-generated.h
+++ b/src/quick-lint-js/diag/diagnostic-metadata-generated.h
@@ -459,10 +459,11 @@ namespace quick_lint_js {
   QLJS_DIAG_TYPE_NAME(Diag_Class_Async_On_Getter_Or_Setter) \
   QLJS_DIAG_TYPE_NAME(Diag_Multiple_Export_Defaults) \
   QLJS_DIAG_TYPE_NAME(Diag_Unintuitive_Bitshift_Precedence) \
+  QLJS_DIAG_TYPE_NAME(Diag_Using_Dot_After_Optional_Chaining) \
   /* END */
 // clang-format on
 
-inline constexpr int Diag_Type_Count = 448;
+inline constexpr int Diag_Type_Count = 449;
 
 extern const Diagnostic_Info all_diagnostic_infos[Diag_Type_Count];
 }

--- a/src/quick-lint-js/diag/diagnostic-types-2.h
+++ b/src/quick-lint-js/diag/diagnostic-types-2.h
@@ -3488,8 +3488,8 @@ struct Diag_Unintuitive_Bitshift_Precedence {
 
 struct Diag_Using_Dot_After_Optional_Chaining {
   [[qljs::diag("E0717", Diagnostic_Severity::warning)]]
-  [[qljs::message("using a '{0}' after a '{1}' might fail, "
-                  "since '{1}' might return 'undefined'.",
+  [[qljs::message("using a '.' after a '?.' might fail, "
+                  "since '?.' might return 'undefined'.",
                   ARG(dot_op), ARG(optional_chain_op))]]
   Source_Code_Span dot_op;
   Source_Code_Span optional_chain_op;

--- a/src/quick-lint-js/diag/diagnostic-types-2.h
+++ b/src/quick-lint-js/diag/diagnostic-types-2.h
@@ -3485,6 +3485,15 @@ struct Diag_Unintuitive_Bitshift_Precedence {
   Source_Code_Span bitshift_operator;
   Source_Code_Span and_operator;
 };
+
+struct Diag_Using_Dot_After_Optional_Chaining {
+  [[qljs::diag("E0717", Diagnostic_Severity::warning)]]
+  [[qljs::message("using a '{0}' after a '{1}' might fail, "
+                  "since '{1}' might return 'undefined'.",
+                  ARG(dot_op), ARG(optional_chain_op))]]
+  Source_Code_Span dot_op;
+  Source_Code_Span optional_chain_op;
+};
 }
 QLJS_WARNING_POP
 

--- a/src/quick-lint-js/fe/expression.h
+++ b/src/quick-lint-js/fe/expression.h
@@ -612,11 +612,13 @@ class Expression::Call final : public Expression {
   static constexpr Expression_Kind kind = Expression_Kind::Call;
 
   explicit Call(Expression_Arena::Array_Ptr<Expression *> children,
-                Source_Code_Span left_paren_span, const Char8 *span_end)
+                Source_Code_Span left_paren_span, const Char8 *span_end,
+                std::optional<Source_Code_Span> optional_chaining_op_)
       : Expression(kind),
         call_left_paren_begin_(left_paren_span.begin()),
         span_end_(span_end),
-        children_(children) {
+        children_(children),
+        optional_chaining_operator_(optional_chaining_op_) {
     QLJS_ASSERT(left_paren_span.size() == 1);
   }
 
@@ -628,6 +630,7 @@ class Expression::Call final : public Expression {
   const Char8 *call_left_paren_begin_;
   const Char8 *span_end_;
   Expression_Arena::Array_Ptr<Expression *> children_;
+  std::optional<Source_Code_Span> optional_chaining_operator_;
 };
 static_assert(Expression_Arena::is_allocatable<Expression::Call>);
 
@@ -647,11 +650,12 @@ class Expression::Dot final : public Expression {
  public:
   static constexpr Expression_Kind kind = Expression_Kind::Dot;
 
-  explicit Dot(Expression *lhs, Identifier rhs)
-      : Expression(kind), variable_identifier_(rhs), child_(lhs) {}
+  explicit Dot(Expression *lhs, Identifier rhs, Source_Code_Span op_span)
+      : Expression(kind), variable_identifier_(rhs), child_(lhs), operator_span_(op_span) {}
 
   Identifier variable_identifier_;
   Expression *child_;
+  Source_Code_Span operator_span_;
 };
 static_assert(Expression_Arena::is_allocatable<Expression::Dot>);
 
@@ -682,15 +686,18 @@ class Expression::Index final : public Expression {
   static constexpr Expression_Kind kind = Expression_Kind::Index;
 
   explicit Index(Expression *container, Expression *subscript,
-                 Source_Code_Span left_square_span, const Char8 *subscript_end)
+                 Source_Code_Span left_square_span, const Char8 *subscript_end,
+                std::optional<Source_Code_Span> optional_chaining_op_)
       : Expression(kind),
         index_subscript_end_(subscript_end),
         left_square_span(left_square_span),
-        children_{container, subscript} {}
+        children_{container, subscript},
+        optional_chaining_operator_(optional_chaining_op_) {}
 
   const Char8 *index_subscript_end_;
   Source_Code_Span left_square_span;
   std::array<Expression *, 2> children_;
+  std::optional<Source_Code_Span> optional_chaining_operator_;
 };
 static_assert(Expression_Arena::is_allocatable<Expression::Index>);
 

--- a/src/quick-lint-js/fe/parse-expression.cpp
+++ b/src/quick-lint-js/fe/parse-expression.cpp
@@ -960,7 +960,7 @@ Expression* Parser::parse_async_expression_only(
           this->expressions_.make_array(std::move(call_children)),
           /*left_paren_span=*/left_paren_span,
           /*span_end=*/right_paren_span.end(),
-          /*optional_chaining_op_=*/std::nullopt);
+          /*optional_chaining_op=*/std::nullopt);
       return call_ast;
     } else if (is_await) {
       // await is an operator.
@@ -2616,7 +2616,7 @@ Expression* Parser::parse_arrow_function_expression_remainder(
 
 Expression::Call* Parser::parse_call_expression_remainder(Parse_Visitor_Base& v,
                                                           Expression* callee,
-                                                          std::optional<Source_Code_Span> optional_chaining_op_) {
+                                                          std::optional<Source_Code_Span> optional_chaining_op) {
   Source_Code_Span left_paren_span = this->peek().span();
   Expression_Arena::Vector<Expression*> call_children(
       "parse_expression_remainder call children",
@@ -2658,12 +2658,12 @@ Expression::Call* Parser::parse_call_expression_remainder(Parse_Visitor_Base& v,
           this->expressions_.make_array(std::move(call_children)),
           /*left_paren_span=*/left_paren_span,
           /*span_end=*/call_span_end,
-          /*optional_chaining_op=*/optional_chaining_op_));
+          /*optional_chaining_op=*/optional_chaining_op));
 }
 
 Expression* Parser::parse_index_expression_remainder(Parse_Visitor_Base& v,
                                                      Expression* lhs,
-                                                     std::optional<Source_Code_Span> optional_chaining_op_) {
+                                                     std::optional<Source_Code_Span> optional_chaining_op) {
   QLJS_ASSERT(this->peek().type == Token_Type::left_square);
   Source_Code_Span left_square_span = this->peek().span();
   this->skip();
@@ -2692,7 +2692,7 @@ Expression* Parser::parse_index_expression_remainder(Parse_Visitor_Base& v,
   }
   return this->make_expression<Expression::Index>(lhs, subscript,
                                                   left_square_span, end,
-                                                  optional_chaining_op_);
+                                                  optional_chaining_op);
 }
 
 Expression_Arena::Vector<Expression*>

--- a/src/quick-lint-js/fe/parse-expression.cpp
+++ b/src/quick-lint-js/fe/parse-expression.cpp
@@ -171,6 +171,8 @@ void Parser::visit_expression(Expression* ast, Parse_Visitor_Base& v,
     break;
   case Expression_Kind::Dot:
     this->visit_expression(ast->child_0(), v, Variable_Context::rhs);
+    this->warn_on_dot_operator_after_optional_chain(
+        expression_cast<Expression::Dot*>(ast));
     break;
   case Expression_Kind::Index:
     this->visit_expression(ast->child_0(), v, Variable_Context::rhs);
@@ -957,7 +959,8 @@ Expression* Parser::parse_async_expression_only(
       Expression* call_ast = this->make_expression<Expression::Call>(
           this->expressions_.make_array(std::move(call_children)),
           /*left_paren_span=*/left_paren_span,
-          /*span_end=*/right_paren_span.end());
+          /*span_end=*/right_paren_span.end(),
+          /*optional_chaining_op_=*/std::nullopt);
       return call_ast;
     } else if (is_await) {
       // await is an operator.
@@ -1636,7 +1639,7 @@ next:
               .func_start = func_start_span});
     }
     Expression* callee = binary_builder.last_expression();
-    Expression::Call* call = this->parse_call_expression_remainder(v, callee);
+    Expression::Call* call = this->parse_call_expression_remainder(v, callee, std::nullopt);
     binary_builder.replace_last(call);
 
     if (this->peek().type == Token_Type::equal_greater) {
@@ -1734,7 +1737,7 @@ next:
             });
       }
       binary_builder.replace_last(this->make_expression<Expression::Dot>(
-          binary_builder.last_expression(), this->peek().identifier_name()));
+          binary_builder.last_expression(), this->peek().identifier_name(), dot_span));
       this->skip();
       goto next;
 
@@ -1765,7 +1768,7 @@ next:
     case Token_Type::semicolon: {
       Source_Code_Span empty_property_name(dot_span.end(), dot_span.end());
       binary_builder.replace_last(this->make_expression<Expression::Dot>(
-          binary_builder.last_expression(), Identifier(empty_property_name)));
+          binary_builder.last_expression(), Identifier(empty_property_name), dot_span));
       this->diag_reporter_->report(Diag_Missing_Property_Name_For_Dot_Operator{
           .dot = dot_span,
       });
@@ -1799,6 +1802,7 @@ next:
   // array?.[index]
   // f?.(x, y)
   case Token_Type::question_dot: {
+    Source_Code_Span question_dot_span = this->peek().span();
     this->skip();
     switch (this->peek().type) {
     // x?.y
@@ -1807,7 +1811,7 @@ next:
     case Token_Type::reserved_keyword_with_escape_sequence:
     QLJS_CASE_KEYWORD:
       binary_builder.replace_last(this->make_expression<Expression::Dot>(
-          binary_builder.last_expression(), this->peek().identifier_name()));
+          binary_builder.last_expression(), this->peek().identifier_name(), question_dot_span));
       this->skip();
       goto next;
 
@@ -1822,7 +1826,8 @@ next:
     // f?.(x, y)
     case Token_Type::left_paren:
       binary_builder.replace_last(this->parse_call_expression_remainder(
-          v, binary_builder.last_expression()));
+          v, binary_builder.last_expression(), 
+          std::optional<Source_Code_Span>(question_dot_span)));
       goto next;
 
     // f?.<T>(x, y)                      // TypeScript only
@@ -1838,13 +1843,13 @@ next:
       }
       this->parse_and_visit_typescript_generic_arguments(v);
       binary_builder.replace_last(this->parse_call_expression_remainder(
-          v, binary_builder.last_expression()));
+          v, binary_builder.last_expression(), std::nullopt));
       goto next;
 
     // array?.[index]
     case Token_Type::left_square:
       binary_builder.replace_last(this->parse_index_expression_remainder(
-          v, binary_builder.last_expression()));
+          v, binary_builder.last_expression(), std::optional<Source_Code_Span>(question_dot_span)));
       goto next;
 
     default:
@@ -1857,7 +1862,7 @@ next:
   // o[key]  // Indexing expression.
   case Token_Type::left_square: {
     binary_builder.replace_last(this->parse_index_expression_remainder(
-        v, binary_builder.last_expression()));
+        v, binary_builder.last_expression(), std::nullopt));
     goto next;
   }
 
@@ -2610,7 +2615,8 @@ Expression* Parser::parse_arrow_function_expression_remainder(
 }
 
 Expression::Call* Parser::parse_call_expression_remainder(Parse_Visitor_Base& v,
-                                                          Expression* callee) {
+                                                          Expression* callee,
+                                                          std::optional<Source_Code_Span> optional_chaining_op_) {
   Source_Code_Span left_paren_span = this->peek().span();
   Expression_Arena::Vector<Expression*> call_children(
       "parse_expression_remainder call children",
@@ -2651,11 +2657,13 @@ Expression::Call* Parser::parse_call_expression_remainder(Parse_Visitor_Base& v,
       this->make_expression<Expression::Call>(
           this->expressions_.make_array(std::move(call_children)),
           /*left_paren_span=*/left_paren_span,
-          /*span_end=*/call_span_end));
+          /*span_end=*/call_span_end,
+          /*optional_chaining_op=*/optional_chaining_op_));
 }
 
 Expression* Parser::parse_index_expression_remainder(Parse_Visitor_Base& v,
-                                                     Expression* lhs) {
+                                                     Expression* lhs,
+                                                     std::optional<Source_Code_Span> optional_chaining_op_) {
   QLJS_ASSERT(this->peek().type == Token_Type::left_square);
   Source_Code_Span left_square_span = this->peek().span();
   this->skip();
@@ -2683,7 +2691,8 @@ Expression* Parser::parse_index_expression_remainder(Parse_Visitor_Base& v,
     break;
   }
   return this->make_expression<Expression::Index>(lhs, subscript,
-                                                  left_square_span, end);
+                                                  left_square_span, end,
+                                                  optional_chaining_op_);
 }
 
 Expression_Arena::Vector<Expression*>

--- a/src/quick-lint-js/fe/parse-statement.cpp
+++ b/src/quick-lint-js/fe/parse-statement.cpp
@@ -2917,6 +2917,7 @@ void Parser::parse_and_visit_decorator(Parse_Visitor_Base &v) {
     this->skip();
 
     while (this->peek().type == Token_Type::dot) {
+      Source_Code_Span op_span_ = this->peek().span();
       this->skip();
       switch (this->peek().type) {
       // @myNamespace.myDecorator
@@ -2924,7 +2925,7 @@ void Parser::parse_and_visit_decorator(Parse_Visitor_Base &v) {
       case Token_Type::identifier:
       case Token_Type::private_identifier:
         ast = this->make_expression<Expression::Dot>(
-            ast, this->peek().identifier_name());
+            ast, this->peek().identifier_name(), op_span_);
         this->skip();
         break;
 
@@ -2937,7 +2938,7 @@ void Parser::parse_and_visit_decorator(Parse_Visitor_Base &v) {
     if (this->peek().type == Token_Type::left_paren) {
       // @decorator()
       // @decorator(arg1, arg2)
-      ast = this->parse_call_expression_remainder(v, ast);
+      ast = this->parse_call_expression_remainder(v, ast, std::nullopt);
     }
 
     this->visit_expression(ast, v, Variable_Context::rhs);

--- a/src/quick-lint-js/fe/parse.cpp
+++ b/src/quick-lint-js/fe/parse.cpp
@@ -469,7 +469,7 @@ void Parser::error_on_invalid_as_const(Expression* ast,
 void Parser::warn_on_dot_operator_after_optional_chain(
     Expression::Dot *ast) {
   Expression *lhs = ast->child_;
-  Source_Code_Span operator_span_ = ast->operator_span_;
+  Source_Code_Span operator_span = ast->operator_span_;
   auto is_optional_chain = [](String8_View s) -> bool {
     return s[0] == u8'?';
   };
@@ -477,7 +477,7 @@ void Parser::warn_on_dot_operator_after_optional_chain(
   // we know the current node is a dot operator. 
   // If it is a '.' and its parent is a '?.' or a '?.(' or a '?.['
   // then we can report a warning
-  if (!is_optional_chain(operator_span_.string_view())) {
+  if (!is_optional_chain(operator_span.string_view())) {
     switch (lhs->kind()) {
     case Expression_Kind::Dot: {
       auto lhs_dot = expression_cast<Expression::Dot*>(lhs);
@@ -485,7 +485,7 @@ void Parser::warn_on_dot_operator_after_optional_chain(
       if (is_optional_chain(lhs_operator_span.string_view())) {
         this->diag_reporter_->report(
             Diag_Using_Dot_After_Optional_Chaining {
-                .dot_op = operator_span_,
+                .dot_op = operator_span,
                 .optional_chain_op = lhs_operator_span,
             });
       }
@@ -497,7 +497,7 @@ void Parser::warn_on_dot_operator_after_optional_chain(
       if (lhs_operator_span.has_value()) {
         this->diag_reporter_->report(
             Diag_Using_Dot_After_Optional_Chaining {
-                .dot_op = operator_span_,
+                .dot_op = operator_span,
                 .optional_chain_op = *lhs_operator_span,
             });
       }
@@ -509,13 +509,14 @@ void Parser::warn_on_dot_operator_after_optional_chain(
       if (lhs_operator_span.has_value()) {
         this->diag_reporter_->report(
             Diag_Using_Dot_After_Optional_Chaining {
-                .dot_op = operator_span_,
+                .dot_op = operator_span,
                 .optional_chain_op = *lhs_operator_span,
             });
       }
       break;
     }
-    default: { /* do nothing */ }
+    default:
+      break;
     }
   }
 }

--- a/src/quick-lint-js/fe/parse.cpp
+++ b/src/quick-lint-js/fe/parse.cpp
@@ -466,6 +466,60 @@ void Parser::error_on_invalid_as_const(Expression* ast,
   }
 }
 
+void Parser::warn_on_dot_operator_after_optional_chain(
+    Expression::Dot *ast) {
+  Expression *lhs = ast->child_;
+  Source_Code_Span operator_span_ = ast->operator_span_;
+  auto is_optional_chain = [](String8_View s) -> bool {
+    return s[0] == u8'?';
+  };
+
+  // we know the current node is a dot operator. 
+  // If it is a '.' and its parent is a '?.' or a '?.(' or a '?.['
+  // then we can report a warning
+  if (!is_optional_chain(operator_span_.string_view())) {
+    switch (lhs->kind()) {
+    case Expression_Kind::Dot: {
+      auto lhs_dot = expression_cast<Expression::Dot*>(lhs);
+      Source_Code_Span lhs_operator_span = lhs_dot->operator_span_;
+      if (is_optional_chain(lhs_operator_span.string_view())) {
+        this->diag_reporter_->report(
+            Diag_Using_Dot_After_Optional_Chaining {
+                .dot_op = operator_span_,
+                .optional_chain_op = lhs_operator_span,
+            });
+      }
+      break;
+    }
+    case Expression_Kind::Call: {
+      auto lhs_call = expression_cast<Expression::Call*>(lhs);
+      std::optional<Source_Code_Span> lhs_operator_span = lhs_call->optional_chaining_operator_;
+      if (lhs_operator_span.has_value()) {
+        this->diag_reporter_->report(
+            Diag_Using_Dot_After_Optional_Chaining {
+                .dot_op = operator_span_,
+                .optional_chain_op = *lhs_operator_span,
+            });
+      }
+      break;
+    }
+    case Expression_Kind::Index: {
+      auto lhs_index = expression_cast<Expression::Index*>(lhs);
+      std::optional<Source_Code_Span> lhs_operator_span = lhs_index->optional_chaining_operator_;
+      if (lhs_operator_span.has_value()) {
+        this->diag_reporter_->report(
+            Diag_Using_Dot_After_Optional_Chaining {
+                .dot_op = operator_span_,
+                .optional_chain_op = *lhs_operator_span,
+            });
+      }
+      break;
+    }
+    default: { /* do nothing */ }
+    }
+  }
+}
+
 void Parser::warn_on_xor_operator_as_exponentiation(
     Expression::Binary_Operator* ast) {
   auto is_xor_operator = [](String8_View s) -> bool { return s == u8"^"_sv; };

--- a/src/quick-lint-js/fe/parse.h
+++ b/src/quick-lint-js/fe/parse.h
@@ -555,6 +555,7 @@ class Parser {
   void warn_on_comma_operator_in_conditional_statement(Expression *);
   void warn_on_comma_operator_in_index(Expression *, Source_Code_Span);
   void warn_on_xor_operator_as_exponentiation(Expression::Binary_Operator *);
+  void warn_on_dot_operator_after_optional_chain(Expression::Dot *);
   void warn_on_unintuitive_bitshift_precedence(Expression *ast);
   void error_on_pointless_string_compare(Expression::Binary_Operator *);
   void error_on_pointless_compare_against_literal(
@@ -819,9 +820,11 @@ class Parser {
       Expression *parameters_expression, Buffering_Visitor *return_type_visits,
       Precedence);
   Expression::Call *parse_call_expression_remainder(Parse_Visitor_Base &,
-                                                    Expression *callee);
+                                                    Expression *callee,
+                                               std::optional<Source_Code_Span>);
   Expression *parse_index_expression_remainder(Parse_Visitor_Base &,
-                                               Expression *lhs);
+                                               Expression *lhs,
+                                               std::optional<Source_Code_Span>);
   Expression_Arena::Vector<Expression *>
   parse_arrow_function_parameters_or_call_arguments(Parse_Visitor_Base &v);
   Expression *parse_arrow_function_body(

--- a/src/quick-lint-js/i18n/translation-table-generated.cpp
+++ b/src/quick-lint-js/i18n/translation-table-generated.cpp
@@ -580,6 +580,7 @@ const Translation_Table translation_data = {
         {0, 0, 0, 47, 0, 60},                //
         {0, 0, 0, 55, 0, 59},                //
         {0, 0, 0, 0, 0, 59},                 //
+        {0, 0, 0, 0, 0, 78},                 //
         {57, 29, 48, 46, 41, 9},             //
         {37, 26, 31, 33, 35, 31},            //
         {0, 0, 0, 0, 0, 41},                 //
@@ -2436,6 +2437,7 @@ const Translation_Table translation_data = {
         u8"using '{0}' against an array literal does not compare items\0"
         u8"using '{0}' against an arrow function always returns '{1}'\0"
         u8"using '{0}' against an object literal always returns '{1}'\0"
+        u8"using a '{0}' after a '{1}' might fail, since '{1}' might return 'undefined'.\0"
         u8"variable\0"
         u8"variable already declared here\0"
         u8"variable assigned before its declaration\0"

--- a/src/quick-lint-js/i18n/translation-table-generated.cpp
+++ b/src/quick-lint-js/i18n/translation-table-generated.cpp
@@ -580,7 +580,7 @@ const Translation_Table translation_data = {
         {0, 0, 0, 47, 0, 60},                //
         {0, 0, 0, 55, 0, 59},                //
         {0, 0, 0, 0, 0, 59},                 //
-        {0, 0, 0, 0, 0, 78},                 //
+        {0, 0, 0, 0, 0, 74},                 //
         {57, 29, 48, 46, 41, 9},             //
         {37, 26, 31, 33, 35, 31},            //
         {0, 0, 0, 0, 0, 41},                 //
@@ -2437,7 +2437,7 @@ const Translation_Table translation_data = {
         u8"using '{0}' against an array literal does not compare items\0"
         u8"using '{0}' against an arrow function always returns '{1}'\0"
         u8"using '{0}' against an object literal always returns '{1}'\0"
-        u8"using a '{0}' after a '{1}' might fail, since '{1}' might return 'undefined'.\0"
+        u8"using a '.' after a '?.' might fail, since '?.' might return 'undefined'.\0"
         u8"variable\0"
         u8"variable already declared here\0"
         u8"variable assigned before its declaration\0"

--- a/src/quick-lint-js/i18n/translation-table-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-generated.h
@@ -19,7 +19,7 @@ using namespace std::literals::string_view_literals;
 
 constexpr std::uint32_t translation_table_locale_count = 5;
 constexpr std::uint16_t translation_table_mapping_table_size = 592;
-constexpr std::size_t translation_table_string_table_size = 81816;
+constexpr std::size_t translation_table_string_table_size = 81812;
 constexpr std::size_t translation_table_locale_table_size = 35;
 
 QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
@@ -594,7 +594,7 @@ QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
           "using '{0}' against an array literal does not compare items"sv,
           "using '{0}' against an arrow function always returns '{1}'"sv,
           "using '{0}' against an object literal always returns '{1}'"sv,
-          "using a '{0}' after a '{1}' might fail, since '{1}' might return 'undefined'."sv,
+          "using a '.' after a '?.' might fail, since '?.' might return 'undefined'."sv,
           "variable"sv,
           "variable already declared here"sv,
           "variable assigned before its declaration"sv,

--- a/src/quick-lint-js/i18n/translation-table-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-generated.h
@@ -18,8 +18,8 @@ namespace quick_lint_js {
 using namespace std::literals::string_view_literals;
 
 constexpr std::uint32_t translation_table_locale_count = 5;
-constexpr std::uint16_t translation_table_mapping_table_size = 591;
-constexpr std::size_t translation_table_string_table_size = 81738;
+constexpr std::uint16_t translation_table_mapping_table_size = 592;
+constexpr std::size_t translation_table_string_table_size = 81816;
 constexpr std::size_t translation_table_locale_table_size = 35;
 
 QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
@@ -594,6 +594,7 @@ QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
           "using '{0}' against an array literal does not compare items"sv,
           "using '{0}' against an arrow function always returns '{1}'"sv,
           "using '{0}' against an object literal always returns '{1}'"sv,
+          "using a '{0}' after a '{1}' might fail, since '{1}' might return 'undefined'."sv,
           "variable"sv,
           "variable already declared here"sv,
           "variable assigned before its declaration"sv,

--- a/src/quick-lint-js/i18n/translation-table-test-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-test-generated.h
@@ -27,7 +27,7 @@ struct Translated_String {
 };
 
 // clang-format off
-inline const Translated_String test_translation_table[590] = {
+inline const Translated_String test_translation_table[591] = {
     {
         "\"global-groups\" entries must be strings"_translatable,
         u8"\"global-groups\" entries must be strings",
@@ -6274,6 +6274,17 @@ inline const Translated_String test_translation_table[590] = {
             u8"using '{0}' against an object literal always returns '{1}'",
             u8"usar '{0}' com um objeto sempre retorna '{1}'",
             u8"using '{0}' against an object literal always returns '{1}'",
+        },
+    },
+    {
+        "using a '{0}' after a '{1}' might fail, since '{1}' might return 'undefined'."_translatable,
+        u8"using a '{0}' after a '{1}' might fail, since '{1}' might return 'undefined'.",
+        {
+            u8"using a '{0}' after a '{1}' might fail, since '{1}' might return 'undefined'.",
+            u8"using a '{0}' after a '{1}' might fail, since '{1}' might return 'undefined'.",
+            u8"using a '{0}' after a '{1}' might fail, since '{1}' might return 'undefined'.",
+            u8"using a '{0}' after a '{1}' might fail, since '{1}' might return 'undefined'.",
+            u8"using a '{0}' after a '{1}' might fail, since '{1}' might return 'undefined'.",
         },
     },
     {

--- a/src/quick-lint-js/i18n/translation-table-test-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-test-generated.h
@@ -6277,14 +6277,14 @@ inline const Translated_String test_translation_table[591] = {
         },
     },
     {
-        "using a '{0}' after a '{1}' might fail, since '{1}' might return 'undefined'."_translatable,
-        u8"using a '{0}' after a '{1}' might fail, since '{1}' might return 'undefined'.",
+        "using a '.' after a '?.' might fail, since '?.' might return 'undefined'."_translatable,
+        u8"using a '.' after a '?.' might fail, since '?.' might return 'undefined'.",
         {
-            u8"using a '{0}' after a '{1}' might fail, since '{1}' might return 'undefined'.",
-            u8"using a '{0}' after a '{1}' might fail, since '{1}' might return 'undefined'.",
-            u8"using a '{0}' after a '{1}' might fail, since '{1}' might return 'undefined'.",
-            u8"using a '{0}' after a '{1}' might fail, since '{1}' might return 'undefined'.",
-            u8"using a '{0}' after a '{1}' might fail, since '{1}' might return 'undefined'.",
+            u8"using a '.' after a '?.' might fail, since '?.' might return 'undefined'.",
+            u8"using a '.' after a '?.' might fail, since '?.' might return 'undefined'.",
+            u8"using a '.' after a '?.' might fail, since '?.' might return 'undefined'.",
+            u8"using a '.' after a '?.' might fail, since '?.' might return 'undefined'.",
+            u8"using a '.' after a '?.' might fail, since '?.' might return 'undefined'.",
         },
     },
     {

--- a/test/test-parse-warning.cpp
+++ b/test/test-parse-warning.cpp
@@ -485,6 +485,39 @@ TEST_F(Test_Parse_Warning, Diag_Fallthrough_Without_Comment_In_Switch) {
       default:})"_sv,
       no_diags);
 }
+
+TEST_F(Test_Parse_Warning, Diag_Using_Dot_After_Optional_Chaining) {
+  test_parse_and_visit_expression(
+      u8"a?.b.c"_sv,
+      u8"    ^ Diag_Using_Dot_After_Optional_Chaining.dot_op\n"_diag
+      u8" ^^ .optional_chain_op"_diag);
+  test_parse_and_visit_expression(
+      u8"a?.b?.c"_sv,
+      no_diags);
+  test_parse_and_visit_expression(
+      u8"a?.b?.a?.c.d"_sv,
+      u8"          ^ Diag_Using_Dot_After_Optional_Chaining.dot_op\n"_diag
+      u8"       ^^ .optional_chain_op"_diag);
+  test_parse_and_visit_expression(
+      u8"a?.b?.a?.c"_sv,
+      no_diags);
+  
+  test_parse_and_visit_expression(
+      u8"_a?.(a)?.(_a)?.(a)"_sv,
+      no_diags);
+  test_parse_and_visit_expression(
+      u8"_a?.(a).b"_sv,
+      u8"       ^ Diag_Using_Dot_After_Optional_Chaining.dot_op\n"_diag
+      u8"  ^^ .optional_chain_op"_diag);
+
+  test_parse_and_visit_expression(
+      u8"g?.[1]"_sv,
+      no_diags);
+  test_parse_and_visit_expression(
+      u8"g?.[1]?.[2].b"_sv,
+      u8"           ^ Diag_Using_Dot_After_Optional_Chaining.dot_op\n"_diag
+      u8"      ^^ .optional_chain_op"_diag);
+}
 }
 }
 


### PR DESCRIPTION
This closes #1128 -- it warns the user about using a dot After an optional chain. This cover optional chain with function call as well as optional chain with index expressions