### PR TITLE
feat: track whitespace

### DIFF
--- a/po/messages.pot
+++ b/po/messages.pot
@@ -1994,6 +1994,10 @@ msgid "matching '{0}' here"
 msgstr ""
 
 #: src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
+msgid "indentation of '{0}' does not match '{1}'"
+msgstr ""
+
+#: src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
 msgid "unclosed interface; expected '}' by end of file"
 msgstr ""
 

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -1998,6 +1998,10 @@ msgid "indentation of '{0}' does not match '{1}'"
 msgstr ""
 
 #: src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
+msgid "misleading indentation after '{0}' body"
+msgstr ""
+
+#: src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
 msgid "unclosed interface; expected '}' by end of file"
 msgstr ""
 

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -1986,6 +1986,14 @@ msgid "unclosed code block; expected '}' by end of file"
 msgstr ""
 
 #: src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
+msgid "missing '}'"
+msgstr ""
+
+#: src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
+msgid "matching '{0}' here"
+msgstr ""
+
+#: src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
 msgid "unclosed interface; expected '}' by end of file"
 msgstr ""
 

--- a/src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
+++ b/src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
@@ -5451,6 +5451,26 @@ const QLJS_CONSTINIT Diagnostic_Info all_diagnostic_infos[] = {
       },
     },
 
+    // Diag_Misleading_Braceless_If_Else_Indentation
+    {
+      .code = 442,
+      .severity = Diagnostic_Severity::warning,
+      .message_formats = {
+        QLJS_TRANSLATABLE("indentation of '{0}' does not match '{1}'"),
+        QLJS_TRANSLATABLE("indentation of '{0}' does not match '{1}'"),
+      },
+      .message_args = {
+        {
+          Diagnostic_Message_Arg_Info(offsetof(Diag_Misleading_Braceless_If_Else_Indentation, if_span), Diagnostic_Arg_Type::source_code_span),
+          Diagnostic_Message_Arg_Info(offsetof(Diag_Misleading_Braceless_If_Else_Indentation, else_span), Diagnostic_Arg_Type::source_code_span),
+        },
+        {
+          Diagnostic_Message_Arg_Info(offsetof(Diag_Misleading_Braceless_If_Else_Indentation, else_span), Diagnostic_Arg_Type::source_code_span),
+          Diagnostic_Message_Arg_Info(offsetof(Diag_Misleading_Braceless_If_Else_Indentation, if_span), Diagnostic_Arg_Type::source_code_span),
+        },
+      },
+    },
+
     // Diag_Unclosed_Interface_Block
     {
       .code = 215,

--- a/src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
+++ b/src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
@@ -5433,6 +5433,24 @@ const QLJS_CONSTINIT Diagnostic_Info all_diagnostic_infos[] = {
       },
     },
 
+    // Diag_Unclosed_Code_Block_V2
+    {
+      .code = 441,
+      .severity = Diagnostic_Severity::error,
+      .message_formats = {
+        QLJS_TRANSLATABLE("missing '}'"),
+        QLJS_TRANSLATABLE("matching '{0}' here"),
+      },
+      .message_args = {
+        {
+          Diagnostic_Message_Arg_Info(offsetof(Diag_Unclosed_Code_Block_V2, expected_block_close), Diagnostic_Arg_Type::source_code_span),
+        },
+        {
+          Diagnostic_Message_Arg_Info(offsetof(Diag_Unclosed_Code_Block_V2, block_open), Diagnostic_Arg_Type::source_code_span),
+        },
+      },
+    },
+
     // Diag_Unclosed_Interface_Block
     {
       .code = 215,

--- a/src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
+++ b/src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
@@ -5471,6 +5471,20 @@ const QLJS_CONSTINIT Diagnostic_Info all_diagnostic_infos[] = {
       },
     },
 
+    // Diag_Misleading_If_Or_Else_Body_Indentation
+    {
+      .code = 443,
+      .severity = Diagnostic_Severity::warning,
+      .message_formats = {
+        QLJS_TRANSLATABLE("misleading indentation after '{0}' body"),
+      },
+      .message_args = {
+        {
+          Diagnostic_Message_Arg_Info(offsetof(Diag_Misleading_If_Or_Else_Body_Indentation, if_or_else_span), Diagnostic_Arg_Type::source_code_span),
+        },
+      },
+    },
+
     // Diag_Unclosed_Interface_Block
     {
       .code = 215,

--- a/src/quick-lint-js/diag/diagnostic-metadata-generated.h
+++ b/src/quick-lint-js/diag/diagnostic-metadata-generated.h
@@ -371,6 +371,7 @@ namespace quick_lint_js {
   QLJS_DIAG_TYPE_NAME(Diag_Unclosed_Block_Comment) \
   QLJS_DIAG_TYPE_NAME(Diag_Unclosed_Class_Block) \
   QLJS_DIAG_TYPE_NAME(Diag_Unclosed_Code_Block) \
+  QLJS_DIAG_TYPE_NAME(Diag_Unclosed_Code_Block_V2) \
   QLJS_DIAG_TYPE_NAME(Diag_Unclosed_Interface_Block) \
   QLJS_DIAG_TYPE_NAME(Diag_Unclosed_Identifier_Escape_Sequence) \
   QLJS_DIAG_TYPE_NAME(Diag_Unclosed_Object_Literal) \
@@ -462,7 +463,7 @@ namespace quick_lint_js {
   /* END */
 // clang-format on
 
-inline constexpr int Diag_Type_Count = 448;
+inline constexpr int Diag_Type_Count = 449;
 
 extern const Diagnostic_Info all_diagnostic_infos[Diag_Type_Count];
 }

--- a/src/quick-lint-js/diag/diagnostic-metadata-generated.h
+++ b/src/quick-lint-js/diag/diagnostic-metadata-generated.h
@@ -373,6 +373,7 @@ namespace quick_lint_js {
   QLJS_DIAG_TYPE_NAME(Diag_Unclosed_Code_Block) \
   QLJS_DIAG_TYPE_NAME(Diag_Unclosed_Code_Block_V2) \
   QLJS_DIAG_TYPE_NAME(Diag_Misleading_Braceless_If_Else_Indentation) \
+  QLJS_DIAG_TYPE_NAME(Diag_Misleading_If_Or_Else_Body_Indentation) \
   QLJS_DIAG_TYPE_NAME(Diag_Unclosed_Interface_Block) \
   QLJS_DIAG_TYPE_NAME(Diag_Unclosed_Identifier_Escape_Sequence) \
   QLJS_DIAG_TYPE_NAME(Diag_Unclosed_Object_Literal) \
@@ -464,7 +465,7 @@ namespace quick_lint_js {
   /* END */
 // clang-format on
 
-inline constexpr int Diag_Type_Count = 450;
+inline constexpr int Diag_Type_Count = 451;
 
 extern const Diagnostic_Info all_diagnostic_infos[Diag_Type_Count];
 }

--- a/src/quick-lint-js/diag/diagnostic-metadata-generated.h
+++ b/src/quick-lint-js/diag/diagnostic-metadata-generated.h
@@ -372,6 +372,7 @@ namespace quick_lint_js {
   QLJS_DIAG_TYPE_NAME(Diag_Unclosed_Class_Block) \
   QLJS_DIAG_TYPE_NAME(Diag_Unclosed_Code_Block) \
   QLJS_DIAG_TYPE_NAME(Diag_Unclosed_Code_Block_V2) \
+  QLJS_DIAG_TYPE_NAME(Diag_Misleading_Braceless_If_Else_Indentation) \
   QLJS_DIAG_TYPE_NAME(Diag_Unclosed_Interface_Block) \
   QLJS_DIAG_TYPE_NAME(Diag_Unclosed_Identifier_Escape_Sequence) \
   QLJS_DIAG_TYPE_NAME(Diag_Unclosed_Object_Literal) \
@@ -463,7 +464,7 @@ namespace quick_lint_js {
   /* END */
 // clang-format on
 
-inline constexpr int Diag_Type_Count = 449;
+inline constexpr int Diag_Type_Count = 450;
 
 extern const Diagnostic_Info all_diagnostic_infos[Diag_Type_Count];
 }

--- a/src/quick-lint-js/diag/diagnostic-types-2.h
+++ b/src/quick-lint-js/diag/diagnostic-types-2.h
@@ -2841,6 +2841,16 @@ struct Diag_Unclosed_Code_Block_V2 {
   Source_Code_Span expected_block_close;
 };
 
+struct Diag_Misleading_Braceless_If_Else_Indentation {
+  [[qljs::diag("E0442", Diagnostic_Severity::warning)]]  //
+  [[qljs::message("indentation of '{0}' does not match '{1}'", ARG(if_span),
+                  ARG(else_span))]]  //
+  [[qljs::message("indentation of '{0}' does not match '{1}'", ARG(else_span),
+                  ARG(if_span))]]  //
+  Source_Code_Span if_span;
+  Source_Code_Span else_span;
+};
+
 struct Diag_Unclosed_Interface_Block {
   [[qljs::diag("E0215", Diagnostic_Severity::error)]]  //
   [[qljs::message("unclosed interface; expected '}' by end of file",

--- a/src/quick-lint-js/diag/diagnostic-types-2.h
+++ b/src/quick-lint-js/diag/diagnostic-types-2.h
@@ -2833,6 +2833,14 @@ struct Diag_Unclosed_Code_Block {
   Source_Code_Span block_open;
 };
 
+struct Diag_Unclosed_Code_Block_V2 {
+  [[qljs::diag("E0441", Diagnostic_Severity::error)]]          //
+  [[qljs::message("missing '}'", ARG(expected_block_close))]]  //
+  [[qljs::message("matching '{0}' here", ARG(block_open))]]    //
+  Source_Code_Span block_open;
+  Source_Code_Span expected_block_close;
+};
+
 struct Diag_Unclosed_Interface_Block {
   [[qljs::diag("E0215", Diagnostic_Severity::error)]]  //
   [[qljs::message("unclosed interface; expected '}' by end of file",

--- a/src/quick-lint-js/diag/diagnostic-types-2.h
+++ b/src/quick-lint-js/diag/diagnostic-types-2.h
@@ -2851,6 +2851,13 @@ struct Diag_Misleading_Braceless_If_Else_Indentation {
   Source_Code_Span else_span;
 };
 
+struct Diag_Misleading_If_Or_Else_Body_Indentation {
+  [[qljs::diag("E0443", Diagnostic_Severity::warning)]]  //
+  [[qljs::message("misleading indentation after '{0}' body",
+                  ARG(if_or_else_span))]]  //
+  Source_Code_Span if_or_else_span;
+};
+
 struct Diag_Unclosed_Interface_Block {
   [[qljs::diag("E0215", Diagnostic_Severity::error)]]  //
   [[qljs::message("unclosed interface; expected '}' by end of file",

--- a/src/quick-lint-js/fe/lex.h
+++ b/src/quick-lint-js/fe/lex.h
@@ -316,7 +316,12 @@ class Lexer {
   static bool is_initial_identifier_character(char32_t code_point);
   static bool is_identifier_character(char32_t code_point, Identifier_Kind);
 
+  int indent_level_;
+  bool increasing_indent_;
+
  private:
+  inline void reset_indent_level();
+
   static bool is_non_ascii_whitespace_character(char32_t code_point);
   static bool is_ascii_character(Char8 code_unit);
   static bool is_ascii_character(char32_t code_point);

--- a/src/quick-lint-js/fe/parse-class.cpp
+++ b/src/quick-lint-js/fe/parse-class.cpp
@@ -658,7 +658,7 @@ void Parser::parse_and_visit_class_or_interface_member(
             modifiers.back().type == Token_Type::kw_static) {
           // class C { static { } }
           v.visit_enter_block_scope();
-          Source_Code_Span left_curly_span = p->peek().span();
+          Token left_curly_span = p->peek();
           p->skip();
 
           error_if_invalid_static_block(/*static_modifier=*/modifiers.back());

--- a/src/quick-lint-js/fe/parse.h
+++ b/src/quick-lint-js/fe/parse.h
@@ -543,6 +543,7 @@ class Parser {
   void parse_and_visit_for(Parse_Visitor_Base &v);
   void parse_and_visit_while(Parse_Visitor_Base &v);
 
+  bool in_if_statement_ = false;
   void parse_and_visit_if(Parse_Visitor_Base &v);
   void parse_and_visit_switch(Parse_Visitor_Base &v);
 

--- a/src/quick-lint-js/fe/parse.h
+++ b/src/quick-lint-js/fe/parse.h
@@ -275,14 +275,16 @@ class Parser {
   void parse_and_visit_typescript_generic_parameters(Parse_Visitor_Base &v);
 
  private:
+  std::optional<std::pair<Token, Token>> mismatched_curly_braces_;
+
   void parse_and_visit_statement_block_no_scope(Parse_Visitor_Base &v);
   void parse_and_visit_statement_block_no_scope(
       Parse_Visitor_Base &v, Parse_Statement_Options statement_options);
   // Parses the closing '}', if present.
+  void parse_and_visit_statement_block_after_left_curly(Parse_Visitor_Base &v,
+                                                        Token left_curly);
   void parse_and_visit_statement_block_after_left_curly(
-      Parse_Visitor_Base &v, Source_Code_Span left_curly_span);
-  void parse_and_visit_statement_block_after_left_curly(
-      Parse_Visitor_Base &v, Source_Code_Span left_curly_span,
+      Parse_Visitor_Base &v, Token left_curly,
       Parse_Statement_Options statement_options);
 
   enum class Name_Requirement {

--- a/src/quick-lint-js/fe/token.h
+++ b/src/quick-lint-js/fe/token.h
@@ -317,6 +317,8 @@ struct Token {
 
   Token_Type type;
 
+  int indent_level;
+
   bool has_leading_newline;
   bool has_leading_comment;
 

--- a/src/quick-lint-js/i18n/translation-table-generated.cpp
+++ b/src/quick-lint-js/i18n/translation-table-generated.cpp
@@ -340,7 +340,8 @@ const Translation_Table translation_data = {
         {0, 0, 0, 0, 0, 14},                 //
         {46, 52, 0, 57, 0, 18},              //
         {43, 18, 70, 35, 40, 32},            //
-        {0, 0, 0, 147, 0, 147},              //
+        {0, 0, 0, 0, 0, 147},                //
+        {0, 0, 0, 147, 0, 42},               //
         {0, 0, 0, 0, 0, 46},                 //
         {0, 0, 0, 54, 0, 26},                //
         {0, 0, 0, 0, 0, 38},                 //
@@ -2199,6 +2200,7 @@ const Translation_Table translation_data = {
         u8"imported variable\0"
         u8"imported variable declared here\0"
         u8"incomplete export; expected 'export default ...' or 'export {{name}' or 'export * from ...' or 'export class' or 'export function' or 'export let'\0"
+        u8"indentation of '{0}' does not match '{1}'\0"
         u8"index signature must be a field, not a method\0"
         u8"index signature parameter\0"
         u8"index signatures require a value type\0"

--- a/src/quick-lint-js/i18n/translation-table-generated.cpp
+++ b/src/quick-lint-js/i18n/translation-table-generated.cpp
@@ -369,6 +369,7 @@ const Translation_Table translation_data = {
         {0, 0, 0, 0, 0, 51},                 //
         {50, 22, 0, 63, 0, 13},              //
         {0, 0, 0, 0, 0, 45},                 //
+        {0, 0, 0, 0, 0, 20},                 //
         {0, 0, 0, 0, 0, 19},                 //
         {0, 0, 0, 46, 0, 35},                //
         {50, 47, 66, 33, 53, 27},            //
@@ -386,7 +387,8 @@ const Translation_Table translation_data = {
         {0, 0, 0, 0, 0, 74},                 //
         {0, 40, 0, 28, 0, 38},               //
         {29, 22, 33, 28, 26, 26},            //
-        {0, 0, 0, 55, 0, 51},                //
+        {0, 0, 0, 0, 0, 51},                 //
+        {0, 0, 0, 55, 0, 12},                //
         {48, 27, 63, 27, 0, 24},             //
         {40, 4, 58, 41, 50, 42},             //
         {31, 22, 36, 32, 30, 28},            //
@@ -2225,6 +2227,7 @@ const Translation_Table translation_data = {
         u8"let statement cannot declare variables named 'let'\0"
         u8"let variable\0"
         u8"lower case letters compared with toUpperCase\0"
+        u8"matching '{0}' here\0"
         u8"method starts here\0"
         u8"methods cannot be marked 'declare'\0"
         u8"methods cannot be readonly\0"
@@ -2243,6 +2246,7 @@ const Translation_Table translation_data = {
         u8"missing 'export' keyword for function\0"
         u8"missing 'if' after 'else'\0"
         u8"missing 'while (condition)' for do-while statement\0"
+        u8"missing '}'\0"
         u8"missing TypeScript type\0"
         u8"missing arrow operator for arrow function\0"
         u8"missing body for 'for' loop\0"

--- a/src/quick-lint-js/i18n/translation-table-generated.cpp
+++ b/src/quick-lint-js/i18n/translation-table-generated.cpp
@@ -375,6 +375,7 @@ const Translation_Table translation_data = {
         {0, 0, 0, 46, 0, 35},                //
         {50, 47, 66, 33, 53, 27},            //
         {0, 0, 0, 0, 0, 46},                 //
+        {0, 0, 0, 0, 0, 40},                 //
         {0, 0, 0, 0, 0, 56},                 //
         {68, 21, 0, 52, 0, 40},              //
         {0, 0, 0, 0, 0, 39},                 //
@@ -2234,6 +2235,7 @@ const Translation_Table translation_data = {
         u8"methods cannot be marked 'declare'\0"
         u8"methods cannot be readonly\0"
         u8"methods should not use the 'function' keyword\0"
+        u8"misleading indentation after '{0}' body\0"
         u8"misleading use of ',' operator in conditional statement\0"
         u8"misleading use of ',' operator in index\0"
         u8"mismatched JSX tags; expected '</{1}>'\0"

--- a/src/quick-lint-js/i18n/translation-table-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-generated.h
@@ -18,8 +18,8 @@ namespace quick_lint_js {
 using namespace std::literals::string_view_literals;
 
 constexpr std::uint32_t translation_table_locale_count = 5;
-constexpr std::uint16_t translation_table_mapping_table_size = 593;
-constexpr std::size_t translation_table_string_table_size = 81770;
+constexpr std::uint16_t translation_table_mapping_table_size = 594;
+constexpr std::size_t translation_table_string_table_size = 81812;
 constexpr std::size_t translation_table_locale_table_size = 35;
 
 QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
@@ -355,6 +355,7 @@ QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
           "imported variable"sv,
           "imported variable declared here"sv,
           "incomplete export; expected 'export default ...' or 'export {{name}' or 'export * from ...' or 'export class' or 'export function' or 'export let'"sv,
+          "indentation of '{0}' does not match '{1}'"sv,
           "index signature must be a field, not a method"sv,
           "index signature parameter"sv,
           "index signatures require a value type"sv,

--- a/src/quick-lint-js/i18n/translation-table-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-generated.h
@@ -18,8 +18,8 @@ namespace quick_lint_js {
 using namespace std::literals::string_view_literals;
 
 constexpr std::uint32_t translation_table_locale_count = 5;
-constexpr std::uint16_t translation_table_mapping_table_size = 594;
-constexpr std::size_t translation_table_string_table_size = 81812;
+constexpr std::uint16_t translation_table_mapping_table_size = 595;
+constexpr std::size_t translation_table_string_table_size = 81852;
 constexpr std::size_t translation_table_locale_table_size = 35;
 
 QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
@@ -389,6 +389,7 @@ QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
           "methods cannot be marked 'declare'"sv,
           "methods cannot be readonly"sv,
           "methods should not use the 'function' keyword"sv,
+          "misleading indentation after '{0}' body"sv,
           "misleading use of ',' operator in conditional statement"sv,
           "misleading use of ',' operator in index"sv,
           "mismatched JSX tags; expected '</{1}>'"sv,

--- a/src/quick-lint-js/i18n/translation-table-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-generated.h
@@ -18,8 +18,8 @@ namespace quick_lint_js {
 using namespace std::literals::string_view_literals;
 
 constexpr std::uint32_t translation_table_locale_count = 5;
-constexpr std::uint16_t translation_table_mapping_table_size = 591;
-constexpr std::size_t translation_table_string_table_size = 81738;
+constexpr std::uint16_t translation_table_mapping_table_size = 593;
+constexpr std::size_t translation_table_string_table_size = 81770;
 constexpr std::size_t translation_table_locale_table_size = 35;
 
 QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
@@ -383,6 +383,7 @@ QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
           "let statement cannot declare variables named 'let'"sv,
           "let variable"sv,
           "lower case letters compared with toUpperCase"sv,
+          "matching '{0}' here"sv,
           "method starts here"sv,
           "methods cannot be marked 'declare'"sv,
           "methods cannot be readonly"sv,
@@ -401,6 +402,7 @@ QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
           "missing 'export' keyword for function"sv,
           "missing 'if' after 'else'"sv,
           "missing 'while (condition)' for do-while statement"sv,
+          "missing '}'"sv,
           "missing TypeScript type"sv,
           "missing arrow operator for arrow function"sv,
           "missing body for 'for' loop"sv,

--- a/src/quick-lint-js/i18n/translation-table-test-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-test-generated.h
@@ -27,7 +27,7 @@ struct Translated_String {
 };
 
 // clang-format off
-inline const Translated_String test_translation_table[593] = {
+inline const Translated_String test_translation_table[594] = {
     {
         "\"global-groups\" entries must be strings"_translatable,
         u8"\"global-groups\" entries must be strings",
@@ -4019,6 +4019,17 @@ inline const Translated_String test_translation_table[593] = {
             u8"les m\u00e9thodes ne doivent pas utiliser le mot-cl\u00e9 'function'",
             u8"m\u00e9todos n\u00e3o podem usar a palavra-chave 'function'",
             u8"metoder b\u00f6r inte anv\u00e4nda nyckelordet 'function'",
+        },
+    },
+    {
+        "misleading indentation after '{0}' body"_translatable,
+        u8"misleading indentation after '{0}' body",
+        {
+            u8"misleading indentation after '{0}' body",
+            u8"misleading indentation after '{0}' body",
+            u8"misleading indentation after '{0}' body",
+            u8"misleading indentation after '{0}' body",
+            u8"misleading indentation after '{0}' body",
         },
     },
     {

--- a/src/quick-lint-js/i18n/translation-table-test-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-test-generated.h
@@ -27,7 +27,7 @@ struct Translated_String {
 };
 
 // clang-format off
-inline const Translated_String test_translation_table[590] = {
+inline const Translated_String test_translation_table[592] = {
     {
         "\"global-groups\" entries must be strings"_translatable,
         u8"\"global-groups\" entries must be strings",
@@ -3956,6 +3956,17 @@ inline const Translated_String test_translation_table[590] = {
         },
     },
     {
+        "matching '{0}' here"_translatable,
+        u8"matching '{0}' here",
+        {
+            u8"matching '{0}' here",
+            u8"matching '{0}' here",
+            u8"matching '{0}' here",
+            u8"matching '{0}' here",
+            u8"matching '{0}' here",
+        },
+    },
+    {
         "method starts here"_translatable,
         u8"method starts here",
         {
@@ -4151,6 +4162,17 @@ inline const Translated_String test_translation_table[590] = {
             u8"'while (condition)' manquant pour une instruction for do-while",
             u8"falta 'while (condi\u00e7\u00e3o)' para a instru\u00e7\u00e3o do-while",
             u8"saknar 'while (vilkor)' till do-while p\u00e5st\u00e5ende",
+        },
+    },
+    {
+        "missing '}'"_translatable,
+        u8"missing '}'",
+        {
+            u8"missing '}'",
+            u8"missing '}'",
+            u8"missing '}'",
+            u8"missing '}'",
+            u8"missing '}'",
         },
     },
     {

--- a/src/quick-lint-js/i18n/translation-table-test-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-test-generated.h
@@ -27,7 +27,7 @@ struct Translated_String {
 };
 
 // clang-format off
-inline const Translated_String test_translation_table[592] = {
+inline const Translated_String test_translation_table[593] = {
     {
         "\"global-groups\" entries must be strings"_translatable,
         u8"\"global-groups\" entries must be strings",
@@ -3645,6 +3645,17 @@ inline const Translated_String test_translation_table[592] = {
             u8"export incompl ; 'export default ...' ou 'export {{name}' ou 'export * from ...' ou 'export class' ou 'export function' ou 'export let' attendu",
             u8"export incompleto; esperado 'export default ...' ou 'export {{nome}' ou 'export * from ...' ou 'export class' ou 'export function' ou 'export let'",
             u8"ofullst\u00e4ndig exportering; f\u00f6rv\u00e4ntades 'export default ...' eller 'export {{name}' eller 'export * from ...' eller 'export class' eller 'export function' eller 'export let'",
+        },
+    },
+    {
+        "indentation of '{0}' does not match '{1}'"_translatable,
+        u8"indentation of '{0}' does not match '{1}'",
+        {
+            u8"indentation of '{0}' does not match '{1}'",
+            u8"indentation of '{0}' does not match '{1}'",
+            u8"indentation of '{0}' does not match '{1}'",
+            u8"indentation of '{0}' does not match '{1}'",
+            u8"indentation of '{0}' does not match '{1}'",
         },
     },
     {

--- a/test/test-parse-statement.cpp
+++ b/test/test-parse-statement.cpp
@@ -855,9 +855,10 @@ TEST_F(Test_Parse_Statement, block_statement) {
 
 TEST_F(Test_Parse_Statement, incomplete_block_statement) {
   {
-    Spy_Visitor p =
-        test_parse_and_visit_statement(u8"{ a; "_sv,  //
-                                       u8"^ Diag_Unclosed_Code_Block"_diag);
+    Spy_Visitor p = test_parse_and_visit_statement(
+        u8"{ a; "_sv,                                        //
+        u8"^ Diag_Unclosed_Code_Block_V2.block_open\n"_diag  //
+        u8"     ` .expected_block_close"_diag);
     EXPECT_THAT(p.visits, ElementsAreArray({
                               "visit_enter_block_scope",  //
                               "visit_variable_use",       // a

--- a/test/test-parse-statement.cpp
+++ b/test/test-parse-statement.cpp
@@ -555,6 +555,19 @@ TEST_F(Test_Parse_Statement, if_without_else) {
                               "visit_variable_use",
                           }));
   }
+
+  {
+    Spy_Visitor p = test_parse_and_visit_module(
+        u8"if (x)\n\ty;\n\tz;"_sv,
+        u8"^^ Diag_Misleading_If_Or_Else_Body_Indentation"_diag,
+        javascript_options);
+    EXPECT_THAT(p.visits, ElementsAreArray({
+                              "visit_variable_use",  // x
+                              "visit_variable_use",  // y
+                              "visit_variable_use",  // z
+                              "visit_end_of_module",
+                          }));
+  }
 }
 
 TEST_F(Test_Parse_Statement, if_with_else) {

--- a/test/test-parse-statement.cpp
+++ b/test/test-parse-statement.cpp
@@ -593,6 +593,44 @@ TEST_F(Test_Parse_Statement, if_with_else) {
                               "visit_variable_use",               // b
                           }));
   }
+
+  {
+    // if (x)
+    //   if (y)
+    //     z();
+    // else
+    //   w();
+    test_parse_and_visit_statement(
+        u8"if(x)\n\tif (y)\n\t\tz();\nelse\n\tw();"_sv,  //
+        u8"         ^^ Diag_Misleading_Braceless_If_Else_Indentation.if_span\n"_diag  //
+        u8"                           ^^^^ .else_span"_diag);
+
+    // if (x)
+    //   if (y)
+    //     z();
+    //   else
+    //     w();
+    test_parse_and_visit_statement(
+        u8"if(x)\n\tif (y)\n\t\tz();\n\telse\n\t\tw();"_sv, no_diags);
+
+    // quick-lint-js should only report a warning about `else` if it's part of a
+    // nested `if`.
+    //
+    // if (x) {
+    //     y();
+    //  } else {
+    //     z();
+    //  }
+    test_parse_and_visit_statement(
+        u8"if (x) {\n\t\ty();\n\t} else {\n\t\tz();\n\t}"_sv, no_diags);
+
+    // if (x)
+    //     y();
+    //  else
+    //     z();
+    test_parse_and_visit_statement(u8"if (x)\n\t\ty();\n\telse\n\t\tz();\n"_sv,
+                                   no_diags);
+  }
 }
 
 TEST_F(Test_Parse_Statement, if_else_with_malformed_condition) {

--- a/test/test-parse-typescript-namespace.cpp
+++ b/test/test-parse-typescript-namespace.cpp
@@ -95,8 +95,9 @@ TEST_F(Test_Parse_TypeScript_Namespace, incomplete_body) {
   {
     // TODO(strager): Report a namespace-specific diagnostic.
     Spy_Visitor p = test_parse_and_visit_module(
-        u8"namespace ns { "_sv,                            //
-        u8"             ^ Diag_Unclosed_Code_Block"_diag,  //
+        u8"namespace ns { "_sv,                                           //
+        u8"             ^ Diag_Unclosed_Code_Block_V2.block_open\n"_diag  //
+        u8"               ` .expected_block_close"_diag,
         typescript_options);
     EXPECT_THAT(p.visits, ElementsAreArray({
                               "visit_enter_namespace_scope",  // {
@@ -110,8 +111,9 @@ TEST_F(Test_Parse_TypeScript_Namespace, incomplete_body) {
 
   {
     Spy_Visitor p = test_parse_and_visit_module(
-        u8"namespace ns { export "_sv,                     //
-        u8"             ^ Diag_Unclosed_Code_Block"_diag,  //
+        u8"namespace ns { export "_sv,                                    //
+        u8"             ^ Diag_Unclosed_Code_Block_V2.block_open\n"_diag  //
+        u8"                      ` .expected_block_close"_diag,
         u8"Diag_Missing_Token_After_Export"_diag, typescript_options);
     EXPECT_THAT(p.visits, ElementsAreArray({
                               "visit_enter_namespace_scope",  // {


### PR DESCRIPTION
This set of commits addresses issues #282 and #1113 by tracking whitespace and adding a few new diagnostics. quick-lint will print warnings about mismatched curly brace indentation, `if/else` indentation, and misleading indentation after a braceless `if`.

Commit 2379dea modifies a couple existing tests by adding whitespace to them to avoid triggering `Diag_Mismatched_Curly_Indentation`.