### PR TITLE
feat(typescript): add new diag for "import type" with import alias

### DIFF
--- a/docs/errors/E0717.md
+++ b/docs/errors/E0717.md
@@ -1,0 +1,19 @@
+# E0717: namespace alias cannot use 'import type'
+
+
+The error message "namespace alias cannot use 'import type'" occurs when
+trying to use the 'import type' syntax with an alias.
+
+
+```typescript
+import type A = ns;
+```
+
+
+To fix this error, you need to use the regular 'import' syntax instead
+of 'import type' when using an alias.
+
+
+```typescript
+import A = ns;
+```

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -2401,6 +2401,10 @@ msgstr ""
 msgid "'&' here"
 msgstr ""
 
+#: src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
+msgid "namespace alias cannot use 'import type'"
+msgstr ""
+
 #: test/test-diagnostic-formatter.cpp
 #: test/test-vim-qflist-json-diag-reporter.cpp
 msgid "something happened"

--- a/src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
+++ b/src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
@@ -6870,6 +6870,20 @@ const QLJS_CONSTINIT Diagnostic_Info all_diagnostic_infos[] = {
         },
       },
     },
+
+    // Diag_TypeScript_Namespace_Alias_Cannot_Use_Import_Type
+    {
+      .code = 717,
+      .severity = Diagnostic_Severity::error,
+      .message_formats = {
+        QLJS_TRANSLATABLE("namespace alias cannot use 'import type'"),
+      },
+      .message_args = {
+        {
+          Diagnostic_Message_Arg_Info(offsetof(Diag_TypeScript_Namespace_Alias_Cannot_Use_Import_Type, type_keyword), Diagnostic_Arg_Type::source_code_span),
+        },
+      },
+    },
 };
 }
 

--- a/src/quick-lint-js/diag/diagnostic-metadata-generated.h
+++ b/src/quick-lint-js/diag/diagnostic-metadata-generated.h
@@ -469,10 +469,11 @@ namespace quick_lint_js {
   QLJS_DIAG_TYPE_NAME(Diag_Class_Async_On_Getter_Or_Setter) \
   QLJS_DIAG_TYPE_NAME(Diag_Multiple_Export_Defaults) \
   QLJS_DIAG_TYPE_NAME(Diag_Unintuitive_Bitshift_Precedence) \
+  QLJS_DIAG_TYPE_NAME(Diag_TypeScript_Namespace_Alias_Cannot_Use_Import_Type) \
   /* END */
 // clang-format on
 
-inline constexpr int Diag_Type_Count = 458;
+inline constexpr int Diag_Type_Count = 459;
 
 extern const Diagnostic_Info all_diagnostic_infos[Diag_Type_Count];
 }

--- a/src/quick-lint-js/diag/diagnostic-types-2.h
+++ b/src/quick-lint-js/diag/diagnostic-types-2.h
@@ -3567,6 +3567,13 @@ struct Diag_Unintuitive_Bitshift_Precedence {
   Source_Code_Span bitshift_operator;
   Source_Code_Span and_operator;
 };
+
+struct Diag_TypeScript_Namespace_Alias_Cannot_Use_Import_Type {
+  [[qljs::diag("E0717", Diagnostic_Severity::error)]]  //
+  [[qljs::message("namespace alias cannot use 'import type'",
+                  ARG(type_keyword))]]  //
+  Source_Code_Span type_keyword;
+};
 }
 QLJS_WARNING_POP
 

--- a/src/quick-lint-js/i18n/translation-table-generated.cpp
+++ b/src/quick-lint-js/i18n/translation-table-generated.cpp
@@ -457,6 +457,7 @@ const Translation_Table translation_data = {
         {0, 0, 0, 0, 0, 51},                 //
         {0, 0, 0, 0, 0, 47},                 //
         {0, 0, 0, 0, 0, 10},                 //
+        {0, 0, 0, 0, 0, 41},                 //
         {69, 26, 0, 59, 0, 22},              //
         {0, 0, 0, 46, 0, 39},                //
         {0, 0, 0, 0, 0, 40},                 //
@@ -2324,6 +2325,7 @@ const Translation_Table translation_data = {
         u8"move the 'extends' clause before 'implements' here\0"
         u8"move the parameter decorator before '{0}' here\0"
         u8"namespace\0"
+        u8"namespace alias cannot use 'import type'\0"
         u8"namespace starts here\0"
         u8"new variable shadows existing variable\0"
         u8"newline is not allowed after 'abstract'\0"

--- a/src/quick-lint-js/i18n/translation-table-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-generated.h
@@ -18,8 +18,8 @@ namespace quick_lint_js {
 using namespace std::literals::string_view_literals;
 
 constexpr std::uint32_t translation_table_locale_count = 5;
-constexpr std::uint16_t translation_table_mapping_table_size = 602;
-constexpr std::size_t translation_table_string_table_size = 82276;
+constexpr std::uint16_t translation_table_mapping_table_size = 603;
+constexpr std::size_t translation_table_string_table_size = 82317;
 constexpr std::size_t translation_table_locale_table_size = 35;
 
 QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
@@ -471,6 +471,7 @@ QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
           "move the 'extends' clause before 'implements' here"sv,
           "move the parameter decorator before '{0}' here"sv,
           "namespace"sv,
+          "namespace alias cannot use 'import type'"sv,
           "namespace starts here"sv,
           "new variable shadows existing variable"sv,
           "newline is not allowed after 'abstract'"sv,

--- a/src/quick-lint-js/i18n/translation-table-test-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-test-generated.h
@@ -27,7 +27,7 @@ struct Translated_String {
 };
 
 // clang-format off
-inline const Translated_String test_translation_table[601] = {
+inline const Translated_String test_translation_table[602] = {
     {
         "\"global-groups\" entries must be strings"_translatable,
         u8"\"global-groups\" entries must be strings",
@@ -4921,6 +4921,17 @@ inline const Translated_String test_translation_table[601] = {
             u8"namespace",
             u8"namespace",
             u8"namespace",
+        },
+    },
+    {
+        "namespace alias cannot use 'import type'"_translatable,
+        u8"namespace alias cannot use 'import type'",
+        {
+            u8"namespace alias cannot use 'import type'",
+            u8"namespace alias cannot use 'import type'",
+            u8"namespace alias cannot use 'import type'",
+            u8"namespace alias cannot use 'import type'",
+            u8"namespace alias cannot use 'import type'",
         },
     },
     {

--- a/test/test-parse-typescript-namespace.cpp
+++ b/test/test-parse-typescript-namespace.cpp
@@ -669,6 +669,20 @@ TEST_F(Test_Parse_TypeScript_Namespace,
 }
 
 TEST_F(Test_Parse_TypeScript_Namespace,
+       namespace_alias_cannot_use_import_type) {
+  {
+    Spy_Visitor p = test_parse_and_visit_statement(
+        u8"import type A = ns;"_sv,  //
+        u8"       ^^^^ Diag_TypeScript_Namespace_Alias_Cannot_Use_Import_Type.type_keyword"_diag,
+        typescript_options);
+    EXPECT_THAT(p.visits, ElementsAreArray({
+                              "visit_variable_declaration",    // A
+                              "visit_variable_namespace_use",  // ns
+                          }));
+  }
+}
+
+TEST_F(Test_Parse_TypeScript_Namespace,
        namespace_alias_cannot_be_used_with_declare_keyword) {
   {
     Spy_Visitor p = test_parse_and_visit_module(


### PR DESCRIPTION
This closes #1139. I've moved `type_span` before switch statement so we can have better diagnostic instead of pointing on `import` keyword.