### PR TITLE
fix(fe): don't report React-specific JSX errors in non-React code

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,9 @@ Semantic Versioning.
 
 * quick-lint-js's tracing no longer crashes with an assertion failure when
   setting its thread name on FreeBSD.
+* React-specific JSX diagnostics, such as [E0193][] ("misspelled React
+  attribute; write 'className' instead"), are now only reported when 'react' is
+  imported. This fixes false warnings in Preact code. ([#1152][])
 
 ## 3.0.0 (2024-01-01)
 
@@ -1375,6 +1378,8 @@ Beta release.
 [tiagovla]: https://github.com/tiagovla
 [toastin0]: https://github.com/toastin0
 [wagner riffel]: https://github.com/wgrr
+
+[#1152]: https://github.com/quick-lint/quick-lint-js/issues/1152
 
 [E0001]: https://quick-lint-js.com/errors/E0001/
 [E0003]: https://quick-lint-js.com/errors/E0003/

--- a/docs/errors/E0191.md
+++ b/docs/errors/E0191.md
@@ -5,6 +5,8 @@ In HTML, attributes are case-insensitive; `onclick` is the same as `onClick` and
 attribute (starting with `on`) to be all lower-case:
 
 ```javascript-jsx
+import React from "react";
+
 function TodoEntry({addTodo, changePendingTodo}) {
   return <form onsubmit={addTodo}>
     <input onchange={changePendingTodo} />
@@ -17,6 +19,8 @@ To fix this error, fix the capitalization by writing the attribute in
 lowerCamelCase:
 
 ```javascript-jsx
+import React from "react";
+
 function TodoEntry({addTodo, changePendingTodo}) {
   return <form onSubmit={addTodo}>
     <input onChange={changePendingTodo} />

--- a/docs/errors/E0192.md
+++ b/docs/errors/E0192.md
@@ -5,6 +5,8 @@ In HTML, attributes are case-insensitive; `colspan` is the same as `colSpan` and
 attribute for a built-in element to have the wrong capitalization:
 
 ```javascript-jsx
+import React from "react";
+
 function Header({columns}) {
   return <tr>
     <th colspan="2">Name</th>
@@ -17,6 +19,8 @@ function Header({columns}) {
 To fix this error, fix the capitalization of the attribute:
 
 ```javascript-jsx
+import React from "react";
+
 function Header({columns}) {
   return <tr>
     <th colSpan="2">Name</th>

--- a/docs/errors/E0193.md
+++ b/docs/errors/E0193.md
@@ -4,6 +4,8 @@ React has a different name for some attributes than HTML. It is a mistake to
 write the HTML attribute instead of the React attribute:
 
 ```javascript-jsx
+import React from "react";
+
 function Title({page}) {
   return <h1 class="title">
     <a href={page.url} class="page-link">
@@ -16,6 +18,8 @@ function Title({page}) {
 To fix this error, write the name of the attribute understood by React:
 
 ```javascript-jsx
+import React from "react";
+
 function Title({page}) {
   return <h1 className="title">
     <a href={page.url} className="page-link">

--- a/src/quick-lint-js/fe/parse-expression.cpp
+++ b/src/quick-lint-js/fe/parse-expression.cpp
@@ -3851,7 +3851,7 @@ next_attribute:
       this->lexer_.skip_in_jsx();
     }
     if (is_intrinsic && !has_namespace && !tag_namespace) {
-      this->check_jsx_attribute(attribute);
+      this->jsx_intrinsic_attributes_.emplace_back(attribute);
     }
     if (this->peek().type == Token_Type::equal) {
       this->lexer_.skip_in_jsx();

--- a/src/quick-lint-js/fe/parse.cpp
+++ b/src/quick-lint-js/fe/parse.cpp
@@ -158,6 +158,27 @@ Expression* Parser::build_expression(Binary_Expression_Builder& builder) {
   }
 }
 
+void Parser::check_all_jsx_attributes() {
+  switch (this->options_.jsx_mode) {
+  case Parser_JSX_Mode::none:
+    break;
+
+  case Parser_JSX_Mode::auto_detect:
+    if (this->imported_react_) {
+      goto react;
+    }
+    break;
+
+  react:
+  case Parser_JSX_Mode::react:
+    this->jsx_intrinsic_attributes_.for_each(
+        [&](const Identifier& attribute_name) -> void {
+          this->check_jsx_attribute(attribute_name);
+        });
+    break;
+  }
+}
+
 QLJS_WARNING_PUSH
 QLJS_WARNING_IGNORE_GCC("-Wnull-dereference")
 void Parser::check_jsx_attribute(const Identifier& attribute_name) {

--- a/test/test-parse-jsx-react.cpp
+++ b/test/test-parse-jsx-react.cpp
@@ -3,6 +3,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <quick-lint-js/container/concat.h>
 #include <quick-lint-js/diag-matcher.h>
 #include <quick-lint-js/parse-support.h>
 #include <quick-lint-js/port/char8.h>
@@ -12,12 +13,27 @@ namespace quick_lint_js {
 namespace {
 class Test_Parse_JSX_React : public Test_Parse_Expression {};
 
+constexpr Parser_Options jsx_react_options{
+    .jsx_mode = Parser_JSX_Mode::react,
+    .jsx = true,
+};
+
+constexpr Parser_Options jsx_auto_detect_options{
+    .jsx_mode = Parser_JSX_Mode::auto_detect,
+    .jsx = true,
+};
+
+constexpr Parser_Options jsx_none_options{
+    .jsx_mode = Parser_JSX_Mode::none,
+    .jsx = true,
+};
+
 TEST_F(Test_Parse_JSX_React, correctly_capitalized_attribute) {
   test_parse_and_visit_module(u8R"(c = <td colSpan="2" />;)"_sv, no_diags,
-                              jsx_options);
+                              jsx_react_options);
 
   test_parse_and_visit_module(u8R"(c = <div onClick={handler} />;)"_sv,
-                              no_diags, jsx_options);
+                              no_diags, jsx_react_options);
 }
 
 TEST_F(Test_Parse_JSX_React, event_attributes_should_be_camel_case) {
@@ -25,26 +41,26 @@ TEST_F(Test_Parse_JSX_React, event_attributes_should_be_camel_case) {
       u8"c = <div onclick={handler} />;"_sv,  //
       u8"         ^^^^^^^ Diag_JSX_Event_Attribute_Should_Be_Camel_Case.attribute_name"_diag
       u8"{.expected_attribute_name=onClick}"_diag,  //
-      jsx_options);
+      jsx_react_options);
 
   // TODO(strager): Should we also report that the handler's value is missing?
   test_parse_and_visit_module(
       u8"c = <div onclick />;"_sv,  //
       u8"         ^^^^^^^ Diag_JSX_Event_Attribute_Should_Be_Camel_Case.attribute_name"_diag
       u8"{.expected_attribute_name=onClick}"_diag,  //
-      jsx_options);
+      jsx_react_options);
 
   test_parse_and_visit_module(
       u8"c = <div onmouseenter={handler} />;"_sv,  //
       u8"         ^^^^^^^^^^^^ Diag_JSX_Event_Attribute_Should_Be_Camel_Case.attribute_name"_diag
       u8"{.expected_attribute_name=onMouseEnter}"_diag,  //
-      jsx_options);
+      jsx_react_options);
 
   test_parse_and_visit_module(
       u8"c = <div oncustomevent={handler} />;"_sv,  //
       u8"         ^^^^^^^^^^^^^ Diag_JSX_Event_Attribute_Should_Be_Camel_Case.attribute_name"_diag
       u8"{.expected_attribute_name=onCustomevent}"_diag,  //
-      jsx_options);
+      jsx_react_options);
 }
 
 TEST_F(Test_Parse_JSX_React, miscapitalized_attribute) {
@@ -52,19 +68,19 @@ TEST_F(Test_Parse_JSX_React, miscapitalized_attribute) {
       u8"c = <td colspan=\"2\" />;"_sv,  //
       u8"        ^^^^^^^ Diag_JSX_Attribute_Has_Wrong_Capitalization.attribute_name"_diag
       u8"{.expected_attribute_name=colSpan}"_diag,  //
-      jsx_options);
+      jsx_react_options);
 
   test_parse_and_visit_module(
       u8"c = <div onMouseenter={handler} />;"_sv,  //
       u8"         ^^^^^^^^^^^^ Diag_JSX_Attribute_Has_Wrong_Capitalization.attribute_name"_diag
       u8"{.expected_attribute_name=onMouseEnter}"_diag,  //
-      jsx_options);
+      jsx_react_options);
 
   test_parse_and_visit_module(
       u8"c = <div onmouseENTER={handler} />;"_sv,  //
       u8"         ^^^^^^^^^^^^ Diag_JSX_Attribute_Has_Wrong_Capitalization.attribute_name"_diag
       u8"{.expected_attribute_name=onMouseEnter}"_diag,  //
-      jsx_options);
+      jsx_react_options);
 }
 
 TEST_F(Test_Parse_JSX_React, commonly_misspelled_attribute) {
@@ -72,41 +88,97 @@ TEST_F(Test_Parse_JSX_React, commonly_misspelled_attribute) {
       u8"c = <span class=\"item\"></span>;"_sv,  //
       u8"          ^^^^^ Diag_JSX_Attribute_Renamed_By_React.attribute_name"_diag
       u8"{.react_attribute_name=className}"_diag,  //
-      jsx_options);
+      jsx_react_options);
 }
 
 TEST_F(Test_Parse_JSX_React, attribute_checking_ignores_namespaced_attributes) {
   test_parse_and_visit_module(u8R"(c = <div ns:onmouseenter={handler} />;)"_sv,
-                              no_diags, jsx_options);
+                              no_diags, jsx_react_options);
   test_parse_and_visit_module(
       u8R"(c = <div onmouseenter:onmouseenter={handler} />;)"_sv, no_diags,
-      jsx_options);
+      jsx_react_options);
   test_parse_and_visit_module(u8R"(c = <div class:class="my-css-class" />;)"_sv,
-                              no_diags, jsx_options);
+                              no_diags, jsx_react_options);
 }
 
 TEST_F(Test_Parse_JSX_React, attribute_checking_ignores_namespaced_elements) {
   test_parse_and_visit_module(u8R"(c = <svg:g onmouseenter={handler} />;)"_sv,
-                              no_diags, jsx_options);
+                              no_diags, jsx_react_options);
   test_parse_and_visit_module(u8R"(c = <svg:g class="red" />;)"_sv, no_diags,
-                              jsx_options);
+                              jsx_react_options);
 }
 
 TEST_F(Test_Parse_JSX_React, attribute_checking_ignores_user_components) {
   test_parse_and_visit_module(
       u8R"(c = <MyComponent onmouseenter={handler} />;)"_sv, no_diags,
-      jsx_options);
+      jsx_react_options);
 
   test_parse_and_visit_module(u8R"(c = <MyComponent class="red" />;)"_sv,
-                              no_diags, jsx_options);
+                              no_diags, jsx_react_options);
 
   test_parse_and_visit_module(
       u8R"(c = <mymodule.mycomponent onmouseenter={handler} />;)"_sv, no_diags,
-      jsx_options);
+      jsx_react_options);
 
   test_parse_and_visit_module(
       u8R"(c = <mymodule.mycomponent class="red" />;)"_sv, no_diags,
-      jsx_options);
+      jsx_react_options);
+}
+
+TEST_F(Test_Parse_JSX_React, no_diagnostic_if_not_react_mode) {
+  test_parse_and_visit_module(u8"c = <div onclick={handler} class=\"c\" />;"_sv,
+                              no_diags, jsx_none_options);
+}
+
+TEST_F(Test_Parse_JSX_React,
+       no_diagnostic_if_auto_detect_and_react_not_imported) {
+  test_parse_and_visit_module(u8"c = <div onclick={handler} class=\"c\" />;"_sv,
+                              no_diags, jsx_auto_detect_options);
+
+  for (String8_View import_code : {
+           // Non-React modules:
+           u8"import React from 'reactive-banana';"_sv,
+           u8"import ReactRouter from 'react-router';"_sv,
+       }) {
+    test_parse_and_visit_module(
+        concat(import_code, u8" c = <div onclick={handler} class=\"c\" />;"_sv),
+        no_diags, jsx_auto_detect_options);
+  }
+}
+
+TEST_F(Test_Parse_JSX_React, diagnostic_if_auto_detect_and_react_is_imported) {
+  for (String8_View import_code : {
+           u8"import React from 'react';"_sv,
+           u8"import React from \"react\";"_sv,
+           u8"import React from 'react-dom';"_sv,
+           u8"import React from 'react-dom/client';"_sv,
+           u8"import React from 'react-dom/server';"_sv,
+           u8"import someVariable from 'react';"_sv,
+           u8"import {someExport} from 'react';"_sv, u8"import 'react';"_sv,
+           // TODO(#1159): u8"import React from '\\u{72}eact';"_sv,
+           // TODO(strager): u8"const React = require('react');"
+       }) {
+    test_parse_and_visit_module(
+        concat(import_code, u8" c = <div onclick={handler} class=\"c\" />;"_sv),
+        u8"Diag_JSX_Event_Attribute_Should_Be_Camel_Case"_diag,
+        u8"Diag_JSX_Attribute_Renamed_By_React"_diag, jsx_auto_detect_options);
+  }
+
+  test_parse_and_visit_module(
+      u8"import React = require('react'); c = <div onclick={handler} class=\"c\" />;"_sv,
+      u8"Diag_JSX_Event_Attribute_Should_Be_Camel_Case"_diag,
+      u8"Diag_JSX_Attribute_Renamed_By_React"_diag,
+      Parser_Options{
+          .jsx_mode = Parser_JSX_Mode::auto_detect,
+          .jsx = true,
+          .typescript = true,
+      });
+
+  // import after the attribute should work too:
+  test_parse_and_visit_module(
+      u8"c = <div onclick={handler} class=\"c\" />; import React from 'react';"_sv,
+      u8"Diag_JSX_Event_Attribute_Should_Be_Camel_Case"_diag,
+      u8"Diag_JSX_Attribute_Renamed_By_React"_diag, jsx_auto_detect_options);
 }
 }
 }


### PR DESCRIPTION
fix(fe): don't report React-specific JSX errors in non-React code

Preact uses JSX but has different rules for attributes. Disable our
React-specific rules if a React import is not detected.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/quick-lint/quick-lint-js/pull/1162).
* __->__ #1162
* #1161
* #1160