### PR TITLE
feat: error on 'for await' in non-async function

### DIFF
--- a/src/quick-lint-js/fe/parse-statement.cpp
+++ b/src/quick-lint-js/fe/parse-statement.cpp
@@ -3998,6 +3998,15 @@ void Parser::parse_and_visit_for(Parse_Visitor_Base &v) {
 
   bool is_for_await = this->peek().type == Token_Type::kw_await;
   if (is_for_await) {
+    if (this->in_top_level_) {
+      // TODO: Emit a diagnostic if the top level await mode does not allow
+      // await operators (Parser_Top_Level_Await_Mode::no_await_operator).
+    } else {
+      if (!this->in_async_function_) {
+        this->diag_reporter_->report(
+            Diag_Await_Operator_Outside_Async{this->peek().span()});
+      }
+    }
     this->skip();
   }
 

--- a/test/test-parse-statement.cpp
+++ b/test/test-parse-statement.cpp
@@ -1312,6 +1312,23 @@ TEST_F(Test_Parse_Statement, if_body_with_semicolon_typescript) {
     EXPECT_THAT(p.errors, IsEmpty());
   }
 }
+
+TEST_F(Test_Parse_Statement, disallow_for_await_in_non_async_function) {
+  Spy_Visitor p = test_parse_and_visit_statement(
+      u8"function f() { for await (let x of []) {} }"_sv,  //
+      u8"                   ^^^^^ Diag_Await_Operator_Outside_Async"_diag);
+  EXPECT_THAT(p.visits, ElementsAreArray({
+                            "visit_enter_function_scope",       //
+                            "visit_enter_function_scope_body",  //
+                            "visit_enter_for_scope",            //
+                            "visit_variable_declaration",       // x
+                            "visit_enter_block_scope",          //
+                            "visit_exit_block_scope",           //
+                            "visit_exit_for_scope",             //
+                            "visit_exit_function_scope",        //
+                            "visit_variable_declaration",       //
+                        }));
+}
 }
 }
 


### PR DESCRIPTION
Added diagnostic when a 'for await' statement is in a non-async function, since this statement can only be used in contexts where 'await' can be used.

closes #1137