### PR TITLE
Tries to fix the fuzzer build

### DIFF
--- a/fuzz/fuzz-configuration-json.cpp
+++ b/fuzz/fuzz-configuration-json.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <quick-lint-js/configuration/configuration.h>
 #include <quick-lint-js/container/padded-string.h>
+#include <quick-lint-js/diag/diag-list.h>
 #include <quick-lint-js/diag/diag-reporter.h>
 #include <quick-lint-js/port/char8.h>
 
@@ -14,7 +15,9 @@ int LLVMFuzzerTestOneInput(const std::uint8_t *data, std::size_t size) {
 
   Padded_String json(String8(reinterpret_cast<const Char8 *>(data), size));
   Configuration c;
-  c.load_from_json(&json, &Null_Diag_Reporter::instance);
+  Monotonic_Allocator temp_memory("fuzz");
+  Diag_List diags(&temp_memory);
+  c.load_from_json(&json, &diags);
 
   return 0;
 }

--- a/fuzz/fuzz-parse-lint.cpp
+++ b/fuzz/fuzz-parse-lint.cpp
@@ -13,10 +13,9 @@ extern "C" {
 int LLVMFuzzerTestOneInput(const std::uint8_t *data, std::size_t size) {
   quick_lint_js::Padded_String source(quick_lint_js::String8(
       reinterpret_cast<const quick_lint_js::Char8 *>(data), size));
-  quick_lint_js::Global_Declared_Variable_Set globals;
   quick_lint_js::parse_and_lint(&source,
                                 quick_lint_js::Null_Diag_Reporter::instance,
-                                globals, quick_lint_js::Linter_Options());
+                                quick_lint_js::Linter_Options());
   return 0;
 }
 }

--- a/fuzz/fuzz-parse-lint.cpp
+++ b/fuzz/fuzz-parse-lint.cpp
@@ -3,6 +3,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <quick-lint-js/configuration/configuration.h>
 #include <quick-lint-js/container/padded-string.h>
 #include <quick-lint-js/diag/diag-reporter.h>
 #include <quick-lint-js/fe/global-declared-variable-set.h>
@@ -13,9 +14,13 @@ extern "C" {
 int LLVMFuzzerTestOneInput(const std::uint8_t *data, std::size_t size) {
   quick_lint_js::Padded_String source(quick_lint_js::String8(
       reinterpret_cast<const quick_lint_js::Char8 *>(data), size));
+
+  quick_lint_js::Configuration config;
   quick_lint_js::parse_and_lint(&source,
                                 quick_lint_js::Null_Diag_Reporter::instance,
-                                quick_lint_js::Linter_Options());
+                                quick_lint_js::Linter_Options{
+                                    .configuration = &config,
+                                });
   return 0;
 }
 }


### PR DESCRIPTION
Building the fuzzers did not work for me.

It looks like the commit `8426914` broke the `fuzz/fuzz-configuration-json.cpp`
and the commit `fe5742f` broke the `fuzz/fuzz-parse-ling.cpp` 

I fixed the first issue, but I'm not quite sure how to fix the second one. I got the second one to compile, but now running `./build-fuzz/fuzz/quick-lint-js-fuzz-parse-lint` gives me an ASAN error. It looks to me like the Linter_Options have to be setup properly.

ASAN Error:
```
$ ./build-fuzz/fuzz/quick-lint-js-fuzz-parse-lint

INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 3978531955
INFO: Loaded 1 modules   (181238 inline 8-bit counters): 181238 [0x55f60eed08f0, 0x55f60eefcce6),
INFO: Loaded 1 PC tables (181238 PCs): 181238 [0x55f60eefcce8,0x55f60f1c0c48),
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
/mnt/r/bar/quick-lint-js/src/quick-lint-js/fe/linter.cpp:21:52: runtime error: member access within null pointer of type 'quick_lint_js::Configuration'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /mnt/r/bar/quick-lint-js/src/quick-lint-js/fe/linter.cpp:21:52 in
/mnt/r/bar/quick-lint-js/src/quick-lint-js/fe/linter.cpp:21:52: runtime error: load of null pointer of type 'quick_lint_js::Parser_JSX_Mode'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /mnt/r/bar/quick-lint-js/src/quick-lint-js/fe/linter.cpp:21:52 in
AddressSanitizer:DEADLYSIGNAL
=================================================================
==2711==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x55f60d99344b bp 0x7fffcd3ba870 sp 0x7fffcd3b9fe0 T0)
==2711==The signal is caused by a READ memory access.
==2711==Hint: address points to the zero page.
    #0 0x55f60d99344b in quick_lint_js::parse_and_lint(quick_lint_js::Padded_String_View, quick_lint_js::Diag_Reporter&, quick_lint_js::Linter_Options) /mnt/r/bar/quick-lint-js/src/quick-lint-js/fe/linter.cpp:21:52
    #1 0x55f60d93fe5f in LLVMFuzzerTestOneInput /mnt/r/bar/quick-lint-js/fuzz/fuzz-parse-lint.cpp:16:3
    #2 0x55f60d872a23 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/mnt/r/bar/quick-lint-js/build-fuzz/fuzz/quick-lint-js-fuzz-parse-lint+0x631a23) (BuildId: 343ad420bde9f1157244409098879f53da1a8a43)
    #3 0x55f60d873970 in fuzzer::Fuzzer::ReadAndExecuteSeedCorpora(std::vector<fuzzer::SizedFile, std::allocator<fuzzer::SizedFile> >&) (/mnt/r/bar/quick-lint-js/build-fuzz/fuzz/quick-lint-js-fuzz-parse-lint+0x632970) (BuildId: 343ad420bde9f1157244409098879f53da1a8a43)
    #4 0x55f60d873fc2 in fuzzer::Fuzzer::Loop(std::vector<fuzzer::SizedFile, std::allocator<fuzzer::SizedFile> >&) (/mnt/r/bar/quick-lint-js/build-fuzz/fuzz/quick-lint-js-fuzz-parse-lint+0x632fc2) (BuildId: 343ad420bde9f1157244409098879f53da1a8a43)
    #5 0x55f60d862bc2 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/mnt/r/bar/quick-lint-js/build-fuzz/fuzz/quick-lint-js-fuzz-parse-lint+0x621bc2) (BuildId: 343ad420bde9f1157244409098879f53da1a8a43)
    #6 0x55f60d88b8c2 in main (/mnt/r/bar/quick-lint-js/build-fuzz/fuzz/quick-lint-js-fuzz-parse-lint+0x64a8c2) (BuildId: 343ad420bde9f1157244409098879f53da1a8a43)
    #7 0x7f50e3e0f1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x271c9) (BuildId: 51657f818beb1ae70372216a99b7412b8a100a20)
    #8 0x7f50e3e0f284 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x27284) (BuildId: 51657f818beb1ae70372216a99b7412b8a100a20)
    #9 0x55f60d8577d0 in _start (/mnt/r/bar/quick-lint-js/build-fuzz/fuzz/quick-lint-js-fuzz-parse-lint+0x6167d0) (BuildId: 343ad420bde9f1157244409098879f53da1a8a43)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV /mnt/r/bar/quick-lint-js/src/quick-lint-js/fe/linter.cpp:21:52 in quick_lint_js::parse_and_lint(quick_lint_js::Padded_String_View, quick_lint_js::Diag_Reporter&, quick_lint_js::Linter_Options)
==2711==ABORTING
MS: 0 ; base unit: 0000000000000000000000000000000000000000


artifact_prefix='./'; Test unit written to ./crash-da39a3ee5e6b4b0d3255bfef95601890afd80709
Base64:
```



