### PR TITLE
CI for building the fuzzers

### DIFF
--- a/.github/workflows/build-fuzzer.yml
+++ b/.github/workflows/build-fuzzer.yml
@@ -1,0 +1,73 @@
+# Copyright (C) 2020  Matthew Glazar
+# See end of file for extended copyright information.
+
+name: build the fuzzers
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  build:
+    name: ${{ matrix.toolchain.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain:
+          - { runs_on: ubuntu-latest, name: "Clang 13 libc++", container: "ghcr.io/quick-lint/quick-lint-js-github-clang:v1", CC: clang-13, CXX: clang++-13, CFLAGS: "-stdlib=libc++", CMAKE_BUILD_TYPE: "Debug", }
+          - { runs_on: ubuntu-latest, name: "Clang 13 libstdc++", container: "ghcr.io/quick-lint/quick-lint-js-github-clang:v1", CC: clang-13, CXX: clang++-13, CFLAGS: "-stdlib=libstdc++", CMAKE_BUILD_TYPE: "Debug", }
+          - { runs_on: ubuntu-latest, name: "Clang 13 Release libc++", container: "ghcr.io/quick-lint/quick-lint-js-github-clang:v1", CC: clang-13, CXX: clang++-13, CFLAGS: "-stdlib=libc++", CMAKE_BUILD_TYPE: "Release", }
+          - { runs_on: ubuntu-latest, name: "Clang 13 Release libstdc++", container: "ghcr.io/quick-lint/quick-lint-js-github-clang:v1", CC: clang-13, CXX: clang++-13, CFLAGS: "-stdlib=libstdc++", CMAKE_BUILD_TYPE: "Release", }
+    runs-on: ${{ matrix.toolchain.runs_on }}
+    container: ${{ matrix.toolchain.container }}
+    env:
+      CMAKE_BUILD_TYPE: ${{ matrix.toolchain.CMAKE_BUILD_TYPE }}
+      CMAKE_C_COMPILER: ${{ matrix.toolchain.CC }}
+      CMAKE_C_FLAGS: ${{ matrix.toolchain.CFLAGS }}
+      CMAKE_CXX_COMPILER: ${{ matrix.toolchain.CXX }}
+      CMAKE_CXX_FLAGS: ${{ matrix.toolchain.CFLAGS }}
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      - name: install dependencies (Homebrew)
+        if: ${{ matrix.toolchain.homebrew_packages }}
+        run: brew install ${{ matrix.toolchain.homebrew_packages }}
+
+      - name: configure
+        run: |
+          env | grep '^ASAN_OPTIONS\|^CMAKE\|^QUICK_LINT_JS' | sort
+          mkdir build
+          cd build
+          CC=$CMAKE_C_COMPILER CXX=$CMAKE_CXX_COMPILER CFLAGS='-fsanitize=address,undefined,fuzzer-no-link $CMAKE_C_FLAGS' CXXFLAGS='-fsanitize=address,undefined,fuzzer-no-link $CMAKE_CXX_FLAGS' cmake -G Ninja -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DQUICK_LINT_JS_ENABLE_LLVM_LIBFUZZER_TESTS=ON ..
+          cd ..
+        shell: bash
+
+      - name: build
+        run: ninja -C build
+
+      - name: sample run
+        run: |
+          mkdir fuzz-tmp
+          ls build/fuzz/
+          # try running every fuzzer for a very short time
+          for FILE in build/fuzz/quick-lint-js-fuzz-*; do echo running: $FILE; $FILE fuzz-tmp -runs=100 || exit 1; done
+
+# quick-lint-js finds bugs in JavaScript programs.
+# Copyright (C) 2020  Matthew Glazar
+#
+# This file is part of quick-lint-js.
+#
+# quick-lint-js is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# quick-lint-js is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with quick-lint-js.  If not, see <https://www.gnu.org/licenses/>.

--- a/fuzz/fuzz-parse-lint.cpp
+++ b/fuzz/fuzz-parse-lint.cpp
@@ -15,7 +15,7 @@ int LLVMFuzzerTestOneInput(const std::uint8_t *data, std::size_t size) {
   quick_lint_js::Padded_String source(quick_lint_js::String8(
       reinterpret_cast<const quick_lint_js::Char8 *>(data), size));
 
-  quick_lint_js::Configuration config;
+  quick_lint_js::CONFIGURATION config;
   quick_lint_js::parse_and_lint(&source,
                                 quick_lint_js::Null_Diag_Reporter::instance,
                                 quick_lint_js::Linter_Options{

--- a/fuzz/fuzz-parse-lint.cpp
+++ b/fuzz/fuzz-parse-lint.cpp
@@ -15,12 +15,10 @@ int LLVMFuzzerTestOneInput(const std::uint8_t *data, std::size_t size) {
   quick_lint_js::Padded_String source(quick_lint_js::String8(
       reinterpret_cast<const quick_lint_js::Char8 *>(data), size));
 
-  quick_lint_js::CONFIGURATION config;
+  quick_lint_js::Configuration config;
   quick_lint_js::parse_and_lint(&source,
                                 quick_lint_js::Null_Diag_Reporter::instance,
-                                quick_lint_js::Linter_Options{
-                                    .configuration = &config,
-                                });
+                                quick_lint_js::Linter_Options{});
   return 0;
 }
 }

--- a/fuzz/fuzz-parse-lint.cpp
+++ b/fuzz/fuzz-parse-lint.cpp
@@ -18,7 +18,9 @@ int LLVMFuzzerTestOneInput(const std::uint8_t *data, std::size_t size) {
   quick_lint_js::Configuration config;
   quick_lint_js::parse_and_lint(&source,
                                 quick_lint_js::Null_Diag_Reporter::instance,
-                                quick_lint_js::Linter_Options{});
+                                quick_lint_js::Linter_Options{
+                                    .configuration = &config,
+                                });
   return 0;
 }
 }


### PR DESCRIPTION
I added a workflow to check if the fuzzer build still works. It will build the fuzzers like described in `docs/FUZZING.md` and after the build succeeds, it will run each fuzzer for a short time to check if there is an obvious runtime error.

To give an example, there are two commits on this branch. 0f9bfee0 will fail at compile time. c1792afb will be caught by ASAN when running the fuzzers.

Right now, it only runs on Linux. Should we also test this on Windows or Mac?

fix #926