### PR TITLE
refactor(vscode): inject translator and workspace

### DIFF
--- a/plugin/vscode/quick-lint-js/vscode/qljs-document.h
+++ b/plugin/vscode/quick-lint-js/vscode/qljs-document.h
@@ -120,19 +120,12 @@ class QLJS_Config_Document : public QLJS_Document_Base {
                               Loaded_Config_File* config_file) override;
 
  private:
-  void lint_config_and_publish_diagnostics(::Napi::Env, VSCode_Module&,
-                                           VSCode_Diagnostic_Collection,
-                                           Loaded_Config_File* loaded_config);
+  void lint_config_and_publish_diagnostics(::Napi::Env, QLJS_Workspace&,
+                                           VSCode_Diagnostic_Collection);
 
-  ::Napi::Array lint_config(::Napi::Env env, VSCode_Module* vscode,
-                            Loaded_Config_File* loaded_config) {
-    vscode->load_non_persistent(env);
+  ::Napi::Array lint_config(::Napi::Env env, QLJS_Workspace& workspace);
 
-    LSP_Locator locator(&loaded_config->file_content);
-    VSCode_Diag_Reporter diag_reporter(vscode, env, &locator, this->uri());
-    diag_reporter.report(loaded_config->errors);
-    return std::move(diag_reporter).diagnostics();
-  }
+  Loaded_Config_File* loaded_config_ = nullptr;
 };
 
 class QLJS_Lintable_Document : public QLJS_Document_Base {
@@ -150,23 +143,11 @@ class QLJS_Lintable_Document : public QLJS_Document_Base {
                               VSCode_Diagnostic_Collection,
                               Loaded_Config_File* config_file) override;
 
-  void lint_javascript_and_publish_diagnostics(::Napi::Env, VSCode_Module&,
+  void lint_javascript_and_publish_diagnostics(::Napi::Env, QLJS_Workspace&,
                                                VSCode_Diagnostic_Collection);
 
  private:
-  ::Napi::Array lint_javascript(::Napi::Env env, VSCode_Module* vscode) {
-    vscode->load_non_persistent(env);
-
-    VSCode_Diag_Reporter diag_reporter(vscode, env, &this->document_.locator(),
-                                       this->uri());
-    parse_and_lint(this->document_.string(), diag_reporter,
-                   Linter_Options{
-                       .language = this->language_,
-                       .configuration = this->config_,
-                   });
-
-    return std::move(diag_reporter).diagnostics();
-  }
+  ::Napi::Array lint_javascript(::Napi::Env env, QLJS_Workspace& workspace);
 
   Configuration* config_;  // Initialized by finish_init.
 

--- a/plugin/vscode/quick-lint-js/vscode/qljs-workspace.h
+++ b/plugin/vscode/quick-lint-js/vscode/qljs-workspace.h
@@ -248,6 +248,8 @@ class QLJS_Workspace : public ::Napi::ObjectWrap<QLJS_Workspace> {
     QLJS_Workspace* workspace_;
   };
 
+ private:
+  Translator translator_;
   bool disposed_ = false;
   VSCode_Tracer tracer_;
   VSCode_Module vscode_;

--- a/plugin/vscode/quick-lint-js/vscode/vscode-diag-reporter.h
+++ b/plugin/vscode/quick-lint-js/vscode/vscode-diag-reporter.h
@@ -18,8 +18,9 @@ class VSCode_Diag_Formatter
   explicit VSCode_Diag_Formatter(VSCode_Module* vscode, ::Napi::Env env,
                                  ::Napi::Array diagnostics,
                                  const LSP_Locator* locator,
-                                 ::Napi::Value document_uri)
-      : Diagnostic_Formatter(qljs_messages),
+                                 ::Napi::Value document_uri,
+                                 Translator message_translator)
+      : Diagnostic_Formatter(message_translator),
         vscode_(vscode),
         env_(env),
         diagnostics_(diagnostics),
@@ -129,12 +130,14 @@ class VSCode_Diag_Reporter final : public Diag_Reporter {
  public:
   explicit VSCode_Diag_Reporter(VSCode_Module* vscode, ::Napi::Env env,
                                 const LSP_Locator* locator,
-                                ::Napi::Value document_uri)
+                                ::Napi::Value document_uri,
+                                Translator message_translator)
       : vscode_(vscode),
         env_(env),
         diagnostics_(::Napi::Array::New(env)),
         locator_(locator),
-        document_uri_(document_uri) {}
+        document_uri_(document_uri),
+        message_translator_(message_translator) {}
 
   ::Napi::Array diagnostics() const { return this->diagnostics_; }
 
@@ -144,7 +147,8 @@ class VSCode_Diag_Reporter final : public Diag_Reporter {
         /*env=*/this->env_,
         /*diagnostics=*/this->diagnostics_,
         /*locator=*/this->locator_,
-        /*document_uri=*/this->document_uri_);
+        /*document_uri=*/this->document_uri_,
+        /*message_translator=*/this->message_translator_);
     formatter.format(get_diagnostic_info(type), diag);
   }
 
@@ -154,6 +158,7 @@ class VSCode_Diag_Reporter final : public Diag_Reporter {
   ::Napi::Array diagnostics_;
   const LSP_Locator* locator_;
   ::Napi::Value document_uri_;
+  Translator message_translator_;
 };
 }
 


### PR DESCRIPTION
refactor(vscode): inject translator and workspace

Summary: This commit refactors the global translator class into a variable
injected into the VSCode workspace, and gives the workspace as an argument to
QLJS_Lintable_Document.

This refactor clears the way for adding snarky and language settings for VSCode

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/quick-lint/quick-lint-js/pull/1189).
* #1190
* __->__ #1189