### PR TITLE
feat(vscode): make quick-lint a jerk 🖕

### DIFF
--- a/plugin/vscode/package.json
+++ b/plugin/vscode/package.json
@@ -47,6 +47,12 @@
           ],
           "default": "off",
           "description": "Log document changes. Useful for quick-lint-js contributors."
+        },
+        "quick-lint-js.snarky": {
+          "scope": "window",
+          "type": "boolean",
+          "default": false,
+          "description": "Add spice to your failures."
         }
       }
     },

--- a/plugin/vscode/quick-lint-js/vscode/qljs-document.cpp
+++ b/plugin/vscode/quick-lint-js/vscode/qljs-document.cpp
@@ -79,6 +79,12 @@ void QLJS_Config_Document::on_config_file_changed(
                                             diagnostic_collection);
 }
 
+void QLJS_Config_Document::on_translator_changed(
+    ::Napi::Env env, QLJS_Workspace& workspace,
+    VSCode_Diagnostic_Collection diagnostic_collection) {
+  this->lint_config_and_publish_diagnostics(env, workspace,
+                                            diagnostic_collection);
+}
 void QLJS_Config_Document::lint_config_and_publish_diagnostics(
     ::Napi::Env env, QLJS_Workspace& workspace,
     VSCode_Diagnostic_Collection diagnostic_collection) {
@@ -106,6 +112,12 @@ void QLJS_Lintable_Document::on_config_file_changed(
                                                 diagnostic_collection);
 }
 
+void QLJS_Lintable_Document::on_translator_changed(
+    ::Napi::Env env, QLJS_Workspace& workspace,
+    VSCode_Diagnostic_Collection diagnostic_collection) {
+  this->lint_javascript_and_publish_diagnostics(env, workspace,
+                                                diagnostic_collection);
+}
 void QLJS_Lintable_Document::lint_javascript_and_publish_diagnostics(
     ::Napi::Env env, QLJS_Workspace& workspace,
     VSCode_Diagnostic_Collection diagnostic_collection) {

--- a/plugin/vscode/quick-lint-js/vscode/qljs-document.h
+++ b/plugin/vscode/quick-lint-js/vscode/qljs-document.h
@@ -94,6 +94,10 @@ class QLJS_Document_Base {
                                       VSCode_Diagnostic_Collection,
                                       Loaded_Config_File* config_file) = 0;
 
+  virtual void on_translator_changed(
+      ::Napi::Env env, QLJS_Workspace& workspace,
+      VSCode_Diagnostic_Collection diagnostic_collection) = 0;
+
  protected:
   ::Napi::Value uri() { return this->vscode_document_.Value().uri(); }
 
@@ -118,6 +122,9 @@ class QLJS_Config_Document : public QLJS_Document_Base {
   void on_config_file_changed(::Napi::Env, QLJS_Workspace&,
                               VSCode_Diagnostic_Collection,
                               Loaded_Config_File* config_file) override;
+  void on_translator_changed(
+      ::Napi::Env env, QLJS_Workspace& workspace,
+      VSCode_Diagnostic_Collection diagnostic_collection) override;
 
  private:
   void lint_config_and_publish_diagnostics(::Napi::Env, QLJS_Workspace&,
@@ -142,6 +149,8 @@ class QLJS_Lintable_Document : public QLJS_Document_Base {
   void on_config_file_changed(::Napi::Env, QLJS_Workspace&,
                               VSCode_Diagnostic_Collection,
                               Loaded_Config_File* config_file) override;
+  void on_translator_changed(::Napi::Env, QLJS_Workspace&,
+                             VSCode_Diagnostic_Collection) override;
 
   void lint_javascript_and_publish_diagnostics(::Napi::Env, QLJS_Workspace&,
                                                VSCode_Diagnostic_Collection);

--- a/plugin/vscode/quick-lint-js/vscode/qljs-document.h
+++ b/plugin/vscode/quick-lint-js/vscode/qljs-document.h
@@ -120,19 +120,12 @@ class QLJS_Config_Document : public QLJS_Document_Base {
                               Loaded_Config_File* config_file) override;
 
  private:
-  void lint_config_and_publish_diagnostics(::Napi::Env, VSCode_Module&,
-                                           VSCode_Diagnostic_Collection,
-                                           Loaded_Config_File* loaded_config);
+  void lint_config_and_publish_diagnostics(::Napi::Env, QLJS_Workspace&,
+                                           VSCode_Diagnostic_Collection);
 
-  ::Napi::Array lint_config(::Napi::Env env, VSCode_Module* vscode,
-                            Loaded_Config_File* loaded_config) {
-    vscode->load_non_persistent(env);
+  ::Napi::Array lint_config(::Napi::Env env, QLJS_Workspace& workspace);
 
-    LSP_Locator locator(&loaded_config->file_content);
-    VSCode_Diag_Reporter diag_reporter(vscode, env, &locator, this->uri());
-    diag_reporter.report(loaded_config->errors);
-    return std::move(diag_reporter).diagnostics();
-  }
+  Loaded_Config_File* loaded_config_ = nullptr;
 };
 
 class QLJS_Lintable_Document : public QLJS_Document_Base {
@@ -150,23 +143,11 @@ class QLJS_Lintable_Document : public QLJS_Document_Base {
                               VSCode_Diagnostic_Collection,
                               Loaded_Config_File* config_file) override;
 
-  void lint_javascript_and_publish_diagnostics(::Napi::Env, VSCode_Module&,
+  void lint_javascript_and_publish_diagnostics(::Napi::Env, QLJS_Workspace&,
                                                VSCode_Diagnostic_Collection);
 
  private:
-  ::Napi::Array lint_javascript(::Napi::Env env, VSCode_Module* vscode) {
-    vscode->load_non_persistent(env);
-
-    VSCode_Diag_Reporter diag_reporter(vscode, env, &this->document_.locator(),
-                                       this->uri());
-    parse_and_lint(this->document_.string(), diag_reporter,
-                   Linter_Options{
-                       .language = this->language_,
-                       .configuration = this->config_,
-                   });
-
-    return std::move(diag_reporter).diagnostics();
-  }
+  ::Napi::Array lint_javascript(::Napi::Env env, QLJS_Workspace& workspace);
 
   Configuration* config_;  // Initialized by finish_init.
 

--- a/plugin/vscode/quick-lint-js/vscode/qljs-workspace.cpp
+++ b/plugin/vscode/quick-lint-js/vscode/qljs-workspace.cpp
@@ -86,6 +86,14 @@ class Extension_Configuration {
     }
   }
 
+  bool get_snarky(::Napi::Env env) {
+    ::Napi::Value value = this->get(env, "snarky");
+    if (!value.IsBoolean()) {
+      return false;
+    }
+    return value.As<::Napi::Boolean>();
+  }
+
   ::Napi::Value get(::Napi::Env env, const char* section) {
     return this->config_ref_.Get("get").As<::Napi::Function>().Call(
         this->config_ref_.Value(), {::Napi::String::New(env, section)});
@@ -124,7 +132,8 @@ QLJS_Workspace::QLJS_Workspace(const Napi::CallbackInfo& info)
           ::Napi::Persistent(info[2].As<::Napi::Object>())),
       ui_(this) {
   QLJS_DEBUG_LOG("Workspace %p: created\n", this);
-  this->update_logging(info.Env());
+  configuration_changed(info);
+
   this->fs_change_detection_thread_ =
       Thread([this]() -> void { this->run_fs_change_detection_thread(); });
 }
@@ -234,8 +243,27 @@ void QLJS_Workspace::dispose_documents() {
   ::Napi::Env env = info.Env();
 
   this->update_logging(env);
+  this->on_translator_changed(env);
 
   return env.Undefined();
+}
+
+void QLJS_Workspace::on_translator_changed(::Napi::Env env) {
+  Extension_Configuration config(env, this->vscode_);
+  bool is_snarky = config.get_snarky(env);
+
+  this->is_snarky_enabled_ = is_snarky;
+  if (is_snarky) {
+    this->translator_.use_messages_from_locale("en_US@snarky");
+  } else {
+    // TODO(#529): Use the locale from the VS Code configuration.
+    this->translator_.use_messages_from_source_code();
+  }
+  this->qljs_documents_.for_each(
+      [this, is_snarky, env](::Napi::Value value) -> void {
+        QLJS_Document_Base* doc = QLJS_Document_Base::unwrap(value);
+        doc->on_translator_changed(env, *this, this->diagnostic_collection());
+      });
 }
 
 ::Napi::Value QLJS_Workspace::editor_visibility_changed(

--- a/plugin/vscode/quick-lint-js/vscode/qljs-workspace.h
+++ b/plugin/vscode/quick-lint-js/vscode/qljs-workspace.h
@@ -248,6 +248,8 @@ class QLJS_Workspace : public ::Napi::ObjectWrap<QLJS_Workspace> {
     QLJS_Workspace* workspace_;
   };
 
+ private:
+  Translator translator_;
   bool disposed_ = false;
   VSCode_Tracer tracer_;
   VSCode_Module vscode_;

--- a/plugin/vscode/quick-lint-js/vscode/qljs-workspace.h
+++ b/plugin/vscode/quick-lint-js/vscode/qljs-workspace.h
@@ -73,6 +73,8 @@ class QLJS_Workspace : public ::Napi::ObjectWrap<QLJS_Workspace> {
   // Disable logging if logging is enabled.
   void disable_logging();
 
+  void on_translator_changed(::Napi::Env env);
+
   ~QLJS_Workspace();
 
   ::Napi::Value dispose(const ::Napi::CallbackInfo& info);
@@ -248,8 +250,13 @@ class QLJS_Workspace : public ::Napi::ObjectWrap<QLJS_Workspace> {
     QLJS_Workspace* workspace_;
   };
 
+ public:
+  bool is_snarky_enabled() const;
+
  private:
+  bool is_snarky_enabled_ = false;
   Translator translator_;
+
   bool disposed_ = false;
   VSCode_Tracer tracer_;
   VSCode_Module vscode_;

--- a/plugin/vscode/quick-lint-js/vscode/vscode-diag-reporter.h
+++ b/plugin/vscode/quick-lint-js/vscode/vscode-diag-reporter.h
@@ -18,8 +18,9 @@ class VSCode_Diag_Formatter
   explicit VSCode_Diag_Formatter(VSCode_Module* vscode, ::Napi::Env env,
                                  ::Napi::Array diagnostics,
                                  const LSP_Locator* locator,
-                                 ::Napi::Value document_uri)
-      : Diagnostic_Formatter(qljs_messages),
+                                 ::Napi::Value document_uri,
+                                 Translator message_translator)
+      : Diagnostic_Formatter(message_translator),
         vscode_(vscode),
         env_(env),
         diagnostics_(diagnostics),
@@ -129,12 +130,14 @@ class VSCode_Diag_Reporter final : public Diag_Reporter {
  public:
   explicit VSCode_Diag_Reporter(VSCode_Module* vscode, ::Napi::Env env,
                                 const LSP_Locator* locator,
-                                ::Napi::Value document_uri)
+                                ::Napi::Value document_uri,
+                                Translator message_translator)
       : vscode_(vscode),
         env_(env),
         diagnostics_(::Napi::Array::New(env)),
         locator_(locator),
-        document_uri_(document_uri) {}
+        document_uri_(document_uri),
+        message_translator_(message_translator) {}
 
   ::Napi::Array diagnostics() const { return this->diagnostics_; }
 
@@ -144,7 +147,8 @@ class VSCode_Diag_Reporter final : public Diag_Reporter {
         /*env=*/this->env_,
         /*diagnostics=*/this->diagnostics_,
         /*locator=*/this->locator_,
-        /*document_uri=*/this->document_uri_);
+        /*document_uri=*/this->document_uri_,
+        /*message_translator=*/this->message_translator_);
     formatter.format(get_diagnostic_info(type), diag);
   }
 
@@ -154,6 +158,7 @@ class VSCode_Diag_Reporter final : public Diag_Reporter {
   ::Napi::Array diagnostics_;
   const LSP_Locator* locator_;
   ::Napi::Value document_uri_;
+  Translator message_translator_;
 };
 }
 

--- a/src/quick-lint-js/i18n/translation.cpp
+++ b/src/quick-lint-js/i18n/translation.cpp
@@ -63,6 +63,7 @@ Span<std::string_view> get_user_locale_preferences(
 
   // TODO(strager): Determine the language using macOS' and Windows' native
   // APIs. See GNU gettext's _nl_language_preferences_default.
+  // TODO (#529): Also use VSCode's "Display Language" setting
 
   Vector<std::string_view> locales("locales", allocator);
   locales.push_back(locale);


### PR DESCRIPTION
feat(vscode): make quick-lint a jerk 🖕


Summary: It ticks me off 😠 how polite 😇 quick-lint is when I code.  If I mess
up 😬, I want it to tell me.  Stop beating around the bush 🌳 and tell it to me
like it is. 💯

Test plan: 📝
1. open TypeScript file with no errors in it ✅
2. add an error ❌
3. note how quick-lint tells you what the problem is like a sissy 😭
4. enable settings > quick-lint-js > snarky 😈
5. note how quick-lint is straight up with you.  You suck. 🗑️

Closes #1188

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/quick-lint/quick-lint-js/pull/1190).
* __->__ #1190
* #1189