### PR TITLE
feat(fe): add warning for 'let({x} = y);'

### DIFF
--- a/docs/errors/E0720.md
+++ b/docs/errors/E0720.md
@@ -1,39 +1,18 @@
-# E0720: calling `let` on an assignment is ambiguous
+# E0720: function 'let' call may be confused for destructuring; remove parentheses to declare a variable
 
-If `let` is declared as a function, then this code:
+In JavaScript, variables can be named `let` and interpreted as a function
+call if it is followed by parentheses. This code calls function `let`
+instead of destructuring an object:
 
 ```javascript
-function let(arg) {
-  console.log(arg);
-}
-
-const y = {x: "hello", z: "world"};
-let ({x} = y);
+const words = {first: "hello", second: "world"};
+let ({first} = words);
 ```
 
-is actually equivalent to:
+If you want to declare a variable, remove the parentheses:
 
 ```javascript
-function let(arg) {
-  console.log(arg);
-}
-
-const y = {x: "hello", z: "world"};
-let(y);
-```
-
-instead of destructuring `y`.
-
-To remove the ambiguity, separate the declaration and the assignment into two
-statements:
-
-```javascript
-function let(arg) {
-  console.log(arg);
-}
-
-const y = {x: "hello", z: "world"};
-let x;
-({x} = y);
+const words = {first: "hello", second: "world"};
+let {first} = words;
 
 ```

--- a/docs/errors/E0720.md
+++ b/docs/errors/E0720.md
@@ -1,0 +1,39 @@
+# E0720: calling `let` on an assignment is ambiguous
+
+If `let` is declared as a function, then this code:
+
+```javascript
+function let(arg) {
+  console.log(arg);
+}
+
+const y = {x: "hello", z: "world"};
+let ({x} = y);
+```
+
+is actually equivalent to:
+
+```javascript
+function let(arg) {
+  console.log(arg);
+}
+
+const y = {x: "hello", z: "world"};
+let(y);
+```
+
+instead of destructuring `y`.
+
+To remove the ambiguity, separate the declaration and the assignment into two
+statements:
+
+```javascript
+function let(arg) {
+  console.log(arg);
+}
+
+const y = {x: "hello", z: "world"};
+let x;
+({x} = y);
+
+```

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -2414,7 +2414,7 @@ msgid "namespace alias cannot use 'import type'"
 msgstr ""
 
 #: src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
-msgid "ambiguous use of the keyword 'let'; let is a function in this scope"
+msgid "function 'let' call may be confused for destructuring;remove parentheses to declare a variable"
 msgstr ""
 
 #: test/test-diagnostic-formatter.cpp

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -2413,6 +2413,10 @@ msgstr ""
 msgid "namespace alias cannot use 'import type'"
 msgstr ""
 
+#: src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
+msgid "ambiguous use of the keyword 'let'; let is a function in this scope"
+msgstr ""
+
 #: test/test-diagnostic-formatter.cpp
 #: test/test-vim-qflist-json-diag-reporter.cpp
 msgid "something happened"

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -2414,7 +2414,7 @@ msgid "namespace alias cannot use 'import type'"
 msgstr ""
 
 #: src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
-msgid "function 'let' call may be confused for destructuring;remove parentheses to declare a variable"
+msgid "function 'let' call may be confused for destructuring; remove parentheses to declare a variable"
 msgstr ""
 
 #: test/test-diagnostic-formatter.cpp

--- a/src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
+++ b/src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
@@ -6912,6 +6912,20 @@ const QLJS_CONSTINIT Diagnostic_Info all_diagnostic_infos[] = {
         },
       },
     },
+
+    // Diag_Ambiguous_Let_Call
+    {
+      .code = 720,
+      .severity = Diagnostic_Severity::warning,
+      .message_formats = {
+        QLJS_TRANSLATABLE("ambiguous use of the keyword 'let'; let is a function in this scope"),
+      },
+      .message_args = {
+        {
+          Diagnostic_Message_Arg_Info(offsetof(Diag_Ambiguous_Let_Call, let_function_call), Diagnostic_Arg_Type::source_code_span),
+        },
+      },
+    },
 };
 }
 

--- a/src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
+++ b/src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
@@ -6913,16 +6913,16 @@ const QLJS_CONSTINIT Diagnostic_Info all_diagnostic_infos[] = {
       },
     },
 
-    // Diag_Ambiguous_Let_Call
+    // Diag_Confusing_Let_Call
     {
       .code = 720,
       .severity = Diagnostic_Severity::warning,
       .message_formats = {
-        QLJS_TRANSLATABLE("ambiguous use of the keyword 'let'; let is a function in this scope"),
+        QLJS_TRANSLATABLE("function 'let' call may be confused for destructuring;remove parentheses to declare a variable"),
       },
       .message_args = {
         {
-          Diagnostic_Message_Arg_Info(offsetof(Diag_Ambiguous_Let_Call, let_function_call), Diagnostic_Arg_Type::source_code_span),
+          Diagnostic_Message_Arg_Info(offsetof(Diag_Confusing_Let_Call, let_function_call), Diagnostic_Arg_Type::source_code_span),
         },
       },
     },

--- a/src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
+++ b/src/quick-lint-js/diag/diagnostic-metadata-generated.cpp
@@ -6918,7 +6918,7 @@ const QLJS_CONSTINIT Diagnostic_Info all_diagnostic_infos[] = {
       .code = 720,
       .severity = Diagnostic_Severity::warning,
       .message_formats = {
-        QLJS_TRANSLATABLE("function 'let' call may be confused for destructuring;remove parentheses to declare a variable"),
+        QLJS_TRANSLATABLE("function 'let' call may be confused for destructuring; remove parentheses to declare a variable"),
       },
       .message_args = {
         {

--- a/src/quick-lint-js/diag/diagnostic-metadata-generated.h
+++ b/src/quick-lint-js/diag/diagnostic-metadata-generated.h
@@ -472,10 +472,11 @@ namespace quick_lint_js {
   QLJS_DIAG_TYPE_NAME(Diag_Multiple_Export_Defaults) \
   QLJS_DIAG_TYPE_NAME(Diag_Unintuitive_Bitshift_Precedence) \
   QLJS_DIAG_TYPE_NAME(Diag_TypeScript_Namespace_Alias_Cannot_Use_Import_Type) \
+  QLJS_DIAG_TYPE_NAME(Diag_Ambiguous_Let_Call) \
   /* END */
 // clang-format on
 
-inline constexpr int Diag_Type_Count = 461;
+inline constexpr int Diag_Type_Count = 462;
 
 extern const Diagnostic_Info all_diagnostic_infos[Diag_Type_Count];
 }

--- a/src/quick-lint-js/diag/diagnostic-metadata-generated.h
+++ b/src/quick-lint-js/diag/diagnostic-metadata-generated.h
@@ -472,7 +472,7 @@ namespace quick_lint_js {
   QLJS_DIAG_TYPE_NAME(Diag_Multiple_Export_Defaults) \
   QLJS_DIAG_TYPE_NAME(Diag_Unintuitive_Bitshift_Precedence) \
   QLJS_DIAG_TYPE_NAME(Diag_TypeScript_Namespace_Alias_Cannot_Use_Import_Type) \
-  QLJS_DIAG_TYPE_NAME(Diag_Ambiguous_Let_Call) \
+  QLJS_DIAG_TYPE_NAME(Diag_Confusing_Let_Call) \
   /* END */
 // clang-format on
 

--- a/src/quick-lint-js/diag/diagnostic-types-2.h
+++ b/src/quick-lint-js/diag/diagnostic-types-2.h
@@ -3589,6 +3589,16 @@ struct Diag_TypeScript_Namespace_Alias_Cannot_Use_Import_Type {
                   ARG(type_keyword))]]  //
   Source_Code_Span type_keyword;
 };
+
+struct Diag_Ambiguous_Let_Call {
+  [[qljs::diag("E0720", Diagnostic_Severity::warning)]]  //
+  [
+      [qljs::message("ambiguous use of the keyword 'let'; "
+                     "let is a function in this scope",
+                     ARG(let_function_call))]]  //
+  Source_Code_Span let_function_call;
+};
+
 }
 QLJS_WARNING_POP
 

--- a/src/quick-lint-js/diag/diagnostic-types-2.h
+++ b/src/quick-lint-js/diag/diagnostic-types-2.h
@@ -3590,11 +3590,11 @@ struct Diag_TypeScript_Namespace_Alias_Cannot_Use_Import_Type {
   Source_Code_Span type_keyword;
 };
 
-struct Diag_Ambiguous_Let_Call {
+struct Diag_Confusing_Let_Call {
   [[qljs::diag("E0720", Diagnostic_Severity::warning)]]  //
   [
-      [qljs::message("ambiguous use of the keyword 'let'; "
-                     "let is a function in this scope",
+      [qljs::message("function 'let' call may be confused for destructuring; "
+                     "remove parentheses to declare a variable",
                      ARG(let_function_call))]]  //
   Source_Code_Span let_function_call;
 };

--- a/src/quick-lint-js/fe/parse-statement.cpp
+++ b/src/quick-lint-js/fe/parse-statement.cpp
@@ -163,14 +163,17 @@ parse_statement:
           this->parse_expression(v, Precedence{.in_operator = true});
       this->visit_expression(ast, v, Variable_Context::rhs);
 
-      // let ({x} = y);  // Ambiguous if 'let' is a function
+      // let ({x} = y);  // Confusing, if 'let' is a function
       if (ast->kind() == Expression_Kind::Call) {
         Expression::Call *call = expression_cast<Expression::Call *>(ast);
         if (call->child_count() == 2 &&
+            call->child_0()->kind() == Expression_Kind::Variable &&
+            expression_cast<Expression::Variable *>(call->child_0())->type_ ==
+                Token_Type::kw_let &&
             call->child_1()->kind() == Expression_Kind::Assignment &&
             call->child_1()->child_0()->kind() == Expression_Kind::Object) {
           this->diag_reporter_->report(
-              Diag_Ambiguous_Let_Call{.let_function_call = let_token.span()});
+              Diag_Confusing_Let_Call{.let_function_call = let_token.span()});
         }
       }
 

--- a/src/quick-lint-js/i18n/translation-table-generated.cpp
+++ b/src/quick-lint-js/i18n/translation-table-generated.cpp
@@ -196,8 +196,7 @@ const Translation_Table translation_data = {
         {0, 0, 0, 58, 0, 50},                //
         {0, 0, 0, 0, 0, 57},                 //
         {0, 0, 0, 0, 0, 37},                 //
-        {0, 0, 0, 0, 0, 29},                 //
-        {14, 14, 0, 64, 0, 68},              //
+        {14, 14, 0, 64, 0, 29},              //
         {0, 0, 0, 0, 0, 18},                 //
         {0, 0, 0, 0, 0, 8},                  //
         {0, 0, 0, 0, 0, 16},                 //
@@ -318,7 +317,8 @@ const Translation_Table translation_data = {
         {61, 26, 69, 43, 41, 46},            //
         {53, 51, 0, 0, 0, 51},               //
         {0, 0, 0, 0, 0, 25},                 //
-        {27, 25, 64, 54, 59, 9},             //
+        {0, 0, 0, 0, 0, 9},                  //
+        {27, 25, 64, 54, 59, 95},            //
         {29, 17, 31, 33, 0, 27},             //
         {68, 28, 70, 45, 30, 55},            //
         {0, 0, 0, 24, 0, 23},                //
@@ -2068,7 +2068,6 @@ const Translation_Table translation_data = {
         u8"abstract properties are only allowed in abstract classes\0"
         u8"abstract properties cannot be static\0"
         u8"accessors cannot be optional\0"
-        u8"ambiguous use of the keyword 'let'; let is a function in this scope\0"
         u8"an 'if' statement\0"
         u8"an enum\0"
         u8"an import alias\0"
@@ -2190,6 +2189,7 @@ const Translation_Table translation_data = {
         u8"forwarding exports are only allowed in export-from\0"
         u8"free {1} and {0} {1} {2}\0"
         u8"function\0"
+        u8"function 'let' call may be confused for destructuring;remove parentheses to declare a variable\0"
         u8"function call started here\0"
         u8"function called before declaration in block scope: {0}\0"
         u8"function declared here\0"

--- a/src/quick-lint-js/i18n/translation-table-generated.cpp
+++ b/src/quick-lint-js/i18n/translation-table-generated.cpp
@@ -196,7 +196,8 @@ const Translation_Table translation_data = {
         {0, 0, 0, 58, 0, 50},                //
         {0, 0, 0, 0, 0, 57},                 //
         {0, 0, 0, 0, 0, 37},                 //
-        {14, 14, 0, 64, 0, 29},              //
+        {0, 0, 0, 0, 0, 29},                 //
+        {14, 14, 0, 64, 0, 68},              //
         {0, 0, 0, 0, 0, 18},                 //
         {0, 0, 0, 0, 0, 8},                  //
         {0, 0, 0, 0, 0, 16},                 //
@@ -2067,6 +2068,7 @@ const Translation_Table translation_data = {
         u8"abstract properties are only allowed in abstract classes\0"
         u8"abstract properties cannot be static\0"
         u8"accessors cannot be optional\0"
+        u8"ambiguous use of the keyword 'let'; let is a function in this scope\0"
         u8"an 'if' statement\0"
         u8"an enum\0"
         u8"an import alias\0"

--- a/src/quick-lint-js/i18n/translation-table-generated.cpp
+++ b/src/quick-lint-js/i18n/translation-table-generated.cpp
@@ -318,7 +318,7 @@ const Translation_Table translation_data = {
         {53, 51, 0, 0, 0, 51},               //
         {0, 0, 0, 0, 0, 25},                 //
         {0, 0, 0, 0, 0, 9},                  //
-        {27, 25, 64, 54, 59, 95},            //
+        {27, 25, 64, 54, 59, 96},            //
         {29, 17, 31, 33, 0, 27},             //
         {68, 28, 70, 45, 30, 55},            //
         {0, 0, 0, 24, 0, 23},                //
@@ -2189,7 +2189,7 @@ const Translation_Table translation_data = {
         u8"forwarding exports are only allowed in export-from\0"
         u8"free {1} and {0} {1} {2}\0"
         u8"function\0"
-        u8"function 'let' call may be confused for destructuring;remove parentheses to declare a variable\0"
+        u8"function 'let' call may be confused for destructuring; remove parentheses to declare a variable\0"
         u8"function call started here\0"
         u8"function called before declaration in block scope: {0}\0"
         u8"function declared here\0"

--- a/src/quick-lint-js/i18n/translation-table-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-generated.h
@@ -19,7 +19,7 @@ using namespace std::literals::string_view_literals;
 
 constexpr std::uint32_t translation_table_locale_count = 5;
 constexpr std::uint16_t translation_table_mapping_table_size = 606;
-constexpr std::size_t translation_table_string_table_size = 82503;
+constexpr std::size_t translation_table_string_table_size = 82504;
 constexpr std::size_t translation_table_locale_table_size = 35;
 
 QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
@@ -332,7 +332,7 @@ QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
           "forwarding exports are only allowed in export-from"sv,
           "free {1} and {0} {1} {2}"sv,
           "function"sv,
-          "function 'let' call may be confused for destructuring;remove parentheses to declare a variable"sv,
+          "function 'let' call may be confused for destructuring; remove parentheses to declare a variable"sv,
           "function call started here"sv,
           "function called before declaration in block scope: {0}"sv,
           "function declared here"sv,

--- a/src/quick-lint-js/i18n/translation-table-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-generated.h
@@ -19,7 +19,7 @@ using namespace std::literals::string_view_literals;
 
 constexpr std::uint32_t translation_table_locale_count = 5;
 constexpr std::uint16_t translation_table_mapping_table_size = 606;
-constexpr std::size_t translation_table_string_table_size = 82476;
+constexpr std::size_t translation_table_string_table_size = 82503;
 constexpr std::size_t translation_table_locale_table_size = 35;
 
 QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
@@ -211,7 +211,6 @@ QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
           "abstract properties are only allowed in abstract classes"sv,
           "abstract properties cannot be static"sv,
           "accessors cannot be optional"sv,
-          "ambiguous use of the keyword 'let'; let is a function in this scope"sv,
           "an 'if' statement"sv,
           "an enum"sv,
           "an import alias"sv,
@@ -333,6 +332,7 @@ QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
           "forwarding exports are only allowed in export-from"sv,
           "free {1} and {0} {1} {2}"sv,
           "function"sv,
+          "function 'let' call may be confused for destructuring;remove parentheses to declare a variable"sv,
           "function call started here"sv,
           "function called before declaration in block scope: {0}"sv,
           "function declared here"sv,

--- a/src/quick-lint-js/i18n/translation-table-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-generated.h
@@ -18,8 +18,8 @@ namespace quick_lint_js {
 using namespace std::literals::string_view_literals;
 
 constexpr std::uint32_t translation_table_locale_count = 5;
-constexpr std::uint16_t translation_table_mapping_table_size = 605;
-constexpr std::size_t translation_table_string_table_size = 82408;
+constexpr std::uint16_t translation_table_mapping_table_size = 606;
+constexpr std::size_t translation_table_string_table_size = 82476;
 constexpr std::size_t translation_table_locale_table_size = 35;
 
 QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
@@ -211,6 +211,7 @@ QLJS_CONSTEVAL std::uint16_t translation_table_const_look_up(
           "abstract properties are only allowed in abstract classes"sv,
           "abstract properties cannot be static"sv,
           "accessors cannot be optional"sv,
+          "ambiguous use of the keyword 'let'; let is a function in this scope"sv,
           "an 'if' statement"sv,
           "an enum"sv,
           "an import alias"sv,

--- a/src/quick-lint-js/i18n/translation-table-test-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-test-generated.h
@@ -3395,14 +3395,14 @@ inline const Translated_String test_translation_table[605] = {
         },
     },
     {
-        "function 'let' call may be confused for destructuring;remove parentheses to declare a variable"_translatable,
-        u8"function 'let' call may be confused for destructuring;remove parentheses to declare a variable",
+        "function 'let' call may be confused for destructuring; remove parentheses to declare a variable"_translatable,
+        u8"function 'let' call may be confused for destructuring; remove parentheses to declare a variable",
         {
-            u8"function 'let' call may be confused for destructuring;remove parentheses to declare a variable",
-            u8"function 'let' call may be confused for destructuring;remove parentheses to declare a variable",
-            u8"function 'let' call may be confused for destructuring;remove parentheses to declare a variable",
-            u8"function 'let' call may be confused for destructuring;remove parentheses to declare a variable",
-            u8"function 'let' call may be confused for destructuring;remove parentheses to declare a variable",
+            u8"function 'let' call may be confused for destructuring; remove parentheses to declare a variable",
+            u8"function 'let' call may be confused for destructuring; remove parentheses to declare a variable",
+            u8"function 'let' call may be confused for destructuring; remove parentheses to declare a variable",
+            u8"function 'let' call may be confused for destructuring; remove parentheses to declare a variable",
+            u8"function 'let' call may be confused for destructuring; remove parentheses to declare a variable",
         },
     },
     {

--- a/src/quick-lint-js/i18n/translation-table-test-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-test-generated.h
@@ -27,7 +27,7 @@ struct Translated_String {
 };
 
 // clang-format off
-inline const Translated_String test_translation_table[604] = {
+inline const Translated_String test_translation_table[605] = {
     {
         "\"global-groups\" entries must be strings"_translatable,
         u8"\"global-groups\" entries must be strings",
@@ -2061,6 +2061,17 @@ inline const Translated_String test_translation_table[604] = {
             u8"accessors cannot be optional",
             u8"accessors cannot be optional",
             u8"accessors cannot be optional",
+        },
+    },
+    {
+        "ambiguous use of the keyword 'let'; let is a function in this scope"_translatable,
+        u8"ambiguous use of the keyword 'let'; let is a function in this scope",
+        {
+            u8"ambiguous use of the keyword 'let'; let is a function in this scope",
+            u8"ambiguous use of the keyword 'let'; let is a function in this scope",
+            u8"ambiguous use of the keyword 'let'; let is a function in this scope",
+            u8"ambiguous use of the keyword 'let'; let is a function in this scope",
+            u8"ambiguous use of the keyword 'let'; let is a function in this scope",
         },
     },
     {

--- a/src/quick-lint-js/i18n/translation-table-test-generated.h
+++ b/src/quick-lint-js/i18n/translation-table-test-generated.h
@@ -2064,17 +2064,6 @@ inline const Translated_String test_translation_table[605] = {
         },
     },
     {
-        "ambiguous use of the keyword 'let'; let is a function in this scope"_translatable,
-        u8"ambiguous use of the keyword 'let'; let is a function in this scope",
-        {
-            u8"ambiguous use of the keyword 'let'; let is a function in this scope",
-            u8"ambiguous use of the keyword 'let'; let is a function in this scope",
-            u8"ambiguous use of the keyword 'let'; let is a function in this scope",
-            u8"ambiguous use of the keyword 'let'; let is a function in this scope",
-            u8"ambiguous use of the keyword 'let'; let is a function in this scope",
-        },
-    },
-    {
         "an 'if' statement"_translatable,
         u8"an 'if' statement",
         {
@@ -3403,6 +3392,17 @@ inline const Translated_String test_translation_table[605] = {
             u8"function",
             u8"function",
             u8"function",
+        },
+    },
+    {
+        "function 'let' call may be confused for destructuring;remove parentheses to declare a variable"_translatable,
+        u8"function 'let' call may be confused for destructuring;remove parentheses to declare a variable",
+        {
+            u8"function 'let' call may be confused for destructuring;remove parentheses to declare a variable",
+            u8"function 'let' call may be confused for destructuring;remove parentheses to declare a variable",
+            u8"function 'let' call may be confused for destructuring;remove parentheses to declare a variable",
+            u8"function 'let' call may be confused for destructuring;remove parentheses to declare a variable",
+            u8"function 'let' call may be confused for destructuring;remove parentheses to declare a variable",
         },
     },
     {

--- a/test/test-parse-warning.cpp
+++ b/test/test-parse-warning.cpp
@@ -507,6 +507,11 @@ TEST_F(Test_Parse_Warning, early_exit_does_not_trigger_fallthrough_warning) {
         no_diags);
   }
 }
+
+TEST_F(Test_Parse_Warning, warn_on_ambiguous_let_use) {
+  test_parse_and_visit_statement(u8"let ({x} = y);"_sv,  //
+                                 u8"^^^ Diag_Ambiguous_Let_Call"_diag);
+}
 }
 }
 

--- a/test/test-parse-warning.cpp
+++ b/test/test-parse-warning.cpp
@@ -508,9 +508,11 @@ TEST_F(Test_Parse_Warning, early_exit_does_not_trigger_fallthrough_warning) {
   }
 }
 
-TEST_F(Test_Parse_Warning, warn_on_ambiguous_let_use) {
+TEST_F(Test_Parse_Warning, warn_on_confusing_let_use) {
   test_parse_and_visit_statement(u8"let ({x} = y);"_sv,  //
-                                 u8"^^^ Diag_Ambiguous_Let_Call"_diag);
+                                 u8"^^^ Diag_Confusing_Let_Call"_diag);
+  test_parse_and_visit_statement(u8"let.prop({x} = y);"_sv, no_diags);
+  test_parse_and_visit_statement(u8"let (x = y);"_sv, no_diags);
 }
 }
 }


### PR DESCRIPTION
Added a new diagnostic E0720 that closes #1203. Issues a warning when a function let() is called on an object assignment expression.

https://github.com/quick-lint/quick-lint-js/issues/1203